### PR TITLE
Fixes to README and styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ A live version with the daily build can be found [here](http://typescript:3000)
 1. Install the latest Node.js.
     * Download Node.js [from here](https://nodejs.org/en/)
 1. Establish your new environment by opening up a new PowerShell/Command Prompt.
-1. Fork https://github.com/Microsoft/TypeScript-Docs to your own GitHub account
-1. Clone https://github.com/[YOUR_ACCOUNT]/TypeScript-Docs
+1. Fork https://github.com/Microsoft/TypeScript-Website to your own GitHub account
+1. Clone https://github.com/[YOUR_ACCOUNT]/TypeScript-Website
 1. Run the following from the cloned repository:
 
     ```shell

--- a/src/assets/scss/_global.scss
+++ b/src/assets/scss/_global.scss
@@ -125,7 +125,7 @@ body {
   min-height: 100%;
 
   .content {
-    flex: 1;
+    flex: 1 1 0;
   }
 }
 @media (max-width: $screen-xs-max) {

--- a/src/assets/scss/footer.scss
+++ b/src/assets/scss/footer.scss
@@ -102,7 +102,7 @@
     font-size: 1.2em;
     line-height: 5.6em;
     vertical-align: middle;
-    margin-left:1em;
+    margin-left: 1em;
 }
 
 .github-buttons {
@@ -110,6 +110,11 @@
     font-size: 1.2em;
     line-height: 5.6em;
     vertical-align: middle;
-    margin-left:1em;
-    margin-top:6px;
+    margin-left: 1em;
+    margin-top: 6px;
+
+    iframe {
+      width: 130px !important;
+      height: 20px !important;
+    }
 }


### PR DESCRIPTION
## Summary
* Fixed cloning instructions : "TypeScript-Docs" to "TypeScript-Website"
* Fixed Star link to TypeScript's GitHub not being displayed
  Before : 
  ![1](https://user-images.githubusercontent.com/10649516/61796549-2e616280-ae58-11e9-93fe-52ecfedf513c.PNG)
  After :
  ![4](https://user-images.githubusercontent.com/10649516/61796613-4e912180-ae58-11e9-91b7-5968d338b995.PNG)
* Fixed footer not appearing in the bottom (for our friends that are IE users)
  Before :
  ![2](https://user-images.githubusercontent.com/10649516/61796648-65377880-ae58-11e9-871f-f66b289e421d.PNG)
  After :
  ![3](https://user-images.githubusercontent.com/10649516/61796666-6e284a00-ae58-11e9-9dee-b84a2b537ed8.PNG)

Tested in IE, Edge, Firefox and Chrome

