### PR TITLE
stick the documentation contents nav sidebar at one place on scroll

### DIFF
--- a/src/assets/scss/docs.scss
+++ b/src/assets/scss/docs.scss
@@ -149,6 +149,10 @@ h1, h2, h3 {
     width: 22em;
     padding-left: 2em;
     padding-right: 0rem;
+    position: sticky;
+    top: 0;
+    height: 100vh;
+    overflow-y: scroll;
   }
   .toc-dropdown > a {
     font-size: 1em;

--- a/src/assets/scss/docs.scss
+++ b/src/assets/scss/docs.scss
@@ -148,12 +148,14 @@ h1, h2, h3 {
     margin-right: 2em;
     width: 22em;
     padding-left: 2em;
-    padding-right: 0rem;
+    padding-right: 1rem;
     position: sticky;
-    top: 0;
-    height: 100vh;
+    top: 20px;
+    height: calc(100vh - 50px);
     overflow-y: scroll;
+    overscroll-behavior: contain;
   }
+
   .toc-dropdown > a {
     font-size: 1em;
     background-color:#ddd;


### PR DESCRIPTION
stick the documentation contents nav sidebar at one place when the page is scrolled and make it scrollable

![ts-website-enhancement](https://user-images.githubusercontent.com/43805922/66898774-71764080-f017-11e9-962b-7d78252f8c87.gif)
