### PR TITLE
Ignore pointer events on skyline image

### DIFF
--- a/src/assets/scss/home.scss
+++ b/src/assets/scss/home.scss
@@ -341,7 +341,7 @@
     // filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#cbdff3', endColorstr='#005a96', GradientType=0 );
 }
 
-.skyline-img {
+%skyline-img {
   position:absolute;
   top:0;
   bottom:0;
@@ -356,13 +356,13 @@
 }
 
 .skyline-img-background {
-    @extend .skyline-img;
+    @extend %skyline-img;
     background-image: url('../images/bg_blueprint_2.svg');
     background-repeat: repeat-x;
 }
 
 .skyline-img-foreground {
-    @extend .skyline-img;
+    @extend %skyline-img;
     background-image: url('../images/foreground_bluprint.svg');
 }
 

--- a/src/assets/scss/home.scss
+++ b/src/assets/scss/home.scss
@@ -352,6 +352,7 @@
   background-size: 150em 32.589em;
   background-repeat: no-repeat;
   background-position: 50% 0;
+  pointer-events: none;
 }
 
 .skyline-img-background {


### PR DESCRIPTION
Banner text is not selectable, because the skyline image is above.

![2019-11-10_19-59-22](https://user-images.githubusercontent.com/6443113/68549086-9da59700-03f4-11ea-9e5a-b00e1c35aa72.png)

---

Other solution would be to move the banner text above the image:
```scss
.banner {
  position: relative;
  z-index: 1;
}
```

