### PR TITLE
Fix the VS version script

### DIFF
--- a/scripts/updateURLs.js
+++ b/scripts/updateURLs.js
@@ -71,7 +71,7 @@ const go = async () => {
   const extensions = await getLatestVSExtensions()
   console.log(`Found ${extensions.length} extensions`)
 
-  const sortedByVersion = extensions.sort((l, r) => r.versions[0].version.localeCompare(l.versions[0].version))
+  const sortedByVersion = extensions.sort((l, r) => r.versions[0].version.localeCompare(l.versions[0].version)).filter(e => !e.extensionName.toLowerCase().includes("beta"))
   console.log(`Looking at ${sortedByVersion.map(e => e.versions[0].version).join(", ")}`)
 
   // @ts-ignore

--- a/scripts/updateURLs.js
+++ b/scripts/updateURLs.js
@@ -12,13 +12,13 @@ const {writeFileSync} = require("fs")
 
 /**
  * Gets the NPM package JSON for a module
- * @param {string} name 
+ * @param {string} name
  */
 const getLatestNPMPackage = async (name) => {
   const packageJSON = await axios({
     url: `https://registry.npmjs.org/${name}`
   })
-  
+
   return packageJSON.data
 }
 
@@ -40,10 +40,10 @@ const getLatestVSExtensions = async () => {
       'X-Requested-With': 'XMLHttpRequest',
       'X-VSS-ReauthenticationAction': 'Suppress',
   };
-  
+
   const query = (name) =>
   `{"assetTypes":["Microsoft.VisualStudio.Services.Icons.Default","Microsoft.VisualStudio.Services.Icons.Branding","Microsoft.VisualStudio.Services.Icons.Small"],"filters":[{"criteria":[{"filterType":8,"value":"Microsoft.VisualStudio.Ide"},{"filterType":10,"value":"${name}"},{"filterType":12,"value":"37888"}],"direction":2,"pageSize":54,"pageNumber":1,"sortBy":0,"sortOrder":0,"pagingToken":null}],"flags":870}`
-  
+
 
   const extensionSearchResults = await axios({
     url: 'https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery',
@@ -51,7 +51,7 @@ const getLatestVSExtensions = async () => {
     headers: headers,
     data: query("typescript")
   })
-  
+
   if (!extensionSearchResults.data || !extensionSearchResults.data.results) {
     throw new Error("Got a bad response from VS marketplace")
   }
@@ -69,13 +69,16 @@ const go = async () => {
 
   console.log(`Grabbing the VS TypeScript extension for ${latest} from the marketplace`)
   const extensions = await getLatestVSExtensions()
-  const currentExtension = extensions.find(e => e.versions[0].version === latest)
-  
+  console.log(`Found ${extensions.length} extensions`)
+
+  const sortedByVersion = extensions.sort((l, r) => r.versions[0].version.localeCompare(l.versions[0].version))
+  console.log(`Looking at ${sortedByVersion.map(e => e.versions[0].version).join(", ")}`)
+
   // @ts-ignore
   const currentURLs = require("../src/_data/urls")
-  
-  if (currentExtension) {
-    const extensionURL = `https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.${currentExtension.extensionName}`
+
+  if (sortedByVersion[0]) {
+    const extensionURL = `https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.${sortedByVersion[0].extensionName}`
      currentURLs.vs2017_download  = extensionURL
      currentURLs.vs2019_download  = extensionURL
   }

--- a/src/_data/urls.json
+++ b/src/_data/urls.json
@@ -1,6 +1,6 @@
 {
-  "vs2017_download": "https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.typescript-364",
-  "vs2019_download": "https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.typescript-364",
+  "vs2017_download": "https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.typescript-372",
+  "vs2019_download": "https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.typescript-372",
   "vscode_download": "https://code.visualstudio.com",
   "sublime_ts_download": "https://github.com/Microsoft/TypeScript-Sublime-Plugin",
   "atom_ts_download": "https://atom.io/packages/atom-typescript",


### PR DESCRIPTION
Previously it would grab the exact version, but that can be temperamental - so now it does string sorting and grabs the highest version:

```
$node scripts/updateURLs.js

Grabbing the TypeScript package from NPM, this takes about 10-15s
Grabbing the VS TypeScript extension for 3.7.3 from the marketplace
Found 39 extensions
Looking at 3.7.2, 3.6.4, 3.6.3, 3.6.2, 3.5.3, 3.5.2, 3.5.1, 3.5, 3.4.5, 3.4.3, 3.4.2, 3.4.1, 3.1.1, 3.1.1, 2.9.2, 2.9.1, 2.7.2, 2.7.1, 2.6.2, 2.6.1, 2.4.1, 2.3.1, 2.2, 2.0.6, 2.0.3, 1.8.4, 1.8.2, 1.7.6, 1.7, 1.5, 1.4, 1.3, 1.1, 1.0.1, 1.0
Updated src/_data/urls.json
```