### PR TITLE
Create an example PR which shows how to add a language

### DIFF
--- a/packages/playground-examples/copy/pt/JavaScript/JavaScript Essentials/Code Flow.ts
+++ b/packages/playground-examples/copy/pt/JavaScript/JavaScript Essentials/Code Flow.ts
@@ -1,0 +1,23 @@
+//// { title: "Fluxo de código", order: 3, compiler: { strictNullChecks: true } }
+
+// Como o código flui dentro de nossos arquivos JavaScript pode afetar
+// os tipos em nossos programas.
+
+const users = [{ name: 'Ahmed' }, { name: 'Gemma' }, { name: 'João' }]
+
+// Vamos ver se conseguimos encontrar um usuário chamado "João".
+const joao = users.find(u => u.name === 'João')
+
+// No caso acima, 'find' pode falhar. Nesse caso, nós
+// não tem um objeto. Isso cria o tipo:
+//
+//   { name: string } | undefined
+//
+// Se você passar o mouse sobre os três usos a seguir de 'joao' abaixo,
+// você verá como os tipos mudam dependendo de onde a palavra está localizada:
+
+if (joao) {
+  joao
+} else {
+  joao
+}

--- a/packages/playground-examples/copy/pt/JavaScript/JavaScript Essentials/Functions.ts
+++ b/packages/playground-examples/copy/pt/JavaScript/JavaScript Essentials/Functions.ts
@@ -1,0 +1,10 @@
+//// { title: 'Funções', order: 2, compiler: { noImplicitAny: false } }
+
+// Existem algumas maneiras de declarar uma função em
+// JavaScript. Vejamos uma função que adiciona dois
+// números juntos:
+
+// Cria a função @ no escopo global chamada modaAntiga
+function modaAntiga(x, y) {
+  return x + y
+}

--- a/packages/playground-examples/copy/pt/JavaScript/JavaScript Essentials/Hello World.ts
+++ b/packages/playground-examples/copy/pt/JavaScript/JavaScript Essentials/Hello World.ts
@@ -1,0 +1,11 @@
+//// { title: 'Olá Mundo', order: 0, compiler: { target: 1 } }
+
+// Bem-vindo ao playground TypeScript. Este site é muito
+// como executar um projeto TypeScript dentro de um navegador da web.
+
+// O playground facilita para você experimentar com segurança
+// com idéias no TypeScript, facilitando o compartilhamento
+// esses projetos. O URL desta página é tudo
+// necessário para carregar o projeto para outra pessoa.
+
+const ola = 'Olá'

--- a/packages/playground-examples/copy/pt/sections.json
+++ b/packages/playground-examples/copy/pt/sections.json
@@ -1,0 +1,47 @@
+{
+  "sections": [
+    {
+      "name": "JavaScript",
+      "id": "JavaScript",
+      "subtitle": "Veja como o TypeScript aprimora o dia a dia trabalhando com JavaScript com uma sintaxe adicional mínima."
+    },
+    {
+      "name": "TypeScript",
+      "id": "TypeScript",
+      "subtitle": "Explore como o TypeScript estende o JavaScript para adicionar mais segurança e ferramentas."
+    },
+    {
+      "name": "3.7",
+      "id": "3.7",
+      "subtitle": "Consulte <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/'>Notas da versão</a>."
+    },
+    {
+      "name": "Playground",
+      "id": "Playground",
+      "subtitle": "Saiba o que mudou neste site."
+    }
+  ],
+
+  "sortedSubSections": [
+    // JS
+    "JavaScript Essentials",
+    "Functions with JavaScript",
+    "Working With Classes",
+    "Modern JavaScript",
+    "External APIs",
+    "Helping with JavaScript",
+    // TS
+    "Primitives",
+    "Type Primitives",
+    "Meta-Types",
+    "Language",
+    "Language Extensions",
+    // Examples
+    "Syntax and Messaging",
+    "Types and Code Flow",
+    "Fixits",
+    // Playground
+    "Config",
+    "Tooling"
+  ]
+}

--- a/packages/tsconfig-reference/copy/pt/categories/Additional_Checks_6176.md
+++ b/packages/tsconfig-reference/copy/pt/categories/Additional_Checks_6176.md
@@ -1,0 +1,5 @@
+---
+display: "Verificação de linter"
+---
+
+Uma coleção de verificações extras, que ultrapassam um pouco os limites do compiler versus linter

--- a/packages/tsconfig-reference/copy/pt/categories/Advanced_Options_6178.md
+++ b/packages/tsconfig-reference/copy/pt/categories/Advanced_Options_6178.md
@@ -1,0 +1,5 @@
+---
+display: "Avançada"
+---
+
+Opções que ajudam com

--- a/packages/tsconfig-reference/copy/pt/categories/Basic_Options_6172.md
+++ b/packages/tsconfig-reference/copy/pt/categories/Basic_Options_6172.md
@@ -1,0 +1,5 @@
+---
+display: "Opções de projeto"
+---
+
+Essas configurações são usadas para definir as expectativas de tempo de execução do seu projeto, como e onde você deseja que o JavaScript seja emitido e o nível de integração desejado com o código JavaScript existente.

--- a/packages/tsconfig-reference/copy/pt/categories/Command_line_Options_6171.md
+++ b/packages/tsconfig-reference/copy/pt/categories/Command_line_Options_6171.md
@@ -1,0 +1,3 @@
+---
+display: "Linha de comando"
+---

--- a/packages/tsconfig-reference/copy/pt/categories/Experimental_Options_6177.md
+++ b/packages/tsconfig-reference/copy/pt/categories/Experimental_Options_6177.md
@@ -1,0 +1,5 @@
+---
+display: "Experimental"
+---
+
+O TypeScript se esforça para incluir apenas os recursos que foram confirmados para serem adicionados à linguagem JavaScript.

--- a/packages/tsconfig-reference/copy/pt/categories/Module_Resolution_Options_6174.md
+++ b/packages/tsconfig-reference/copy/pt/categories/Module_Resolution_Options_6174.md
@@ -1,0 +1,3 @@
+---
+display: "Module Resolution"
+---

--- a/packages/tsconfig-reference/copy/pt/categories/Project_Files_0.md
+++ b/packages/tsconfig-reference/copy/pt/categories/Project_Files_0.md
@@ -1,0 +1,5 @@
+---
+display: "Inclusão de projeto"
+---
+
+Essas configurações ajudam a garantir que o TypeScript escolha os arquivos certos.

--- a/packages/tsconfig-reference/copy/pt/categories/Source_Map_Options_6175.md
+++ b/packages/tsconfig-reference/copy/pt/categories/Source_Map_Options_6175.md
@@ -1,0 +1,5 @@
+---
+display: "Source Maps"
+---
+
+Para fornecer ferramentas avançadas de depuração e relatórios de falhas que fazem sentido para os desenvolvedores, o TypeScript suporta a emissão de arquivos adicionais que estão em conformidade com os padrões do JavaScript Source Map

--- a/packages/tsconfig-reference/copy/pt/categories/Strict_Type_Checking_Options_6173.md
+++ b/packages/tsconfig-reference/copy/pt/categories/Strict_Type_Checking_Options_6173.md
@@ -1,0 +1,5 @@
+---
+display: "Strict Checks"
+---
+
+Recomendamos usar a opção [`strict`](#strict) para aceitar todas as melhorias possíveis à medida que elas são construídas.

--- a/packages/tsconfig-reference/copy/pt/options/files.md
+++ b/packages/tsconfig-reference/copy/pt/options/files.md
@@ -1,0 +1,26 @@
+---
+display: "Arquivos"
+oneline: "Incluir uma lista definida de arquivos, não suporta globs"
+---
+
+Especifica uma lista de permissão de arquivos para incluir no programa. Ocorre um erro se algum dos arquivos não puder ser encontrado.
+
+```json
+{
+  "compilerOptions": {},
+  "files": [
+    "core.ts",
+    "sys.ts",
+    "types.ts",
+    "scanner.ts",
+    "parser.ts",
+    "utilities.ts",
+    "binder.ts",
+    "checker.ts",
+    "tsc.ts"
+  ]
+}
+```
+
+Isso é útil quando você possui apenas um pequeno número de arquivos e não precisa usar um glob para fazer referência
+a muitos arquivos. Se você precisar, use [`include`](#include).

--- a/packages/typescriptlang-org/src/copy/pt.ts
+++ b/packages/typescriptlang-org/src/copy/pt.ts
@@ -1,0 +1,9 @@
+import { defineMessages } from "react-intl"
+import { navCopy } from "./pt/nav"
+import { docCopy } from "./en/documentation"
+import { Copy } from "./en"
+
+export const lang: Copy = defineMessages({
+  ...navCopy,
+  ...docCopy,
+})

--- a/packages/typescriptlang-org/src/copy/pt/nav.ts
+++ b/packages/typescriptlang-org/src/copy/pt/nav.ts
@@ -1,0 +1,16 @@
+import { navCopy as enNavCopy } from "../en/nav"
+
+export const navCopy = {
+  ...enNavCopy,
+  skip_to_content: "Pular para o conteúdo principal",
+  nav_documentation: "Documentação",
+  nav_documentation_short: "Documentos",
+  nav_download: "Download",
+  nav_connect: "Conectar",
+  nav_playground: "Parque infantil",
+  nav_search_placeholder: "Documentos de pesquisa",
+  nav_search_aria: "Pesquise no site TypeScript",
+  nav_beta: "Pesquise no site TypeScript",
+  nav_beta_notification:
+    "Nota: esta página é uma página beta, não confie nos problemas de URL e de arquivos <a>no microsoft/TypeScript-Website</a>",
+}


### PR DESCRIPTION
I'm not going to merge this PR (most of the translation was done via Google Translate) but this PR exists to show you a working example of adding a language to the TypeScript website:

I added the beginnings of Portuguese, click the images to go through to the PR deploy:

[![Screen Shot 2020-01-15 at 6 03 46 PM](https://user-images.githubusercontent.com/49038/72479251-f6612980-37c1-11ea-9c23-614c3ab210c4.png)](https://typescript-v2-181.ortam.now.sh/pt/tsconfig)

[![Screen Shot 2020-01-15 at 6 04 10 PM](https://user-images.githubusercontent.com/49038/72479252-f6612980-37c1-11ea-913d-f75e27837b4a.png)](https://typescript-v2-181.ortam.now.sh/pt/play)

Will leave a review with inline info now