### PR TITLE
Fix try-beta button

### DIFF
--- a/src/assets/scss/docs.scss
+++ b/src/assets/scss/docs.scss
@@ -464,6 +464,7 @@ h1, h2, h3 {
   right: 20px;
   top: 20px;
   cursor: pointer;
+  z-index: 1;
 
   &:hover, &:active {
     color: white;


### PR DESCRIPTION
closes #182 

At very small sizes (below 250px) the button will now start to cover up the toc dropdown, but this seems acceptable.