### PR TITLE
Remove Melbourne Typescript's incorrect Twitter URL

### DIFF
--- a/src/_data/community/meetups.yml
+++ b/src/_data/community/meetups.yml
@@ -32,7 +32,6 @@ ready:
       image: "/assets/images/community/meetup-logos/ktug.jpg"
       country: "🇵🇱"
     - title: Melbourne TypeScript
-      twitter: https://twitter.com/WrocTypeScript
       url: https://www.meetup.com/Melbourne-TypeScript-Meetup/
       image: "/assets/images/community/meetup-logos/melbourne.jpg"
       country: "🇦🇺"


### PR DESCRIPTION
Fixes #195 

Based on other examples without a Twitter URL, this should be ok!