### PR TITLE
make getDTS to store tsWorker.d.ts

### DIFF
--- a/packages/create-typescript-playground-plugin/template/scripts/getDTS.js
+++ b/packages/create-typescript-playground-plugin/template/scripts/getDTS.js
@@ -22,13 +22,18 @@ const go = async () => {
   }
 
   await getFileAndStoreLocally(
+    'https://www.typescriptlang.org/v2/js/sandbox/tsWorker.d.ts',
+    join(vendor, 'tsWorker.d.ts'),
+  )
+
+  await getFileAndStoreLocally(
     'https://www.typescriptlang.org/v2/js/sandbox/index.d.ts',
     join(vendor, 'sandbox.d.ts'),
     text => {
       const removeImports = text.replace(/^import/g, '// import').replace(/\nimport/g, '// import')
       const removedLZ = removeImports.replace('lzstring: typeof lzstring', '// lzstring: typeof lzstring')
-      const prefix = 'type TypeScriptWorker = any;\n'
-      return prefix + removedLZ
+      const addedTsWorkerImport = 'import { TypeScriptWorker } from "./tsWorker";' + removedLZ;
+      return addedTsWorkerImport;
     }
   )
 

--- a/packages/create-typescript-playground-plugin/template/tsconfig.json
+++ b/packages/create-typescript-playground-plugin/template/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "esModuleInterop": true,
     "noEmit": true
   }
 }


### PR DESCRIPTION
Hi @orta . I'm loving Playground Plugin systems you created 😄 

In some plugins, I want to access language service methods using TypeScript worker such as:

```ts
  modelChanged: (sandbox, model) => {
     sandbox.getWorkerProcess.then(worker => {
         return worker.getSemanticDiagnostics(model.uri.toString());
     }).then(result => /* processing diagnositic */)
  },
```

But for now, the `getDTS` script replaces `TypeScriptWorker` type to `any` and I can't auto-complete worker's methods.

I think it's better to fetch tsWorker.d.ts too. How about it?