### PR TITLE
fix: type mismatch #217

### DIFF
--- a/packages/handbook-v1/en/Advanced Types.md
+++ b/packages/handbook-v1/en/Advanced Types.md
@@ -1296,7 +1296,7 @@ class C {
 
 type T10 = ReturnType<() => string>;  // string
 type T11 = ReturnType<(s: string) => void>;  // void
-type T12 = ReturnType<(<T>() => T)>;  // {}
+type T12 = ReturnType<(<T>() => T)>;  // unkown
 type T13 = ReturnType<(<T extends U, U extends number[]>() => T)>;  // number[]
 type T14 = ReturnType<typeof f1>;  // { a: number, b: string }
 type T15 = ReturnType<any>;  // any

--- a/packages/handbook-v1/en/Advanced Types.md
+++ b/packages/handbook-v1/en/Advanced Types.md
@@ -1296,7 +1296,7 @@ class C {
 
 type T10 = ReturnType<() => string>;  // string
 type T11 = ReturnType<(s: string) => void>;  // void
-type T12 = ReturnType<(<T>() => T)>;  // unkown
+type T12 = ReturnType<(<T>() => T)>;  // unknown
 type T13 = ReturnType<(<T extends U, U extends number[]>() => T)>;  // number[]
 type T14 = ReturnType<typeof f1>;  // { a: number, b: string }
 type T15 = ReturnType<any>;  // any
@@ -1312,4 +1312,3 @@ type T24 = InstanceType<Function>;  // Error
 ```
 
 > Note: The `Exclude` type is a proper implementation of the `Diff` type suggested [here](https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-307871458). We've used the name `Exclude` to avoid breaking existing code that defines a `Diff`, plus we feel that name better conveys the semantics of the type.
-


### PR DESCRIPTION
fixes #217

This section of advanced types seems to have been written during TypeScript 2.8 and was correct then. TypeScript 3.0 introduced the unknown top type making the type now `unknown` rather than `{}`

@orta the documentation is not locked to a specific version right, so should all doc follow latest TypeScript version?