### PR TITLE
Fix broken link about Starter Kits

### DIFF
--- a/packages/typescriptlang-org/src/pages/documentation.en.tsx
+++ b/packages/typescriptlang-org/src/pages/documentation.en.tsx
@@ -141,9 +141,9 @@ const react = [
     title: "Razzle"
   },
   {
-    href: "https://reactjs.org/community/starter-kits.html",
+    href: "https://reactjs.org/docs/create-a-new-react-app.html#recommended-toolchains",
     blurb: "Recommendations from the React Team",
-    title: "Starter Kits"
+    title: "Recommended Toolchains"
   }
 ]
 


### PR DESCRIPTION
As you know, there is `Starter Kits` in [Documentation](https://www.typescriptlang.org/docs/home.html) like below but it links to `Page Not Found`.

<img width="535" alt="home" src="https://user-images.githubusercontent.com/44132406/74078654-6afd5000-4a70-11ea-8931-852c9aa0a599.png">

I think you probably intended to link to this page(below), but the exact same page no longer exists in React docs.

<img width="834" alt="starter kits" src="https://user-images.githubusercontent.com/44132406/74078693-c7606f80-4a70-11ea-86c2-65786df33c81.png">

I found a page that gave a similar introduction, and changed the link to it : [Recommended Toolchains](https://reactjs.org/docs/create-a-new-react-app.html#recommended-toolchains)

<img width="862" alt="recommended toolchains" src="https://user-images.githubusercontent.com/44132406/74078741-59687800-4a71-11ea-9fe1-9378ded302d6.png">

The page covers a lot including `Neutrino`, `Parcel` and `Razzle`, so I believe it will be a good alternative.

Closes #143 