### PR TITLE
Fix Angular link in Web Frameworks section

### DIFF
--- a/packages/typescriptlang-org/src/pages/documentation.en.tsx
+++ b/packages/typescriptlang-org/src/pages/documentation.en.tsx
@@ -70,7 +70,7 @@ const apis = [
 
 const webFrameworks = [
   {
-    href: "/docs/handbook/typescript-in-5-minutes.html",
+    href: "https://angular.io",
     blurb: "Makes writing beautiful apps be joyful and fun",
     title: "Angular"
   },


### PR DESCRIPTION
Link previously pointed to the TS in 5m overview doc.

Fixes this link:

![Screen Shot 2020-02-09 at 3 07 42 PM](https://user-images.githubusercontent.com/2449384/74112223-a589ea00-4b4f-11ea-85b2-7931c02dea6d.png)
