### PR TITLE
Set the font to be consistent on pre code blocks for playground plugins

### DIFF
--- a/packages/typescriptlang-org/backstop.json
+++ b/packages/typescriptlang-org/backstop.json
@@ -8,30 +8,30 @@
   "scenarios": [
     {
       "label": "Index",
-      "url": "file:///Users/orta/dev/typescript/new-typescript-website/packages/typescriptlang-org/public/index.html",
+      "url": "file:///Users/ortatherox/dev/typescript/new-website/packages/typescriptlang-org/public/index.html",
       "misMatchThreshold": 0.1
     },
     {
       "label": "Empty Page",
-      "url": "file:///Users/orta/dev/typescript/new-typescript-website/packages/typescriptlang-org/public/empty/index.html",
+      "url": "file:///Users/ortatherox/dev/typescript/new-website/packages/typescriptlang-org/public/empty/index.html",
       "misMatchThreshold": 0.1
     },
     {
       "label": "Old Handbook Example",
-      "url": "file:///Users/orta/dev/typescript/new-typescript-website/packages/typescriptlang-org/public/docs/handbook/functions.html",
+      "url": "file:///Users/ortatherox/dev/typescript/new-website/packages/typescriptlang-org/public/docs/handbook/functions.html",
       "misMatchThreshold": 0.1,
       "selectors": ["viewport"]
     },
     {
       "label": "Old Handbook Example Dark",
-      "url": "file:///Users/orta/dev/typescript/new-typescript-website/packages/typescriptlang-org/public/docs/handbook/functions.html",
+      "url": "file:///Users/ortatherox/dev/typescript/new-website/packages/typescriptlang-org/public/docs/handbook/functions.html",
       "misMatchThreshold": 0.1,
       "selectors": ["viewport"],
       "onReadyScript": "../../../scripts/backstop/makeDarkMode.js"
     },
     {
       "label": "TSConfig Example",
-      "url": "file:///Users/orta/dev/typescript/new-typescript-website/packages/typescriptlang-org/public/en/tsconfig/index.html",
+      "url": "file:///Users/ortatherox/dev/typescript/new-website/packages/typescriptlang-org/public/en/tsconfig/index.html",
       "misMatchThreshold": 0.1,
       "selectors": ["viewport"]
     }

--- a/packages/typescriptlang-org/src/templates/play.scss
+++ b/packages/typescriptlang-org/src/templates/play.scss
@@ -373,6 +373,10 @@ main #editor-toolbar {
           background-color: #1e1e1e;
           color: white;
         }
+
+        code {
+          font-family: Menlo, Monaco, Consolas, Courier New, monospace;
+        }
       }
     }
 


### PR DESCRIPTION
We spotted this: 

See the sidebar in English:
![Screen Shot 2020-02-10 at 6 20 10 PM](https://user-images.githubusercontent.com/49038/74199395-038efe00-4c32-11ea-973b-683f3bcd02cd.png)

But when Japanese:

![Screen Shot 2020-02-10 at 6 20 21 PM](https://user-images.githubusercontent.com/49038/74199397-0558c180-4c32-11ea-93e2-a4175fb8a682.png)

The font gets messed up, but looks OK when I set the font family manually

![Screen Shot 2020-02-10 at 6 22 25 PM](https://user-images.githubusercontent.com/49038/74199495-52d52e80-4c32-11ea-8df6-1f3b9825bedf.png)
