### PR TITLE
docs: translate configs for playground to Japanese

### DIFF
--- a/packages/typescriptlang-org/src/copy/ja/playground.ts
+++ b/packages/typescriptlang-org/src/copy/ja/playground.ts
@@ -1,55 +1,57 @@
 export const playCopy = {
-  play_subnav_title: "プレイグラウンド",
-  play_subnav_config: "プレイグラウンド",
-  play_config_language_blurb: "エディタの言語設定",
-  play_subnav_examples: "Examples",
-  play_subnav_examples_close: "閉じる",
-  play_subnav_whatsnew: "新着情報",
-  play_downloading_typescript: "TypeScriptをダウンロード中...", // when loading
-  play_downloading_version: "バージョン...", // when loading
-  play_toolbar_run: "実行",
-  play_toolbar_export: "エクスポート",
-  play_sidebar_js: "JS",
-  play_sidebar_dts: "DTS",
-  play_sidebar_errors: "エラー",
-  play_sidebar_errors_no_errors: "エラーはありません",
-  play_sidebar_logs: "ログ",
-  play_sidebar_logs_no_logs: "ログはありません",
-  play_sidebar_options: "オプション",
-  play_sidebar_options_restart_required: "設定の反映にはリロードが必要です",
-  play_sidebar_options_disable_ata: "ATAを無効にする",
-  play_sidebar_options_disable_ata_copy:
-    "importsやrequiresで取得した型の補完を無効にします。",
-  play_sidebar_options_disable_save: "Save-On-Typeを無効にする",
-  play_sidebar_options_disable_save_copy:
-    "入力時にURLが変更される機能を無効にします。",
-  play_sidebar_options_external: "外部プラグイン",
-  play_sidebar_options_external_warning:
-    "注意: プラグインのコードはサードパーティのものです。",
-  play_sidebar_options_modules: "カスタムモジュール",
-  play_sidebar_options_modules_placeholder: "npmモジュール名",
-  play_sidebar_options_plugin_dev: "Plugin Dev",
-  play_sidebar_options_plugin_dev_option:
-    "<code>localhost:5000/index.js</code>に接続する",
-  play_sidebar_options_plugin_dev_copy:
-    "ローカルで開発中のプレイグラウンドプラグインに接続します。詳しくは<a href='https://www.typescriptlang.org/v2/dev/playground-plugins/'>こちら</a>。",
-  play_export_report_issue: "TypeScriptのエラーをGitHub issueとして報告",
-  play_export_copy_md: "Markdown Issueとしてコピー",
-  play_export_copy_link: "Markdownリンクとしてコピー",
-  play_export_copy_link_preview: "プレビュー付きMarkdownリンクとしてコピー",
-  play_export_tsast: "TypeScript AST Viewerで開く",
-  play_export_sandbox: "CodeSandboxで開く",
-  play_export_stackblitz: "StackBlitzで開く",
-  play_export_clipboard: "URLをクリップボードにコピーしました。",
-  play_run_js: "JavaScriptが実行されました",
-  play_run_ts: "トランスパイルされたTypeScriptが実行されました",
-  play_run_js_fail: "実行されたJavaScriptにエラーが発生しました:",
-  play_default_code_sample: `// TypeScriptプレイグラウンドへようこそ。 
+         play_subnav_title: "プレイグラウンド",
+         play_subnav_config: "プレイグラウンド",
+         play_config_language_blurb: "エディタの言語設定",
+         play_subnav_examples: "Examples",
+         play_subnav_examples_close: "閉じる",
+         play_subnav_whatsnew: "新着情報",
+         play_downloading_typescript: "TypeScriptをダウンロード中...", // when loading
+         play_downloading_version: "バージョン...", // when loading
+         play_toolbar_run: "実行",
+         play_toolbar_export: "エクスポート",
+         play_sidebar_js: "JS",
+         play_sidebar_dts: "DTS",
+         play_sidebar_errors: "エラー",
+         play_sidebar_errors_no_errors: "エラーはありません",
+         play_sidebar_logs: "ログ",
+         play_sidebar_logs_no_logs: "ログはありません",
+         play_sidebar_options: "オプション",
+         play_sidebar_options_restart_required:
+           "設定の反映にはリロードが必要です",
+         play_sidebar_options_disable_ata: "ATAを無効にする",
+         play_sidebar_options_disable_ata_copy:
+           "importやrequireで指定した型ファイルの取得を無効化します。",
+         play_sidebar_options_disable_save: "Save-On-Typeを無効にする",
+         play_sidebar_options_disable_save_copy:
+           "入力時にURLが変更される機能を無効にします。",
+         play_sidebar_options_external: "外部プラグイン",
+         play_sidebar_options_external_warning:
+           "注意: プラグインのコードはサードパーティのものです。",
+         play_sidebar_options_modules: "カスタムモジュール",
+         play_sidebar_options_modules_placeholder: "npmモジュール名",
+         play_sidebar_options_plugin_dev: "Plugin Dev",
+         play_sidebar_options_plugin_dev_option:
+           "<code>localhost:5000/index.js</code>に接続する",
+         play_sidebar_options_plugin_dev_copy:
+           "ローカルで開発中のプレイグラウンドプラグインに接続します。詳しくは<a href='https://www.typescriptlang.org/v2/dev/playground-plugins/'>こちら</a>。",
+         play_export_report_issue: "TypeScriptのエラーをGitHub issueとして報告",
+         play_export_copy_md: "Markdown Issueとしてコピー",
+         play_export_copy_link: "Markdownリンクとしてコピー",
+         play_export_copy_link_preview:
+           "プレビュー付きMarkdownリンクとしてコピー",
+         play_export_tsast: "TypeScript AST Viewerで開く",
+         play_export_sandbox: "CodeSandboxで開く",
+         play_export_stackblitz: "StackBlitzで開く",
+         play_export_clipboard: "URLをクリップボードにコピーしました。",
+         play_run_js: "JavaScriptが実行されました",
+         play_run_ts: "トランスパイルされたTypeScriptが実行されました",
+         play_run_js_fail: "実行されたJavaScriptにエラーが発生しました:",
+         play_default_code_sample: `// TypeScriptプレイグラウンドへようこそ。 
   // このサイトではTypeScriptを試したり、共有したり、学ぶことができます。
   
   // このプレイグラウンドは以下のような用途に使えるでしょう:
   //
-  //  - バグの心配をせずにTypeScriptを学べる場所
+  //  - 外部要因を気にせず TypeScript を学べる場所
   //  - TypeScriptのシンタックスを試し、そのURLを他人と共有する場所
   //  - TypeScriptの様々なコンパイラ機能を試す場所
   
@@ -60,6 +62,6 @@ export const playCopy = {
   // それか、これらのコメントを消して、あなたの好きなように書きましょう。このプレイグラウンドはあなたの世界です！
   `,
 
-  // メモ:
-  // コンパイラフラグの情報はTSConfigリファレンスから取得しています。
-}
+         // メモ:
+         // コンパイラフラグの情報はTSConfigリファレンスから取得しています。
+       }

--- a/packages/typescriptlang-org/src/copy/ja/playground.ts
+++ b/packages/typescriptlang-org/src/copy/ja/playground.ts
@@ -1,0 +1,65 @@
+export const playCopy = {
+  play_subnav_title: "プレイグラウンド",
+  play_subnav_config: "プレイグラウンド",
+  play_config_language_blurb: "エディタの言語設定",
+  play_subnav_examples: "Examples",
+  play_subnav_examples_close: "閉じる",
+  play_subnav_whatsnew: "新着情報",
+  play_downloading_typescript: "TypeScriptをダウンロード中...", // when loading
+  play_downloading_version: "バージョン...", // when loading
+  play_toolbar_run: "実行",
+  play_toolbar_export: "エクスポート",
+  play_sidebar_js: "JS",
+  play_sidebar_dts: "DTS",
+  play_sidebar_errors: "エラー",
+  play_sidebar_errors_no_errors: "エラーはありません",
+  play_sidebar_logs: "ログ",
+  play_sidebar_logs_no_logs: "ログはありません",
+  play_sidebar_options: "オプション",
+  play_sidebar_options_restart_required: "設定の反映にはリロードが必要です",
+  play_sidebar_options_disable_ata: "ATAを無効にする",
+  play_sidebar_options_disable_ata_copy:
+    "importsやrequiresで取得した型の補完を無効にします。",
+  play_sidebar_options_disable_save: "Save-On-Typeを無効にする",
+  play_sidebar_options_disable_save_copy:
+    "入力時にURLが変更される機能を無効にします。",
+  play_sidebar_options_external: "外部プラグイン",
+  play_sidebar_options_external_warning:
+    "注意: プラグインのコードはサードパーティのものです。",
+  play_sidebar_options_modules: "カスタムモジュール",
+  play_sidebar_options_modules_placeholder: "npmモジュール名",
+  play_sidebar_options_plugin_dev: "Plugin Dev",
+  play_sidebar_options_plugin_dev_option:
+    "<code>localhost:5000/index.js</code>に接続する",
+  play_sidebar_options_plugin_dev_copy:
+    "ローカルで開発中のプレイグラウンドプラグインに接続します。詳しくは<a href='https://www.typescriptlang.org/v2/dev/playground-plugins/'>こちら</a>。",
+  play_export_report_issue: "TypeScriptのエラーをGitHub issueとして報告",
+  play_export_copy_md: "Markdown Issueとしてコピー",
+  play_export_copy_link: "Markdownリンクとしてコピー",
+  play_export_copy_link_preview: "プレビュー付きMarkdownリンクとしてコピー",
+  play_export_tsast: "TypeScript AST Viewerで開く",
+  play_export_sandbox: "CodeSandboxで開く",
+  play_export_stackblitz: "StackBlitzで開く",
+  play_export_clipboard: "URLをクリップボードにコピーしました。",
+  play_run_js: "JavaScriptが実行されました",
+  play_run_ts: "トランスパイルされたTypeScriptが実行されました",
+  play_run_js_fail: "実行されたJavaScriptにエラーが発生しました:",
+  play_default_code_sample: `// TypeScriptプレイグラウンドへようこそ。 
+  // このサイトではTypeScriptを試したり、共有したり、学ぶことができます。
+  
+  // このプレイグラウンドは以下のような用途に使えるでしょう:
+  //
+  //  - バグの心配をせずにTypeScriptを学べる場所
+  //  - TypeScriptのシンタックスを試し、そのURLを他人と共有する場所
+  //  - TypeScriptの様々なコンパイラ機能を試す場所
+  
+  const anExampleVariable = "こんにちは、世界"
+  console.log(anExampleVariable)
+  
+  // TypeScriptの言語についてもっと学ぶには、"Examples"や"新着情報"をクリックしてください。
+  // それか、これらのコメントを消して、あなたの好きなように書きましょう。このプレイグラウンドはあなたの世界です！
+  `,
+
+  // メモ:
+  // コンパイラフラグの情報はTSConfigリファレンスから取得しています。
+}


### PR DESCRIPTION
Part of #100 #220 
Translated `playground.ts`
The original document can be found [here](https://github.com/microsoft/TypeScript-Website/blob/v2/packages/typescriptlang-org/src/copy/en/playground.ts)
