### PR TITLE
Translate allowJs, checkJs, jsx, declaration, declarationMap, and sourcemap options into Japanese

### DIFF
--- a/packages/tsconfig-reference/copy/ja/options/allowJs.md
+++ b/packages/tsconfig-reference/copy/ja/options/allowJs.md
@@ -1,0 +1,39 @@
+---
+display: "Allow JS"
+oneline: "Let TS include .JS files in imports"
+---
+
+`.ts`、`.tsx`ファイルだけでなく、JavaScriptファイルをプロジェクトへインポートできるようにします。例えば、次のJSファイルを:
+
+```js twoslasher
+// @filename: card.js
+export const defaultCardDeck = "Heart";
+```
+
+TypeScriptのファイルへインポートするとエラーとなるでしょう:
+
+```ts twoslasher
+// @errors: 2307
+// @filename: card.js
+module.exports.defaultCardDeck = "Heart";
+// ---cut---
+// @filename: index.ts
+import { defaultCardDeck } from "./card";
+
+console.log(defaultCardDeck);
+```
+
+`allowJs`を付与するとインポートは成功します:
+
+```ts twoslasher
+// @filename: card.js
+module.exports.defaultCardDeck = "Heart";
+// ---cut---
+// @allowJs
+// @filename: index.ts
+import { defaultCardDeck } from "./card";
+
+console.log(defaultCardDeck);
+```
+
+このフラグを使うと、`.ts`や`.tsx`ファイルが既存のJavaScriptファイルと共存可能となり、TypeScriptファイルをJSプロジェクトへ徐々に追加できるようになります。

--- a/packages/tsconfig-reference/copy/ja/options/checkJs.md
+++ b/packages/tsconfig-reference/copy/ja/options/checkJs.md
@@ -1,0 +1,40 @@
+---
+display: "Check JS"
+oneline: "Run the type checker on .js files in your project"
+---
+
+`allowJs`と連携動作します。`checkJs`が有効化されている場合、JavaScriptファイル内のエラーが報告されるようになります。
+これは、プロジェクトに含まれるすべてのJavaScriptファイルの先頭で`// @ts-check`を付与することと等価です。
+
+例えば、TypeScriptの`parseFloat`定義から、次の例は誤ったJavaScriptです。
+
+```js
+// parseFloatはstringのみを受け付けます
+module.exports.pi = parseFloat(3.124);
+```
+
+このファイルがTypeScriptのモジュールにインポートされた場合:
+
+```ts twoslash
+// @allowJs
+// @filename: constants.js
+module.exports.pi = parseFloat(3.124);
+
+// @filename: index.ts
+import { pi } from "./constants";
+console.log(pi);
+```
+
+いかなるエラーも報告されません。しかし、もし`checkJs`を有効化すれば、JavaScriptファイルで発生したエラーメッセージを受け取れるようになります。
+
+```ts twoslash
+// @errors: 2345
+// @allowjs: true
+// @checkjs: true
+// @filename: constants.js
+module.exports.pi = parseFloat(3.124);
+
+// @filename: index.ts
+import { pi } from "./constants";
+console.log(pi);
+```

--- a/packages/tsconfig-reference/copy/ja/options/declaration.md
+++ b/packages/tsconfig-reference/copy/ja/options/declaration.md
@@ -1,0 +1,32 @@
+---
+display: "Declaration"
+oneline: "Emit d.ts files for referenced files in the project"
+---
+
+プロジェクト内のすべてのTypeScriptファイルとJavaScriptファイルについて、`d.ts`ファイルを生成します。
+生成された`d.ts`ファイルはモジュールの外部APIを記述する定義ファイルです。
+`d.ts`ファイルを用いると、TypeScriptなどのツールは、型指定されていないコードに対して、Intelisenceや正確な型定義を提供できるようになります。
+
+`declaration`を`true`に設定している場合、次のTypeScriptコードに対してコンパイラーを実行すると:
+
+```ts twoslash
+export let helloWorld = "hi";
+```
+
+次のような`index.js`ファイルが生成されます:
+
+```ts twoslash
+// @showEmit
+export let helloWorld = "hi";
+```
+
+対応する`helloWorld.d.ts`ファイルは次のとおりです:
+
+```ts twoslash
+// @showEmittedFile: index.d.ts
+// @showEmit
+// @declaration
+export let helloWorld = "hi";
+```
+
+JavaScriptファイルに対応する`.d.ts`を利用する場合、[`emitDeclarationOnly`](#emitDeclarationOnly)や[`outDir`](#outDir)を設定することでJavaScriptファイルを上書きしないようにできます。

--- a/packages/tsconfig-reference/copy/ja/options/declarationMap.md
+++ b/packages/tsconfig-reference/copy/ja/options/declarationMap.md
@@ -1,0 +1,10 @@
+---
+display: "Declaration Map"
+oneline: "Create sourcemaps for d.ts files"
+---
+
+元の`.ts`ソースファイルにマップされる`.d.ts`のソースマップを生成します。
+
+これにより、VS Codeなどのエディターは、_Go to Definition_のような機能で元の`.ts`ファイルにジャンプできるようになります。
+
+プエジェクト参照機能を利用している場合、このオプションの有効化を強く推奨します。

--- a/packages/tsconfig-reference/copy/ja/options/jsx.md
+++ b/packages/tsconfig-reference/copy/ja/options/jsx.md
@@ -1,0 +1,11 @@
+---
+display: "JSX"
+oneline: "Control how JSX is emitted"
+---
+
+JSX構文がどのようにJavaScriptファイルに出力されるかを設定します。
+`.tsx`で終わるファイルのJS出力にのみ影響します。
+
+- `preserve`: JSXを変更せずに`.jsx`ファイルを出力します
+- `react`: JSXを等価な`react.createElement`に変換して`.js`ファイルを出力します
+- `react-native`: JSXを変更せずに、`.js`ファイルを出力します

--- a/packages/tsconfig-reference/copy/ja/options/sourceMap.md
+++ b/packages/tsconfig-reference/copy/ja/options/sourceMap.md
@@ -1,0 +1,39 @@
+---
+display: "Source Map"
+oneline: "Creates source map files for emitted JavaScript files"
+---
+
+[ソースマップファイル](https://developer.mozilla.org/en-US/docs/Tools/Debugger/How_to/Use_a_source_map)の生成を有効化します。
+これらのファイルにより、出力されたJavaScriptファイルが実際に動作させるときに、デバッガーやその他のツールが元のTypeScriptソースファイルを表示できるようになります。
+ソースマップファイルは`.js.map`（または`.jsx.map`）として、対応する`.js`ファイルとともに出力されます。
+
+次の例のように、`.js`ファイルには、外部ツールにソースマップファイルがどこにあるかを示すためのソースマップコメントが含まれるようになります:
+
+```ts
+// helloWorld.ts
+export declare const helloWorld = "hi";
+```
+
+`sourceMap`を`true`に設定してコンパイルすると、次のJavaScriptファイルが生成されます:
+
+```js
+// helloWorld.js
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.helloWorld = "hi";
+//# sourceMappingURL=// helloWorld.js.map
+```
+
+この設定は次のようなjson形式のマップファイルも生成します:
+
+```json
+// helloWorld.js.map
+{
+  "version": 3,
+  "file": "ex.js",
+  "sourceRoot": "",
+  "sources": ["../ex.ts"],
+  "names": [],
+  "mappings": ";;AAAa,QAAA,UAAU,GAAG,IAAI,CAAA"
+}
+```


### PR DESCRIPTION
This PR is a part of #220 

## What I did

Translated tsconfig references corresponding to the following sections into Japanese:

- https://www.typescriptlang.org/v2/en/tsconfig#allowJs
- https://www.typescriptlang.org/v2/en/tsconfig#checkJs
- https://www.typescriptlang.org/v2/en/tsconfig#jsx
- https://www.typescriptlang.org/v2/en/tsconfig#declaration
- https://www.typescriptlang.org/v2/en/tsconfig#declarationMap
- https://www.typescriptlang.org/v2/en/tsconfig#sourceMap

