### PR TITLE
Use twoslash for example codes of "strictBindCallApply"

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/strictBindCallApply.md
+++ b/packages/tsconfig-reference/copy/en/options/strictBindCallApply.md
@@ -1,25 +1,27 @@
 ---
 display: "Strict Bind Call Apply"
-oneline: "Ensure that 'call', 'bind' and 'apply' have the rught arguments"
+oneline: "Ensure that 'call', 'bind' and 'apply' have the right arguments"
 ---
 
 When set, TypeScript will check that the built-in methods of functions `call`, `bind`, and `apply` are invoked with correct argument for the underlying function:
 
-```ts
+```ts twoslash
+// @strictBindCallApply: true
+// @errors: 2345
+
 // With strictBindCallApply on
 function fn(x: string) {
    return parseInt(x);
 }
 
 const n1 = fn.call(undefined, "10");
-      ^?
 
 const n2 = fn.call(undefined, false);
 ```
 
 Otherwise, these functions accept any arguments and will return `any`:
 
-```ts
+```ts twoslash
 // @strictBindCallApply: false
 
 // With strictBindCallApply off
@@ -29,5 +31,4 @@ function fn(x: string) {
 
 // Note: No error; return type is 'any'
 const n = fn.call(undefined, false);
-      ^?
 ```


### PR DESCRIPTION
I think it's better to use `twoslash` feature to explain which errors `strinctBindCallApply` option throws.

<img width="2080" alt="スクリーンショット 2020-02-26 15 57 02" src="https://user-images.githubusercontent.com/1262998/75319920-e3f20980-58b0-11ea-80fa-fb2c33d81fdf.png">
[left: before (latest v2), right: after (this PR)]
