### PR TITLE
Translate the latter of strict options into ja

### DIFF
--- a/packages/tsconfig-reference/copy/ja/options/alwaysStrict.md
+++ b/packages/tsconfig-reference/copy/ja/options/alwaysStrict.md
@@ -3,6 +3,6 @@ display: "Always Strict"
 oneline: "Ensure 'use strict' is always emitted"
 ---
 
-ファイルをECMAScriptのstrictモードへ変換し、各ファイルへ"use strict"を出力することを保証します。
+ファイルをECMAScriptのstrictモードで解釈し、各ファイルへ"use strict"を出力することを保証します。
 
 [ECMAScript strict](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode)モードはES5で導入され、JavaScriptエンジンが実行時にパフォーマンスを改善できるよう微調整されます。代わりにいくつかのエラーが無視されずにスローされるようになります。

--- a/packages/tsconfig-reference/copy/ja/options/alwaysStrict.md
+++ b/packages/tsconfig-reference/copy/ja/options/alwaysStrict.md
@@ -1,0 +1,8 @@
+---
+display: "Always Strict"
+oneline: "Ensure 'use strict' is always emitted"
+---
+
+ファイルをECMAScriptのstrictモードへ変換し、各ファイルへ"use strict"を出力することを保証します。
+
+[ECMAScript strict](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode)モードはES5で導入され、JavaScriptエンジンが実行時にパフォーマンスを改善できるよう微調整されます。代わりにいくつかのエラーが無視されずにスローされるようになります。

--- a/packages/tsconfig-reference/copy/ja/options/noImplicitThis.md
+++ b/packages/tsconfig-reference/copy/ja/options/noImplicitThis.md
@@ -1,0 +1,28 @@
+---
+display: "No Implicit This"
+oneline: "Raise errors when 'this' would be any"
+---
+
+暗黙的に`any`型となるthis式でエラーを発生させます。
+
+例えば、以下のClassは`this.width`と`this.height`にアクセスする関数を返しています。
+しかし、`getAreaFunction`の内側の関数内でのコンテキストにおける`this`はRectangleのインスタンスではありません。
+
+```ts twoslash
+// @errors: 2683
+class Rectangle {
+  width: number;
+  height: number;
+
+  constructor(width: number, height: number) {
+    this.width = width;
+    this.height = height;
+  }
+
+  getAreaFunction() {
+    return function() {
+      return this.width * this.height;
+    };
+  }
+}
+```

--- a/packages/tsconfig-reference/copy/ja/options/strictBindCallApply.md
+++ b/packages/tsconfig-reference/copy/ja/options/strictBindCallApply.md
@@ -1,0 +1,34 @@
+---
+display: "Strict Bind Call Apply"
+oneline: "Ensure that 'call', 'bind' and 'apply' have the right arguments"
+---
+
+設定されている場合、関数の組み込みメソッドの`call`と`bind`と`apply`について、元となっている関数に対して正しい引数で呼び出されているかをTypeScriptがチェックします:
+
+```ts twoslash
+// @strictBindCallApply: true
+// @errors: 2345
+
+// strictBindCallApplyが有効な場合
+function fn(x: string) {
+   return parseInt(x);
+}
+
+const n1 = fn.call(undefined, "10");
+
+const n2 = fn.call(undefined, false);
+```
+
+設定されていない場合、これらの関数は任意の引数を受け取って`any`を返します:
+
+```ts twoslash
+// @strictBindCallApply: false
+
+// strictBindCallApplyが無効な場合
+function fn(x: string) {
+   return parseInt(x);
+}
+
+// Note: エラーになりません。戻り値の型は'any'です。
+const n = fn.call(undefined, false);
+```

--- a/packages/tsconfig-reference/copy/ja/options/strictPropertyInitialization.md
+++ b/packages/tsconfig-reference/copy/ja/options/strictPropertyInitialization.md
@@ -16,7 +16,7 @@ class UserAccount {
 
   constructor(name: string) {
     this.name = name;
-    // Note that this.email is not set
+    // 注 this.emailがセットされていません
   }
 }
 ```

--- a/packages/tsconfig-reference/copy/ja/options/strictPropertyInitialization.md
+++ b/packages/tsconfig-reference/copy/ja/options/strictPropertyInitialization.md
@@ -1,0 +1,29 @@
+---
+display: "Strict Property Initialization"
+oneline: "Ensure that all class properties match their types after the constructor has finished"
+---
+
+trueに設定した場合、Classプロパティが宣言されているがコンストラクターで値がセットされていないときに、TypeScriptはエラーを発生させます。
+
+```ts twoslash
+// @errors: 2564
+class UserAccount {
+  name: string;
+  accountType = "user";
+
+  email: string;
+  address: string | undefined;
+
+  constructor(name: string) {
+    this.name = name;
+    // Note that this.email is not set
+  }
+}
+```
+
+上記の場合:
+
+- `this.name`は具体的に設定されています。
+- `this.accountType`はデフォルト値が設定されています。
+- `this.email`は値が設定されていないため、エラーとなります。
+- `this.address`は潜在的に`undefined`として宣言されており、これは値の設定が必須でないことを意味しています。

--- a/packages/tsconfig-reference/copy/ja/options/strictPropertyInitialization.md
+++ b/packages/tsconfig-reference/copy/ja/options/strictPropertyInitialization.md
@@ -26,4 +26,4 @@ class UserAccount {
 - `this.name`は具体的に設定されています。
 - `this.accountType`はデフォルト値が設定されています。
 - `this.email`は値が設定されていないため、エラーとなります。
-- `this.address`は潜在的に`undefined`として宣言されており、これは値の設定が必須でないことを意味しています。
+- `this.address`は`undefined`になりうる値として宣言されており、これは値の設定が必須でないことを意味しています。


### PR DESCRIPTION
It's a part of #220 ( and the rest of #286  )

I translated the following options into Japanese:

- https://www.typescriptlang.org/v2/en/tsconfig#strictBindCallApply
- https://www.typescriptlang.org/v2/en/tsconfig#strictPropertyInitialization
- https://www.typescriptlang.org/v2/en/tsconfig#noImplicitThis
- https://www.typescriptlang.org/v2/en/tsconfig#alwaysStrict