### PR TITLE
Translate tsconfig SourceMap options into ja

### DIFF
--- a/packages/tsconfig-reference/copy/ja/categories/Source_Map_Options_6175.md
+++ b/packages/tsconfig-reference/copy/ja/categories/Source_Map_Options_6175.md
@@ -1,0 +1,8 @@
+---
+display: "Source Maps"
+---
+
+In order to provide rich debugging tools and crash reports which make sense to developers, TypeScript supports
+emitting additional files which conform to the JavaScript Source Map standards.
+
+These are emitted as `.map` files which live alongside the file they represent.

--- a/packages/tsconfig-reference/copy/ja/categories/Source_Map_Options_6175.md
+++ b/packages/tsconfig-reference/copy/ja/categories/Source_Map_Options_6175.md
@@ -1,8 +1,8 @@
 ---
-display: "Source Maps"
+display: "ソースマップ"
 ---
 
-In order to provide rich debugging tools and crash reports which make sense to developers, TypeScript supports
-emitting additional files which conform to the JavaScript Source Map standards.
+開発者にとって有用であるリッチなデバッグツールやクラッシュレポートを提供するため、
+TypeScriptはJavaScriptのソースマップ標準に準拠したファイルを追加で出力します。
 
-These are emitted as `.map` files which live alongside the file they represent.
+ソースマップは、そのソースマップが指し示す実体ファイルの隣に`.map`ファイルとして出力されます。

--- a/packages/tsconfig-reference/copy/ja/options/inlineSourceMap.md
+++ b/packages/tsconfig-reference/copy/ja/options/inlineSourceMap.md
@@ -1,0 +1,35 @@
+---
+display: "Inline Source Map"
+oneline: "Include sourcemap files inside the emitted JavaScript"
+---
+
+When set, instead of writing out a `.js.map` file to provide source maps, TypeScript will embed the source map content in the `.js` files.
+Although this results in larger JS files, it can be convenient in some scenarios.
+For example, you might want to debug JS files on a webserver that doesn't allow `.map` files to be served.
+
+Mutually exclusive with [`sourceMap`](#sourceMap).
+
+For example, with this TypeScript:
+
+```ts
+const helloWorld = "hi";
+console.log(helloWorld);
+```
+
+Converts to this JavaScript:
+
+```ts twoslasher
+// @showEmit
+const helloWorld = "hi";
+console.log(helloWorld);
+```
+
+Then enable building it with `inlineSourceMap` enabled there is a comment at the bottom of the file which includes
+a source-map for the file.
+
+```ts twoslasher
+// @inlineSourceMap
+// @showEmit
+const helloWorld = "hi";
+console.log(helloWorld);
+```

--- a/packages/tsconfig-reference/copy/ja/options/inlineSourceMap.md
+++ b/packages/tsconfig-reference/copy/ja/options/inlineSourceMap.md
@@ -3,20 +3,20 @@ display: "Inline Source Map"
 oneline: "Include sourcemap files inside the emitted JavaScript"
 ---
 
-When set, instead of writing out a `.js.map` file to provide source maps, TypeScript will embed the source map content in the `.js` files.
-Although this results in larger JS files, it can be convenient in some scenarios.
-For example, you might want to debug JS files on a webserver that doesn't allow `.map` files to be served.
+設定すると、TypeScriptはソースマップを`.js.map`ファイルへ出力するのではなく、ソースマップの内容を`.js`ファイルに埋め込みます。
+この結果、JSファイルはより大きくなりますが、くつかのシナリオにおいては便利です。
+例えば、`.map`ファイルの提供が許可されていないwebサーバーでJSファイルをデバッグしたい、という場合です。
 
-Mutually exclusive with [`sourceMap`](#sourceMap).
+このオプションは、[`sourceMap`](#sourceMap)とは互いに排他的にです。
 
-For example, with this TypeScript:
+例えば、次のTypeScriptは:
 
 ```ts
 const helloWorld = "hi";
 console.log(helloWorld);
 ```
 
-Converts to this JavaScript:
+次のJavaScriptに変換されます:
 
 ```ts twoslasher
 // @showEmit
@@ -24,8 +24,8 @@ const helloWorld = "hi";
 console.log(helloWorld);
 ```
 
-Then enable building it with `inlineSourceMap` enabled there is a comment at the bottom of the file which includes
-a source-map for the file.
+`inlineSourceMap`を有効にしてビルドすると、
+ファイルの末尾にこのファイルのソースマップを含んだコメントが出力されます。
 
 ```ts twoslasher
 // @inlineSourceMap

--- a/packages/tsconfig-reference/copy/ja/options/inlineSourceMap.md
+++ b/packages/tsconfig-reference/copy/ja/options/inlineSourceMap.md
@@ -4,7 +4,7 @@ oneline: "Include sourcemap files inside the emitted JavaScript"
 ---
 
 設定すると、TypeScriptはソースマップを`.js.map`ファイルへ出力するのではなく、ソースマップの内容を`.js`ファイルに埋め込みます。
-この結果、JSファイルはより大きくなりますが、くつかのシナリオにおいては便利です。
+この結果、JSファイルはより大きくなりますが、いくつかのシナリオにおいては便利です。
 例えば、`.map`ファイルの提供が許可されていないwebサーバーでJSファイルをデバッグしたい、という場合です。
 
 このオプションは、[`sourceMap`](#sourceMap)とは互いに排他的にです。

--- a/packages/tsconfig-reference/copy/ja/options/inlineSources.md
+++ b/packages/tsconfig-reference/copy/ja/options/inlineSources.md
@@ -3,19 +3,19 @@ display: "Inline Sources"
 oneline: "Include sourcemap files inside the emitted JavaScript"
 ---
 
-When set, TypeScript will include the original content of the `.ts` file as an embedded string in the source map.
-This is often useful in the same cases as `inlineSourceMap`.
+設定すると、TypeScriptは元の`.ts`ファイルの内容を文字列としてソースマップに埋め込みます。
+このオプションは`inlineSourceMap`と同様のケースで有用です。
 
-Requires either `sourceMap` or `inlineSourceMap` to be set.
+`sourceMap`または`inlineSourceMap`のいずれかが設定されている必要があります。
 
-For example, with this TypeScript:
+例えば、次のTypeScriptについて:
 
 ```ts twoslash
 const helloWorld = "hi";
 console.log(helloWorld);
 ```
 
-By default converts to this JavaScript:
+デフォルトでは、次のJavaScriptに変換されます:
 
 ```ts twoslasher
 // @showEmit
@@ -23,9 +23,9 @@ const helloWorld = "hi";
 console.log(helloWorld);
 ```
 
-Then enable building it with `inlineSources` and `inlineSourceMap` enabled there is a comment at the bottom of the file which includes
-a source-map for the file.
-Note that the end is different from the example in [`inlineSourceMap`](#inlineSourceMap) because the source-map now contains the original source code also.
+`inlineSources`と`inlineSourceMap`を有効にしてビルドすると、
+ファイルの末尾にこのファイルのソースマップを含んだコメントが付きます。
+このソースマップは元となったソースコードも含んでいるため、[`inlineSourceMap`](#inlineSourceMap)の例とは異なる点に留意してください。
 
 ```ts twoslasher
 // @inlineSources

--- a/packages/tsconfig-reference/copy/ja/options/inlineSources.md
+++ b/packages/tsconfig-reference/copy/ja/options/inlineSources.md
@@ -1,0 +1,36 @@
+---
+display: "Inline Sources"
+oneline: "Include sourcemap files inside the emitted JavaScript"
+---
+
+When set, TypeScript will include the original content of the `.ts` file as an embedded string in the source map.
+This is often useful in the same cases as `inlineSourceMap`.
+
+Requires either `sourceMap` or `inlineSourceMap` to be set.
+
+For example, with this TypeScript:
+
+```ts twoslash
+const helloWorld = "hi";
+console.log(helloWorld);
+```
+
+By default converts to this JavaScript:
+
+```ts twoslasher
+// @showEmit
+const helloWorld = "hi";
+console.log(helloWorld);
+```
+
+Then enable building it with `inlineSources` and `inlineSourceMap` enabled there is a comment at the bottom of the file which includes
+a source-map for the file.
+Note that the end is different from the example in [`inlineSourceMap`](#inlineSourceMap) because the source-map now contains the original source code also.
+
+```ts twoslasher
+// @inlineSources
+// @inlineSourceMap
+// @showEmit
+const helloWorld = "hi";
+console.log(helloWorld);
+```

--- a/packages/tsconfig-reference/copy/ja/options/mapRoot.md
+++ b/packages/tsconfig-reference/copy/ja/options/mapRoot.md
@@ -3,8 +3,8 @@ display: "Map Root"
 oneline: "Set an external root for sourcemaps"
 ---
 
-Specify the location where debugger should locate map files instead of generated locations.
-This string is treated verbatim inside the source-map, for example:
+生成された場所情報を利用するのではなく、デバッガがマップファイルを探索すべき場所を明示します。
+この文字列はソースマップの中で、文字列そのままの値として処理されます。例えば:
 
 ```json
 {
@@ -15,4 +15,4 @@ This string is treated verbatim inside the source-map, for example:
 }
 ```
 
-Would declare that `index.js` will have sourcemaps at `https://my-website.com/debug/sourcemaps/index.js.map`.
+この設定は、`index.js`は`https://my-website.com/debug/sourcemaps/index.js.map`にソースマップがあることを宣言しています。

--- a/packages/tsconfig-reference/copy/ja/options/mapRoot.md
+++ b/packages/tsconfig-reference/copy/ja/options/mapRoot.md
@@ -1,0 +1,18 @@
+---
+display: "Map Root"
+oneline: "Set an external root for sourcemaps"
+---
+
+Specify the location where debugger should locate map files instead of generated locations.
+This string is treated verbatim inside the source-map, for example:
+
+```json
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "mapRoot": "https://my-website.com/debug/sourcemaps/"
+  }
+}
+```
+
+Would declare that `index.js` will have sourcemaps at `https://my-website.com/debug/sourcemaps/index.js.map`.

--- a/packages/tsconfig-reference/copy/ja/options/sourceRoot.md
+++ b/packages/tsconfig-reference/copy/ja/options/sourceRoot.md
@@ -1,0 +1,18 @@
+---
+display: "Source Root"
+oneline: "Sets the root path for debuggers to find the reference source code"
+---
+
+Specify the location where a debugger should locate TypeScript files instead of relative source locations.
+This string is treated verbatim inside the source-map where you can use a path or a URL:
+
+```json
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "sourceRoot": "https://my-website.com/debug/source/"
+  }
+}
+```
+
+Would declare that `index.js` will have a source file at `https://my-website.com/debug/source/index.ts`.

--- a/packages/tsconfig-reference/copy/ja/options/sourceRoot.md
+++ b/packages/tsconfig-reference/copy/ja/options/sourceRoot.md
@@ -3,8 +3,8 @@ display: "Source Root"
 oneline: "Sets the root path for debuggers to find the reference source code"
 ---
 
-Specify the location where a debugger should locate TypeScript files instead of relative source locations.
-This string is treated verbatim inside the source-map where you can use a path or a URL:
+相対的なソースコードの場所の代わりに、デバッガがTypeScriptのファイルを探索すべき場所を明示します。
+この文字列は、パスやURLを使用できるソースマップの中で、文字列そのままの値として処理されます:
 
 ```json
 {
@@ -15,4 +15,4 @@ This string is treated verbatim inside the source-map where you can use a path o
 }
 ```
 
-Would declare that `index.js` will have a source file at `https://my-website.com/debug/source/index.ts`.
+上記の設定は、`index.js`は`https://my-website.com/debug/source/index.ts`にソースコードがある、ということを宣言しています。


### PR DESCRIPTION

It's a part of #220 

I translated tsconfig references under http://www.typescriptlang.org/v2/en/tsconfig#Source_Map_Options_6175 .

Comparison for original docs:
https://github.com/microsoft/TypeScript-Website/pull/302/commits/aaa46117129e2d7f2e7da19941921f7e8e6ab971