### PR TITLE
Translate tsconfig LinterChecks options into ja

### DIFF
--- a/packages/tsconfig-reference/copy/ja/categories/Additional_Checks_6176.md
+++ b/packages/tsconfig-reference/copy/ja/categories/Additional_Checks_6176.md
@@ -1,0 +1,5 @@
+---
+display: "Linter Checks"
+---
+
+A collection of extra checks, which somewhat cross the boundaries of compiler vs linter. You may prefer to use a tool like <a href="https://github.com/typescript-eslint/typescript-eslint#typescript-eslint">eslint</a> over these options if you are looking for more in-depth rules.

--- a/packages/tsconfig-reference/copy/ja/categories/Additional_Checks_6176.md
+++ b/packages/tsconfig-reference/copy/ja/categories/Additional_Checks_6176.md
@@ -2,4 +2,4 @@
 display: "Linter Checks"
 ---
 
-A collection of extra checks, which somewhat cross the boundaries of compiler vs linter. You may prefer to use a tool like <a href="https://github.com/typescript-eslint/typescript-eslint#typescript-eslint">eslint</a> over these options if you are looking for more in-depth rules.
+追加のチェック集です。これらのチェックは、コンパイラとリンターの境界を多少跨いでいます。より詳細なルールを探しているのであれば、これらのオプションよりも<a href="https://github.com/typescript-eslint/typescript-eslint#typescript-eslint">eslint</a>のようなツールの使用を推奨します。

--- a/packages/tsconfig-reference/copy/ja/options/noFallthroughCasesInSwitch.md
+++ b/packages/tsconfig-reference/copy/ja/options/noFallthroughCasesInSwitch.md
@@ -3,9 +3,9 @@ display: "No Fallthrough Cases In Switch"
 oneline: "Report errors for fallthrough cases in switch statements."
 ---
 
-Report errors for fallthrough cases in switch statements.
-Ensures that any non-empty case inside a switch statement includes either `break` or `return`.
-This means you won't accidentally ship a case fallthrough bug.
+switch文において、次のcaseへ処理を持ち越した場合にエラーを報告します。
+switch文内の空でないcase句が`break`または`return`を含むことを確約します。
+これは、意図しないcaseへの処理持ち越しによるバグを流出させない、ということ意味しています。
 
 ```ts twoslash
 // @noFallthroughCasesInSwitch

--- a/packages/tsconfig-reference/copy/ja/options/noFallthroughCasesInSwitch.md
+++ b/packages/tsconfig-reference/copy/ja/options/noFallthroughCasesInSwitch.md
@@ -1,0 +1,22 @@
+---
+display: "No Fallthrough Cases In Switch"
+oneline: "Report errors for fallthrough cases in switch statements."
+---
+
+Report errors for fallthrough cases in switch statements.
+Ensures that any non-empty case inside a switch statement includes either `break` or `return`.
+This means you won't accidentally ship a case fallthrough bug.
+
+```ts twoslash
+// @noFallthroughCasesInSwitch
+// @errors: 7029
+const a: number = 6;
+
+switch (a) {
+  case 0:
+    console.log("even");
+  case 1:
+    console.log("odd");
+    break;
+}
+```

--- a/packages/tsconfig-reference/copy/ja/options/noImplicitReturns.md
+++ b/packages/tsconfig-reference/copy/ja/options/noImplicitReturns.md
@@ -1,0 +1,17 @@
+---
+display: "No Implicit Returns"
+oneline: "Ensure that all codepaths return in a function"
+---
+
+When enabled, TypeScript will check all code paths in a function to ensure they return a value.
+
+```ts twoslash
+// @errors: 2366 2322
+function lookupHeadphonesManufacturer(color: "blue" | "black"): string {
+  if (color === "blue") {
+    return "beats";
+  } else {
+    "bose";
+  }
+}
+```

--- a/packages/tsconfig-reference/copy/ja/options/noImplicitReturns.md
+++ b/packages/tsconfig-reference/copy/ja/options/noImplicitReturns.md
@@ -3,7 +3,7 @@ display: "No Implicit Returns"
 oneline: "Ensure that all codepaths return in a function"
 ---
 
-When enabled, TypeScript will check all code paths in a function to ensure they return a value.
+有効化すると、TypeScriptは関数内のすべてのコードパスについて、値を返却していることをチェックします。
 
 ```ts twoslash
 // @errors: 2366 2322

--- a/packages/tsconfig-reference/copy/ja/options/noUnusedLocals.md
+++ b/packages/tsconfig-reference/copy/ja/options/noUnusedLocals.md
@@ -3,7 +3,7 @@ display: "No Unused Locals"
 oneline: "Error when a local variable isn't read"
 ---
 
-Report errors on unused local variables.
+利用されていないローカル変数について、エラーを報告します。
 
 ```ts twoslash
 // @noUnusedLocals

--- a/packages/tsconfig-reference/copy/ja/options/noUnusedLocals.md
+++ b/packages/tsconfig-reference/copy/ja/options/noUnusedLocals.md
@@ -1,0 +1,15 @@
+---
+display: "No Unused Locals"
+oneline: "Error when a local variable isn't read"
+---
+
+Report errors on unused local variables.
+
+```ts twoslash
+// @noUnusedLocals
+// @errors: 6133
+const createKeyboard = (modelID: number) => {
+  const defaultModelID = 23;
+  return { type: "keyboard", modelID };
+};
+```

--- a/packages/tsconfig-reference/copy/ja/options/noUnusedParameters.md
+++ b/packages/tsconfig-reference/copy/ja/options/noUnusedParameters.md
@@ -1,0 +1,15 @@
+---
+display: "No Unused Parameters"
+oneline: "Error when a parameter isn't used"
+---
+
+Report errors on unused parameters in functions.
+
+```ts twoslash
+// @noUnusedParameters
+// @errors: 6133
+const createDefaultKeyboard = (modelID: number) => {
+  const defaultModelID = 23;
+  return { type: "keyboard", modelID: defaultModelID };
+};
+```

--- a/packages/tsconfig-reference/copy/ja/options/noUnusedParameters.md
+++ b/packages/tsconfig-reference/copy/ja/options/noUnusedParameters.md
@@ -3,7 +3,7 @@ display: "No Unused Parameters"
 oneline: "Error when a parameter isn't used"
 ---
 
-Report errors on unused parameters in functions.
+利用されていない関数のパラメータについて、エラーを報告します。
 
 ```ts twoslash
 // @noUnusedParameters


### PR DESCRIPTION
It's a part of #220 .

I translated tsconfig options under https://www.typescriptlang.org/v2/en/tsconfig#Additional_Checks_6176 into Japanese.

Comparison for original docs: https://github.com/microsoft/TypeScript-Website/commit/5f84170ac5cb058e95169eb27c3e5e8c398997ae