### PR TITLE
Translate advanced tsconfig options(jsxFactory ~ stripInternal) into Japanese

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/noResolve.md
+++ b/packages/tsconfig-reference/copy/en/options/noResolve.md
@@ -5,5 +5,5 @@ oneline: "Skip ahead-of-time checking for import and <reference files"
 
 By default, TypeScript will examine the initial set of files for `import` and `<reference` directives and add these resolved files to your program.
 
-If `noResolve` isn't set, this process doesn't happen.
+If `noResolve` is set, this process doesn't happen.
 However, `import` statements are still checked to see if they resolve to a valid module, so you'll need to make sure this is satisfied by some other means.

--- a/packages/tsconfig-reference/copy/ja/options/charset.md
+++ b/packages/tsconfig-reference/copy/ja/options/charset.md
@@ -1,0 +1,7 @@
+---
+display: "Charset"
+oneline: "Manually set the text encoding for reading files"
+---
+
+In prior versions of TypeScript, this controlled what encoding was used when reading text files from disk.
+Today, TypeScript assumes UTF-8 encoding, but will correctly detect UTF-16 (BE and LE) or UTF-8 BOMs.

--- a/packages/tsconfig-reference/copy/ja/options/charset.md
+++ b/packages/tsconfig-reference/copy/ja/options/charset.md
@@ -3,5 +3,5 @@ display: "Charset"
 oneline: "Manually set the text encoding for reading files"
 ---
 
-In prior versions of TypeScript, this controlled what encoding was used when reading text files from disk.
-Today, TypeScript assumes UTF-8 encoding, but will correctly detect UTF-16 (BE and LE) or UTF-8 BOMs.
+以前のTypeScriptのバージョンでは、このオプションでディスクからどのエンコードでファイルを読み込むかを制御していました。
+今のTypeScriptはUTF-8でエンコードされていることを前提としています。ただし、UTF-16（BEおよびLE）またはUTF-8のBOMを正しく検出します。

--- a/packages/tsconfig-reference/copy/ja/options/emitBOM.md
+++ b/packages/tsconfig-reference/copy/ja/options/emitBOM.md
@@ -1,0 +1,8 @@
+---
+display: "Emit BOM"
+oneline: "Include a byte order mark to output files"
+---
+
+Controls whether TypeScript will emit a [byte order mark (BOM)](https://en.wikipedia.org/wiki/Byte_order_mark) when writing output files.
+Some runtime environments require a BOM to correctly interpret a JavaScript files; others require that it is not present.
+The default value of `false` is generally best unless you have a reason to change it.

--- a/packages/tsconfig-reference/copy/ja/options/emitBOM.md
+++ b/packages/tsconfig-reference/copy/ja/options/emitBOM.md
@@ -3,6 +3,6 @@ display: "Emit BOM"
 oneline: "Include a byte order mark to output files"
 ---
 
-Controls whether TypeScript will emit a [byte order mark (BOM)](https://en.wikipedia.org/wiki/Byte_order_mark) when writing output files.
-Some runtime environments require a BOM to correctly interpret a JavaScript files; others require that it is not present.
-The default value of `false` is generally best unless you have a reason to change it.
+TypeScriptがファイルを書き込むときに[バイトオーダーマーク（BOM）](https://en.wikipedia.org/wiki/Byte_order_mark)を出力するかどうかを制御します。
+一部の実行環境ではJavaScriptファイルを正しく解釈するために、BOMが必要となりますが、他の実行環境ではBOMの存在を許容しません。
+デフォルト値の`false`は一般的に最適な値ですが、必要であれば変更できます。

--- a/packages/tsconfig-reference/copy/ja/options/jsxFactory.md
+++ b/packages/tsconfig-reference/copy/ja/options/jsxFactory.md
@@ -3,7 +3,7 @@ display: "JSX Factory"
 oneline: "Control the function emitted by JSX"
 ---
 
-Changes the function called in `.js` files when compiling JSX Elements.
-The most common change is to use `"h"` or `"preact.h"` instead of the default `"React.createElement"` if using `preact`.
+JSX要素がコンパイルされるときの`.js`ファイルで呼び出される関数を変更します。
+`preact`を使う場合に、デフォルトの`"React.createElement"`の代わりに`"h"`や`"preact.h"`に変更するのが一般的な変更です。
 
-This is the same as [Babel's `/** @jsx h */` directive](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx#custom).
+このオプションは[Babelにおける`/** @jsx h */`ディレクティブ](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx#custom)と同じものです。

--- a/packages/tsconfig-reference/copy/ja/options/jsxFactory.md
+++ b/packages/tsconfig-reference/copy/ja/options/jsxFactory.md
@@ -1,0 +1,9 @@
+---
+display: "JSX Factory"
+oneline: "Control the function emitted by JSX"
+---
+
+Changes the function called in `.js` files when compiling JSX Elements.
+The most common change is to use `"h"` or `"preact.h"` instead of the default `"React.createElement"` if using `preact`.
+
+This is the same as [Babel's `/** @jsx h */` directive](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx#custom).

--- a/packages/tsconfig-reference/copy/ja/options/newLine.md
+++ b/packages/tsconfig-reference/copy/ja/options/newLine.md
@@ -3,4 +3,5 @@ display: "New Line"
 oneline: "Set the newline character"
 ---
 
-Specify the end of line sequence to be used when emitting files: 'CRLF' (dos) or 'LF' (unix).
+ファイルを出力するときの改行コードを指定します: 'CRLF'（dos）または'LF'（unix）のいずれかを指定してください。
+

--- a/packages/tsconfig-reference/copy/ja/options/newLine.md
+++ b/packages/tsconfig-reference/copy/ja/options/newLine.md
@@ -1,0 +1,6 @@
+---
+display: "New Line"
+oneline: "Set the newline character"
+---
+
+Specify the end of line sequence to be used when emitting files: 'CRLF' (dos) or 'LF' (unix).

--- a/packages/tsconfig-reference/copy/ja/options/newLine.md
+++ b/packages/tsconfig-reference/copy/ja/options/newLine.md
@@ -4,4 +4,3 @@ oneline: "Set the newline character"
 ---
 
 ファイルを出力するときの改行コードを指定します: 'CRLF'（dos）または'LF'（unix）のいずれかを指定してください。
-

--- a/packages/tsconfig-reference/copy/ja/options/noErrorTruncation.md
+++ b/packages/tsconfig-reference/copy/ja/options/noErrorTruncation.md
@@ -3,7 +3,7 @@ display: "No Error Truncation"
 oneline: "Do not truncate error messages"
 ---
 
-エラーメッセージを打ち切らないようにします。
+エラーメッセージを切り捨てないようにします。
 
 デフォルト値の`false`の場合、次のようになります。
 

--- a/packages/tsconfig-reference/copy/ja/options/noErrorTruncation.md
+++ b/packages/tsconfig-reference/copy/ja/options/noErrorTruncation.md
@@ -3,9 +3,9 @@ display: "No Error Truncation"
 oneline: "Do not truncate error messages"
 ---
 
-Do not truncate error messages.
+エラーメッセージを打ち切らないようにします。
 
-With `false`, the default.
+デフォルト値の`false`の場合、次のようになります。
 
 ```ts twoslash
 // @errors: 2322 2454
@@ -18,11 +18,11 @@ var x: {
   propertyWithAnExceedinglyLongName5: string;
 };
 
-// String representation of type of 'x' should be truncated in error message
+// 型'x'の文字列表現はエラメッセージ中で省略されます
 var s: string = x;
 ```
 
-With `true`
+`true`にすると、次のようになります。
 
 ```ts twoslash
 // @errors: 2322 2454
@@ -35,6 +35,6 @@ var x: {
   propertyWithAnExceedinglyLongName5: string;
 };
 
-// String representation of type of 'x' should be truncated in error message
+// 型'x'の文字列表現はエラメッセージ中で省略されます
 var s: string = x;
 ```

--- a/packages/tsconfig-reference/copy/ja/options/noErrorTruncation.md
+++ b/packages/tsconfig-reference/copy/ja/options/noErrorTruncation.md
@@ -1,0 +1,40 @@
+---
+display: "No Error Truncation"
+oneline: "Do not truncate error messages"
+---
+
+Do not truncate error messages.
+
+With `false`, the default.
+
+```ts twoslash
+// @errors: 2322 2454
+// @noErrorTruncation: false
+var x: {
+  propertyWithAnExceedinglyLongName1: string;
+  propertyWithAnExceedinglyLongName2: string;
+  propertyWithAnExceedinglyLongName3: string;
+  propertyWithAnExceedinglyLongName4: string;
+  propertyWithAnExceedinglyLongName5: string;
+};
+
+// String representation of type of 'x' should be truncated in error message
+var s: string = x;
+```
+
+With `true`
+
+```ts twoslash
+// @errors: 2322 2454
+// @noErrorTruncation: true
+var x: {
+  propertyWithAnExceedinglyLongName1: string;
+  propertyWithAnExceedinglyLongName2: string;
+  propertyWithAnExceedinglyLongName3: string;
+  propertyWithAnExceedinglyLongName4: string;
+  propertyWithAnExceedinglyLongName5: string;
+};
+
+// String representation of type of 'x' should be truncated in error message
+var s: string = x;
+```

--- a/packages/tsconfig-reference/copy/ja/options/noLib.md
+++ b/packages/tsconfig-reference/copy/ja/options/noLib.md
@@ -3,5 +3,5 @@ display: "No Lib"
 oneline: "Ignore options from lib"
 ---
 
-Disables the automatic inclusion of any library files.
-If this option is set, `lib` is ignored.
+すべてのライブラリファイルについて、自動でのインクルードを無効化します。
+このオプションを設定した場合、`lib`は無視されます。

--- a/packages/tsconfig-reference/copy/ja/options/noLib.md
+++ b/packages/tsconfig-reference/copy/ja/options/noLib.md
@@ -1,0 +1,7 @@
+---
+display: "No Lib"
+oneline: "Ignore options from lib"
+---
+
+Disables the automatic inclusion of any library files.
+If this option is set, `lib` is ignored.

--- a/packages/tsconfig-reference/copy/ja/options/noResolve.md
+++ b/packages/tsconfig-reference/copy/ja/options/noResolve.md
@@ -1,0 +1,9 @@
+---
+display: "No Resolve"
+oneline: "Skip ahead-of-time checking for import and <reference files"
+---
+
+By default, TypeScript will examine the initial set of files for `import` and `<reference` directives and add these resolved files to your program.
+
+If `noResolve` isn't set, this process doesn't happen.
+However, `import` statements are still checked to see if they resolve to a valid module, so you'll need to make sure this is satisfied by some other means.

--- a/packages/tsconfig-reference/copy/ja/options/noResolve.md
+++ b/packages/tsconfig-reference/copy/ja/options/noResolve.md
@@ -3,7 +3,7 @@ display: "No Resolve"
 oneline: "Skip ahead-of-time checking for import and <reference files"
 ---
 
-By default, TypeScript will examine the initial set of files for `import` and `<reference` directives and add these resolved files to your program.
+デフォルトでは、TypeScriptは起動時に与えられたファイルについて`import`と`<reference`ディレクティブを確認し、解決されたファイルをプログラムに追加します。
 
-If `noResolve` isn't set, this process doesn't happen.
-However, `import` statements are still checked to see if they resolve to a valid module, so you'll need to make sure this is satisfied by some other means.
+`noResolve`が設定されているとき、このプロセスは発生しなくなります。
+しかし、`import`文は正しいモジュールを解決しているかどうかチェックされるため、これが満たされているかどうかを他の方法で確認する必要があります。

--- a/packages/tsconfig-reference/copy/ja/options/out.md
+++ b/packages/tsconfig-reference/copy/ja/options/out.md
@@ -3,7 +3,7 @@ display: "Out"
 oneline: "Do not use this"
 ---
 
-Use [outFile](#outfile) instead.
+代わりに[outFile](#outfile)を使ってください。
 
-The `out` option computes the final file location in a way that is not predictable or consistent.
-This option is retained for backward compatibility only and is deprecated.
+`out`オプションは、予測可能でない、または一貫性のない方法によってファイルの最終的な場所を計算してしまいます。
+このオプションは後方互換性の維持のためにのみ残されていますが、非推奨です。

--- a/packages/tsconfig-reference/copy/ja/options/out.md
+++ b/packages/tsconfig-reference/copy/ja/options/out.md
@@ -1,0 +1,9 @@
+---
+display: "Out"
+oneline: "Do not use this"
+---
+
+Use [outFile](#outfile) instead.
+
+The `out` option computes the final file location in a way that is not predictable or consistent.
+This option is retained for backward compatibility only and is deprecated.

--- a/packages/tsconfig-reference/copy/ja/options/reactNamespace.md
+++ b/packages/tsconfig-reference/copy/ja/options/reactNamespace.md
@@ -1,0 +1,6 @@
+---
+display: "React Namespace"
+oneline: "Specify the object which 'createElement' is called on in JSX"
+---
+
+Use [`--jsxFactory`](#jsxFactory) instead. Specify the object invoked for `createElement` when targeting `react` for TSX files.

--- a/packages/tsconfig-reference/copy/ja/options/reactNamespace.md
+++ b/packages/tsconfig-reference/copy/ja/options/reactNamespace.md
@@ -3,4 +3,4 @@ display: "React Namespace"
 oneline: "Specify the object which 'createElement' is called on in JSX"
 ---
 
-Use [`--jsxFactory`](#jsxFactory) instead. Specify the object invoked for `createElement` when targeting `react` for TSX files.
+代わりに[`--jsxFactory`](#jsxFactory)を利用してください。`react`のときにTSXファイルの`createElement`が実行されるオブジェクトを指定します。

--- a/packages/tsconfig-reference/copy/ja/options/resolveJsonModule.md
+++ b/packages/tsconfig-reference/copy/ja/options/resolveJsonModule.md
@@ -3,10 +3,10 @@ display: "Resolve JSON Module"
 oneline: "Allow importing .json files"
 ---
 
-Allows importing modules with a '.json' extension, which is a common practice in node projects. This includes
-generating a type for the `import` based on the static JSON shape.
+'.json'拡張子のファイルをモジュールとしてインポートできるようにします。Nodeのプロジェクトで一般的に利用されている手法です。
+このオプションは、`import`時に静的なJSONの構造から型を生成します。
 
-TypeScript does not support resolving JSON files by default:
+デフォルトでは、TypeScriptはJSONファイルの解決をサポートしていません:
 
 ```ts
 // @filename: settings.json
@@ -22,7 +22,7 @@ settings.debug === true;
 settings.dry === 2;
 ```
 
-Enabling the option allows importing JSON, and validating the types in that JSON file.
+このオプションを有効にするとJSONのインポートが可能となり、JSONファイルの型を検査できるようになります。
 
 ```ts
 // @filename: settings.json

--- a/packages/tsconfig-reference/copy/ja/options/resolveJsonModule.md
+++ b/packages/tsconfig-reference/copy/ja/options/resolveJsonModule.md
@@ -1,0 +1,39 @@
+---
+display: "Resolve JSON Module"
+oneline: "Allow importing .json files"
+---
+
+Allows importing modules with a '.json' extension, which is a common practice in node projects. This includes
+generating a type for the `import` based on the static JSON shape.
+
+TypeScript does not support resolving JSON files by default:
+
+```ts
+// @filename: settings.json
+{
+    "repo": "TypeScript",
+    "dry": false,
+    "debug": false
+}
+// @filename: index.ts
+import settings from "./settings.json";
+
+settings.debug === true;
+settings.dry === 2;
+```
+
+Enabling the option allows importing JSON, and validating the types in that JSON file.
+
+```ts
+// @filename: settings.json
+{
+    "repo": "TypeScript",
+    "dry": false,
+    "debug": false
+}
+// @filename: index.ts
+import settings from "./settings.json";
+
+settings.debug === true;
+settings.dry === 2;
+```

--- a/packages/tsconfig-reference/copy/ja/options/skipDefaultLibCheck.md
+++ b/packages/tsconfig-reference/copy/ja/options/skipDefaultLibCheck.md
@@ -1,0 +1,6 @@
+---
+display: "Skip Default Lib Check"
+oneline: "use SkipLibCheck instead"
+---
+
+Use [`--skipLibCheck`](#skipLibCheck) instead. Skip type checking of default library declaration files.

--- a/packages/tsconfig-reference/copy/ja/options/skipDefaultLibCheck.md
+++ b/packages/tsconfig-reference/copy/ja/options/skipDefaultLibCheck.md
@@ -3,4 +3,4 @@ display: "Skip Default Lib Check"
 oneline: "use SkipLibCheck instead"
 ---
 
-Use [`--skipLibCheck`](#skipLibCheck) instead. Skip type checking of default library declaration files.
+代わりに[`--skipLibCheck`](#skipLibCheck)を利用してください。デフォルトのライブラリ型定義ファイルをチェックしないようになります。

--- a/packages/tsconfig-reference/copy/ja/options/stripInternal.md
+++ b/packages/tsconfig-reference/copy/ja/options/stripInternal.md
@@ -3,9 +3,9 @@ display: "Strip Internal"
 oneline: "Remove declarations which have '@internal' in their JSDoc comments"
 ---
 
-Do not emit declarations for code that has an `@internal` annotation in it's JSDoc comment.
-This is an internal compiler option; use at your own risk, because the compiler does not check that the result is valid.
-If you are searching for a tool to handle additional levels of visibility within your `d.ts` files, look at [api-extractor](https://api-extractor.com).
+JSDocコメントとして`@internal`が付与されたコードについて、定義情報を出力しないようにします。
+このオプションはコンパイラが内部で利用するためのものです; コンパイラは結果の妥当性検証をしないため、自己責任で使ってください。
+`d.ts`ファイル内での可視性を細かく制御できるツールを探しているのであれば、[api-extractor](https://api-extractor.com)を参照してください。
 
 ```ts twoslash
 /**
@@ -20,25 +20,25 @@ export function weeklySalary(dayRate: number) {
 }
 ```
 
-With the flag set to `false` (default):
+このフラグが`false`であるとき（デフォルト）:
 
 ```ts twoslash
 // @showEmittedFile: index.d.ts
 // @showEmit
 // @declaration
 /**
- * Days available in a week
+ * 一週間の日数
  * @internal
  */
 export const daysInAWeek = 7;
 
-/** Calculate how much someone earns in a week */
+/** 一週間あたりの稼ぎを計算する */
 export function weeklySalary(dayRate: number) {
   return daysInAWeek * dayRate;
 }
 ```
 
-With `stripInternal` set to `true` the `d.ts` emitted will be redacted.
+`stripInternal`を`true`に設定すると、`d.ts`は次のように編集されて出力されます。
 
 ```ts twoslash
 // @stripinternal
@@ -46,15 +46,15 @@ With `stripInternal` set to `true` the `d.ts` emitted will be redacted.
 // @showEmit
 // @declaration
 /**
- * Days available in a week
+ * 一週間の日数
  * @internal
  */
 export const daysInAWeek = 7;
 
-/** Calculate how much someone earns in a week */
+/** 一週間あたりの稼ぎを計算する */
 export function weeklySalary(dayRate: number) {
   return daysInAWeek * dayRate;
 }
 ```
 
-The JavaScript output is still the same.
+JavaScriptとしての出力は一緒です。

--- a/packages/tsconfig-reference/copy/ja/options/stripInternal.md
+++ b/packages/tsconfig-reference/copy/ja/options/stripInternal.md
@@ -1,0 +1,60 @@
+---
+display: "Strip Internal"
+oneline: "Remove declarations which have '@internal' in their JSDoc comments"
+---
+
+Do not emit declarations for code that has an `@internal` annotation in it's JSDoc comment.
+This is an internal compiler option; use at your own risk, because the compiler does not check that the result is valid.
+If you are searching for a tool to handle additional levels of visibility within your `d.ts` files, look at [api-extractor](https://api-extractor.com).
+
+```ts twoslash
+/**
+ * Days available in a week
+ * @internal
+ */
+export const daysInAWeek = 7;
+
+/** Calculate how much someone earns in a week */
+export function weeklySalary(dayRate: number) {
+  return daysInAWeek * dayRate;
+}
+```
+
+With the flag set to `false` (default):
+
+```ts twoslash
+// @showEmittedFile: index.d.ts
+// @showEmit
+// @declaration
+/**
+ * Days available in a week
+ * @internal
+ */
+export const daysInAWeek = 7;
+
+/** Calculate how much someone earns in a week */
+export function weeklySalary(dayRate: number) {
+  return daysInAWeek * dayRate;
+}
+```
+
+With `stripInternal` set to `true` the `d.ts` emitted will be redacted.
+
+```ts twoslash
+// @stripinternal
+// @showEmittedFile: index.d.ts
+// @showEmit
+// @declaration
+/**
+ * Days available in a week
+ * @internal
+ */
+export const daysInAWeek = 7;
+
+/** Calculate how much someone earns in a week */
+export function weeklySalary(dayRate: number) {
+  return daysInAWeek * dayRate;
+}
+```
+
+The JavaScript output is still the same.


### PR DESCRIPTION
Part of #220 .

I translated tsconfig options from https://www.typescriptlang.org/v2/en/tsconfig#jsxFactory to https://www.typescriptlang.org/v2/en/tsconfig#stripInternal .

Comparison from the original docs: https://github.com/microsoft/TypeScript-Website/commit/95b0a2ee320d22eadde6e203b0b52ac65d9c20a5