### PR TITLE
Display "plugins" tsconfig option

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/plugins.md
+++ b/packages/tsconfig-reference/copy/en/options/plugins.md
@@ -12,5 +12,6 @@ For example:
 - [ts-sql-plugin](https://github.com/xialvjun/ts-sql-plugin#readme) &mdash; Adds SQL linting with a template strings SQL builder.
 - [typescript-styled-plugin](https://github.com/Microsoft/typescript-styled-plugin) &mdash; Provides CSS linting inside template strings .
 - [typescript-eslint-language-service](https://github.com/Quramy/typescript-eslint-language-service) &mdash; Provides eslint error messaging and fix-its inside the compiler's output.
+- [ts-graphql-plugin](https://github.com/Quramy/ts-graphql-plugin) &mdash; Provides validation and auto-completion inside GraphQL query template strings.
 
 VS Code has the ability for a extension to [automatically include language service plugins](https://code.visualstudio.com/api/references/contribution-points#contributes.typescriptServerPlugins), and so you may have some running in your editor without needing to define them in your `tsconfig.json`.

--- a/packages/tsconfig-reference/scripts/generateJSON.ts
+++ b/packages/tsconfig-reference/scripts/generateJSON.ts
@@ -20,7 +20,8 @@ import {
   defaultsForOptions,
   recommended,
   allowedValues,
-  configToRelease
+  configToRelease,
+  additionalOptionDescriptors,
 } from "./tsconfigRules";
 import { CompilerOptionName } from "../data/_types";
 
@@ -67,6 +68,9 @@ filteredOptions.forEach(option => {
     categories.add(option.category);
     option.categoryCode = option.category.code;
     option.category = undefined;
+  } else if (option.name in additionalOptionDescriptors) {
+    // Set category code manually because some options have no category 
+    option.categoryCode = additionalOptionDescriptors[option.name].categoryCode;
   }
 
   // If it's got related fields, set them

--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -237,6 +237,12 @@ export const releaseToConfigsMap: { [key: string]: AnOption[] } = {
   "1.0": ["declaration", "target", "module", "outFile"]
 };
 
+export const additionalOptionDescriptors: Record<string, { categoryCode: number }> = {
+  "plugins": {
+    categoryCode: 6172,
+  },
+};
+
 /** When a particular compiler flag (or CLI command...) was added  */
 export const configToRelease = {};
 Object.keys(releaseToConfigsMap).forEach(v => {


### PR DESCRIPTION
It fixes #334 .

<img width="1186" alt="スクリーンショット 2020-03-11 16 05 18" src="https://user-images.githubusercontent.com/1262998/76391142-26880b80-63b2-11ea-929b-9a14684374af.png">

@orta Thanks for your advice https://github.com/microsoft/TypeScript-Website/issues/334#issuecomment-597033002

>  Let's manually set its category to Project Options in the generation script