### PR TITLE
Remove fixed line-height to improve readability

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/main.scss
+++ b/packages/typescriptlang-org/src/components/layout/main.scss
@@ -8,7 +8,6 @@ html {
   font-family: "Segoe UI Web (West European)", "Segoe UI", -apple-system,
     BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;
   font-size: 16px;
-  line-height: 18px;
 
   @media (prefers-color-scheme: dark) {
     background-color: $ts-dark-bg-color;


### PR DESCRIPTION
The fixed line-height of 18px looks very cramped. Simply removing it and using the default improves the readability a lot, e.g. for the paragraphs under "What is TypeScript?" on the landing page. You may try this out using the CSS inspector.