### PR TITLE
Fixed sintax error in example for set and get accessor in ambient context

### DIFF
--- a/packages/handbook-v1/en/release notes/Overview.md
+++ b/packages/handbook-v1/en/release notes/Overview.md
@@ -1522,7 +1522,7 @@ As a result, users can write getters and setters in ambient contexts in TypeScri
 declare class Foo {
   // Allowed in 3.6+.
   get x(): number;
-  set x(val: number): void;
+  set x(val: number);
 }
 ```
 

--- a/packages/handbook-v1/en/release notes/TypeScript 3.6.md
+++ b/packages/handbook-v1/en/release notes/TypeScript 3.6.md
@@ -250,7 +250,7 @@ As a result, users can write getters and setters in ambient contexts in TypeScri
 declare class Foo {
   // Allowed in 3.6+.
   get x(): number;
-  set x(val: number): void;
+  set x(val: number);
 }
 ```
 


### PR DESCRIPTION
The current example is wrong as tslint return a sintax error.
As per TS annotation: "A 'set' accessor cannot have a return type annotation.(1095)"