### PR TITLE
Fix broken youtube video link (By Tj VanToll)

### DIFF
--- a/packages/typescriptlang-org/src/templates/pages/index.tsx
+++ b/packages/typescriptlang-org/src/templates/pages/index.tsx
@@ -149,7 +149,7 @@ const Index: React.FC<Props> = (props) => {
                   </a>
                 </li>
                 <li className="video" data-img={withPrefix("/images/index/wrong-ts.jpg")}>
-                  <a href="https://www.youtube.com/watch?v=P-J9Eg7hJwE" target="_blank">
+                  <a href="https://www.youtube.com/watch?v=AQOEZVG2WY0" target="_blank">
                     <p>Why I Was Wrong About TypeScript<br /><span>By TJ VanToll</span></p>
                   </a>
                 </li>


### PR DESCRIPTION
Fixes the broken youtube link in this page, [https://www.typescriptlang.org/](https://www.typescriptlang.org/)
Last video in _Watch TypeScript in Action_ section.