### PR TITLE
Improve the LSP handling and make sure that the codeblocks dont scroll

### DIFF
--- a/packages/typescriptlang-org/src/templates/handbook-lsp-hover.ts
+++ b/packages/typescriptlang-org/src/templates/handbook-lsp-hover.ts
@@ -1,0 +1,47 @@
+const getAbsoluteElementPos = (element: HTMLElement) => {
+  const bodyRect = document.body.getBoundingClientRect()
+  const elemRect = element.getBoundingClientRect()
+  const top = elemRect.top - bodyRect.top
+  const left = elemRect.left - bodyRect.left
+  return {
+    top,
+    left,
+  }
+}
+
+// Hide it
+const resetHover = () => {
+  const globalPopover = document.getElementById("mouse-hover-info")!
+  globalPopover.style.display = "none"
+}
+
+/** Creates the main mouse over popup for LSP info */
+export const setupHandbookHovers = () => {
+  const twoslashes = document.querySelectorAll(
+    ".shiki.twoslash .code-container code"
+  )
+
+  // Gets triggered on the spans inside the codeblocks
+  const hover = event => {
+    const hovered = event.target as HTMLElement
+    if (!hovered.className.includes("lsp")) return resetHover()
+    if (!hovered.firstElementChild) return resetHover()
+
+    const message = hovered.firstElementChild.textContent
+    const position = getAbsoluteElementPos(hovered)
+
+    const globalPopover = document.getElementById("mouse-hover-info")!
+    globalPopover.textContent = message
+
+    const yOffset = 20
+
+    globalPopover.style.display = "block"
+    globalPopover.style.top = `${position.top + yOffset}px`
+    globalPopover.style.left = `${position.left}px`
+  }
+
+  twoslashes.forEach(codeblock => {
+    codeblock.addEventListener("mouseover", hover)
+    codeblock.addEventListener("mouseout", resetHover)
+  })
+}

--- a/packages/typescriptlang-org/src/templates/handbook.tsx
+++ b/packages/typescriptlang-org/src/templates/handbook.tsx
@@ -11,6 +11,7 @@ import slugger from "github-slugger"
 
 import "./handbook.scss"
 import "./markdown.scss"
+import { setupHandbookHovers } from "./handbook-lsp-hover"
 
 type Props = {
   pageContext: any
@@ -70,11 +71,15 @@ const HandbookTemplate: React.FC<Props> = (props) => {
 
     // Handles setting the scroll 
     window.addEventListener("scroll", updateSidebar, { passive: true, capture: true });
+    // Sets current selection
     updateSidebar()
+
+    setupHandbookHovers()
+
     return () => {
       window.removeEventListener("scroll", updateSidebar)
     }
-  })
+  }, [])
 
   const { previous, next } = props.pageContext
   if (!post.frontmatter) throw new Error(`No front-matter found for the file with props: ${props}`)
@@ -95,6 +100,7 @@ const HandbookTemplate: React.FC<Props> = (props) => {
 
             <div className="whitespace raised">
               <div className="markdown" dangerouslySetInnerHTML={{ __html: post.html! }} />
+              <div id="mouse-hover-info" className="hover-info" />
             </div>
 
             {showSidebar &&

--- a/packages/typescriptlang-org/src/templates/markdown.scss
+++ b/packages/typescriptlang-org/src/templates/markdown.scss
@@ -53,6 +53,7 @@ pre {
   border-left: 1px solid #999;
   border-bottom: 1px solid #999;
   width: calc(100% - 40px);
+  line-height: 20px;
 
   overflow: auto;
   &.shiki {
@@ -135,27 +136,24 @@ pre:hover .lsp {
 }
 
 .lsp {
-  position: relative;
-  border-bottom: 1px dotted black; /* If you want dots under the hoverable text */
+  box-sizing: border-box;
+  border-bottom: 1px dotted rgb(116, 116, 116); /* If you want dots under the hoverable text */
 }
 
-.lsp .lsp-result {
+.lsp-result {
   display: none;
-  position: absolute;
+}
+
+.hover-info {
   background-color: #555;
   color: #fff;
   text-align: left;
   padding: 5px 2px;
   border-radius: 2px;
-  z-index: 1;
-  opacity: 0;
-  transition: opacity 0.15s;
-  margin-left: 4px;
-  left: calc(100% + 2px);
-  top: -33%;
+  font-family: Menlo, Monaco, Consolas, Courier New, monospace;
 }
 
-.lsp:hover .lsp-result {
-  display: block;
-  opacity: 1;
+#mouse-hover-info {
+  position: absolute;
+  z-index: 1;
 }


### PR DESCRIPTION
when an LSP response is on the last page, fixes #193

![Screen Shot 2020-03-21 at 1 53 33 PM](https://user-images.githubusercontent.com/49038/77233060-5f2aa080-6b7b-11ea-8c75-64ef9d803125.png)
