### PR TITLE
Add replacement from relative links to permanent links in handbook-v1

### DIFF
--- a/packages/typescriptlang-org/lib/bootup/ingestion/createPagesForOldHandbook.ts
+++ b/packages/typescriptlang-org/lib/bootup/ingestion/createPagesForOldHandbook.ts
@@ -37,9 +37,9 @@ export const createOldHandbookPages = async (
   const anyData = result.data as any
   const docs = anyData.allFile.nodes
 
-  // create a map(mdToSlug) to replace markdown links to slugs.
+  // create a map(mdToSlug) to replace markdown links to permalinks.
   // E.g. mdToSlug: {foo.md: '/docs/bar/foo.html', ...}
-  const mdToSlug = docs.reduce((result: { ["mdName"]: string }, next: any) => {
+  const mdToSlug: { [mdName: string]: string } = docs.reduce((result, next) => {
     return next.childMarkdownRemark ? {
       ...result,
       [encodeURI(next.name)+".md"]: // encodeURI in case name contains space. ' ' -> '%20'
@@ -55,7 +55,7 @@ export const createOldHandbookPages = async (
 
     if (post.childMarkdownRemark) {
 
-      const html = (() => { // html string whose markdown links are replaced to slugs.
+      const html = (() => { // html string whose markdown links are replaced to permalinks.
         const document = parser.parseFromString(post.childMarkdownRemark.html, "text/html")
         document.querySelectorAll("a").forEach(a => {
           const link = a.getAttribute("href") || ""

--- a/packages/typescriptlang-org/src/templates/handbook.tsx
+++ b/packages/typescriptlang-org/src/templates/handbook.tsx
@@ -81,7 +81,7 @@ const HandbookTemplate: React.FC<Props> = (props) => {
     }
   }, [])
 
-  const { previous, next } = props.pageContext
+  const { previous, next, html } = props.pageContext
   if (!post.frontmatter) throw new Error(`No front-matter found for the file with props: ${props}`)
   if (!post.html) throw new Error(`No html found for the file with props: ${props}`)
 
@@ -99,7 +99,7 @@ const HandbookTemplate: React.FC<Props> = (props) => {
           <article>
 
             <div className="whitespace raised">
-              <div className="markdown" dangerouslySetInnerHTML={{ __html: post.html! }} />
+              <div className="markdown" dangerouslySetInnerHTML={{ __html: html }} />
               <div id="mouse-hover-info" className="hover-info" />
             </div>
 


### PR DESCRIPTION
Hi,

Currently, relative links (see below)  in handbook-v1 are broken because relative links in markdown are not converted to slugs.
So I added replacement of links to `createOldHandbookPages` and let `handbook.tsx` to use the patched html string.

The broken links are following:
``` 
# grep -oE "\[.*\]\(.*\.md.*\)" packages/handbook-v1/en/ -r | grep -v -E "https?://" > mdlinks.list
packages/handbook-v1/en/declaration files/Library Structures.md:[`global-modifying-module.d.ts`](./templates/global-modifying-module.d.ts.md)
packages/handbook-v1/en/declaration files/Templates.md:[global-modifying-module.d.ts](./templates/global-modifying-module.d.ts.md)
packages/handbook-v1/en/declaration files/Introduction.md:[Consumption](./Consumption.md)
packages/handbook-v1/en/declaration files/Do's and Don'ts.md:[added in TypeScript 2.2](../release%20notes/TypeScript%202.2.md#object-type))
packages/handbook-v1/en/release notes/TypeScript 3.0.md:[Project References handbook page](../Project%20References.md)
packages/handbook-v1/en/Iterators and Generators.md:[`Symbol.iterator`](Symbols.md#symboliterator)
packages/handbook-v1/en/tutorials/React.md:[React & Webpack walkthrough here](./React%20&%20Webpack.md)
packages/handbook-v1/en/tutorials/Migrating from JavaScript.md:[using Gulp](./Gulp.md)
packages/handbook-v1/en/tutorials/Migrating from JavaScript.md:[tutorial on React and Webpack](./React%20&%20Webpack.md)
packages/handbook-v1/en/Modules.md:[Namespaces and Modules](./Namespaces%20and%20Modules.md)
packages/handbook-v1/en/Variable Declarations.md:[As we mentioned earlier](./Basic%20Types.md#a-note-about-let)
packages/handbook-v1/en/Namespaces and Modules.md:[it's possible](./release%20notes/TypeScript%201.8.md#concatenate-amd-and-system-modules-with---outfile)
```

[This](https://github.com/microsoft/TypeScript-Website/files/4385017/build.log) is a log file of build when I tested. I hope it helps review.

