### PR TITLE
Add missing colours to jsx code blocks

### DIFF
--- a/packages/handbook-v1/en/JSX.md
+++ b/packages/handbook-v1/en/JSX.md
@@ -292,7 +292,7 @@ Additionally, the `JSX.IntrinsicAttributes` interface can be used to specify ext
 
 The spread operator also works:
 
-```JSX
+```ts
 var props = { requiredProp: "bar" };
 <foo {...props} />; // ok
 
@@ -378,7 +378,7 @@ It is a black box.
 
 JSX allows you to embed expressions between tags by surrounding the expressions with curly braces (`{ }`).
 
-```JSX
+```ts
 var a = <div>
   {["foo", "bar"].map(i => <span>{i / 2}</span>)}
 </div>
@@ -387,7 +387,7 @@ var a = <div>
 The above code will result in an error since you cannot divide a string by a number.
 The output, when using the `preserve` option, looks like:
 
-```JSX
+```ts
 var a = <div>
   {["foo", "bar"].map(function (i) { return <span>{i / 2}</span>; })}
 </div>


### PR DESCRIPTION
Changed the markdown language on JSX code blocks.
In reference to the following ticket: https://github.com/microsoft/TypeScript-Website/issues/396

**Before**
<img width="1331" alt="Screenshot 2020-03-29 at 12 55 01" src="https://user-images.githubusercontent.com/22731314/77860143-5ad93580-71c2-11ea-99a8-962080d2dd3b.png">
<img width="1337" alt="Screenshot 2020-03-29 at 12 55 28" src="https://user-images.githubusercontent.com/22731314/77860093-1a79b780-71c2-11ea-94b5-9817a8bb6047.png">

**After**
<img width="1340" alt="Screenshot 2020-03-29 at 13 00 34" src="https://user-images.githubusercontent.com/22731314/77860103-26657980-71c2-11ea-8b95-7aa0a9ab4109.png">
<img width="1338" alt="Screenshot 2020-03-29 at 13 00 51" src="https://user-images.githubusercontent.com/22731314/77860108-2d8c8780-71c2-11ea-8e4e-369150fd355a.png">

This is my first time contributing, if I've got the wrong end of the stick please let me know!

