### PR TITLE
Fix next button chevron in Safari

### DIFF
--- a/packages/typescriptlang-org/src/templates/pages/index.scss
+++ b/packages/typescriptlang-org/src/templates/pages/index.scss
@@ -370,6 +370,7 @@
       display: flex;
       flex-direction: row;
       justify-content: center;
+      align-items: center;
 
       p {
         margin-left: 20px;


### PR DESCRIPTION
| Before | After |
|--------|------|
| <img width="381" alt="Screen Shot 2020-03-30 at 2 40 52 PM" src="https://user-images.githubusercontent.com/3277153/77964755-79a7fc80-7294-11ea-827b-55b83107f179.png"> | <img width="369" alt="Screen Shot 2020-03-30 at 2 40 46 PM" src="https://user-images.githubusercontent.com/3277153/77964766-7e6cb080-7294-11ea-961a-28773cde857c.png"> |