### PR TITLE
Fix nav scrolling with page

### DIFF
--- a/packages/typescriptlang-org/src/templates/handbook.scss
+++ b/packages/typescriptlang-org/src/templates/handbook.scss
@@ -8,7 +8,6 @@
 #handbook-content {
   margin-left: 2rem;
   margin-right: 2rem;
-  overflow: hidden;
 
   @media (max-width: $screen-xs) {
     margin-left: 0;


### PR DESCRIPTION
Fixes the `#handbook-content` lack of stickiness when scrolling down the page in reference to https://github.com/microsoft/TypeScript-Website/issues/336

| **Before**  | **After** |
| ------------- | ------------- |
| ![336 before](https://user-images.githubusercontent.com/22731314/78041183-41043380-7325-11ea-9a3b-a8e28ee2ed18.gif)  | ![336 after](https://user-images.githubusercontent.com/22731314/78041285-5711f400-7325-11ea-8733-8c66bec72e6c.gif)  |

I noticed that the links don't highlight the correct section when clicked on, should I raise a separate issue for that?

