### PR TITLE
Fix permalink icon colour in dark mode

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/main.scss
+++ b/packages/typescriptlang-org/src/components/layout/main.scss
@@ -73,12 +73,13 @@ html {
 }
 
 // Style the permalink icon in dark colour-scheme
-.raised svg path {
+.raised .markdown h1 svg path,
+.raised .markdown h2 svg path,
+.raised .markdown h3 svg path {
   @media (prefers-color-scheme: dark) {
     fill: white;
   }
 }
-
 .main-content-block {
   max-width: 960px;
   margin: 1rem auto;

--- a/packages/typescriptlang-org/src/components/layout/main.scss
+++ b/packages/typescriptlang-org/src/components/layout/main.scss
@@ -72,6 +72,13 @@ html {
   }
 }
 
+// Style the permalink icon in dark colour-scheme
+.raised svg path {
+  @media (prefers-color-scheme: dark) {
+    fill: white;
+  }
+}
+
 .main-content-block {
   max-width: 960px;
   margin: 1rem auto;


### PR DESCRIPTION
Changed the colour of permalink icon in dark mode from black to white.

**Before**:
![image](https://user-images.githubusercontent.com/12188873/78461150-3b6f6a80-76e4-11ea-9539-a575d5899f44.png)
**After**:
![image](https://user-images.githubusercontent.com/12188873/78461152-41fde200-76e4-11ea-8ce7-b3ab049546c5.png)
