### PR TITLE
Adds Ember as additional web framework

### DIFF
--- a/packages/sandbox/src/releases.ts
+++ b/packages/sandbox/src/releases.ts
@@ -11,7 +11,7 @@ export const supportedReleases = [
   "3.0.1",
   "2.8.1",
   "2.7.2",
-  "2.4.1"
+  "2.4.1",
 ] as const;
 
 export type ReleaseVersions =

--- a/packages/typescriptlang-org/src/copy/en/documentation.ts
+++ b/packages/typescriptlang-org/src/copy/en/documentation.ts
@@ -24,6 +24,7 @@ export const docCopy = {
   doc_frameworks: "Web Frameworks",
   doc_frameworks_angular_blurb:
     "Makes writing beautiful apps be joyful and fun",
+  doc_frameworks_ember_blurb: "A framework for ambitious web developers",
   doc_frameworks_react_blurb:
     "A JavaScript library for building user interfaces",
   doc_frameworks_vue_blurb: "The Progressive JavaScript Framework",

--- a/packages/typescriptlang-org/src/copy/zh/documentation.ts
+++ b/packages/typescriptlang-org/src/copy/zh/documentation.ts
@@ -21,6 +21,7 @@ export const docCopy = {
     "一个令人愉悦的工具，用于构建由 TypeScript 驱动的命令行应用程序。",
   doc_frameworks: "Web 框架",
   doc_frameworks_angular_blurb: "让编写优雅的程序充满乐趣",
+  doc_frameworks_ember_blurb: "雄心勃勃的Web开发人员的框架",
   doc_frameworks_react_blurb: "一个用于构建用户界面的 JavaScript 库",
   doc_frameworks_vue_blurb: "渐进式 JavaScript 框架",
   doc_frameworks_ror_blurb: "约定优于配置的 Web 框架",

--- a/packages/typescriptlang-org/src/lib/release-info.json
+++ b/packages/typescriptlang-org/src/lib/release-info.json
@@ -3,15 +3,15 @@
   "tags": {
     "stableMajMin": "3.8",
     "stable": "3.8.3",
-    "betaMajMin": "3.8",
-    "beta": "3.8.0-beta",
+    "betaMajMin": "3.9",
+    "beta": "3.9.0-beta",
     "rc": "3.8.1-rc",
     "rcMajMin": "3.8"
   },
   "isRC": false,
-  "isBeta": false,
+  "isBeta": true,
   "releaseNotesURL": "/docs/handbook/release-notes/typescript-3-8.html",
-  "betaPostURL": "https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/",
+  "betaPostURL": "https://devblogs.microsoft.com/typescript/announcing-typescript-3-9-beta/",
   "rcPostURL": "https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-rc/",
   "vs": {
     "stable": {
@@ -19,8 +19,8 @@
       "vs2019_download": "https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.typescript-38beta"
     },
     "beta": {
-      "vs2017_download": "https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.typescript-38beta",
-      "vs2019_download": "https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.typescript-38beta"
+      "vs2017_download": "https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.typescript-373",
+      "vs2019_download": "https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.typescript-373"
     },
     "rc": {
       "vs2017_download": "https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.typescript-38beta",

--- a/packages/typescriptlang-org/src/templates/pages/docs/home.tsx
+++ b/packages/typescriptlang-org/src/templates/pages/docs/home.tsx
@@ -86,6 +86,11 @@ const Index: React.FC<Props> = (props) => {
               title: "Angular",
             },
             {
+              href: "https://emberjs.com",
+              blurb: i("doc_frameworks_ember_blurb"),
+              title: "Ember",
+            },
+            {
               href: "https://reactjs.org",
               badge: "Examples below",
               blurb: i("doc_frameworks_react_blurb"),

--- a/packages/typescriptlang-org/src/templates/pages/docs/home.tsx
+++ b/packages/typescriptlang-org/src/templates/pages/docs/home.tsx
@@ -86,7 +86,7 @@ const Index: React.FC<Props> = (props) => {
               title: "Angular",
             },
             {
-              href: "https://emberjs.com",
+              href: "https://ember-cli-typescript.com",
               blurb: i("doc_frameworks_ember_blurb"),
               title: "Ember",
             },
@@ -274,7 +274,6 @@ const Index: React.FC<Props> = (props) => {
     </Layout>
   )
 }
-
 
 export const query = graphql`
   query DocsHome {


### PR DESCRIPTION
This PR adds Ember as an additional Web Framework in the `https://www.typescriptlang.org/docs/home` page. Ember both uses TS internally for large portions of its development (ember.js, glimmer-vm, etc), but also supports TypeScript for development. Ember also recently went through a huge modernization, which both simplifies the framework _and_ takes advantage of a lot of newer language features.

<img width="1311" alt="Screen Shot 2020-04-04 at 2 14 14 PM" src="https://user-images.githubusercontent.com/180990/78461749-88215a00-7680-11ea-86e8-8ddd6c247907.png">

These changes add Ember in alphabetical order relative to the other JS frameworks (Angular, React, Vue). Additionally ensures that the blurb is translated.