### PR TITLE
fix(handbook-v1): mistake in code example block

### DIFF
--- a/packages/handbook-v1/en/Interfaces.md
+++ b/packages/handbook-v1/en/Interfaces.md
@@ -380,11 +380,11 @@ That means that indexing with `100` (a `number`) is the same thing as indexing w
 ```ts twoslash
 // @errors: 2413
 // @strictPropertyInitialization: false
-class Animal {
+interface Animal {
   name: string;
 }
 
-class Dog extends Animal {
+interface Dog extends Animal {
   breed: string;
 }
 


### PR DESCRIPTION
<!--
  Before we get started, you can fix these!
  Reports are appreciated too though.
-->

<!-- Issue Report -->

**Page URL:** https://www.typescriptlang.org/v2/docs/handbook/interfaces.html#indexable-types

**Issue:** Mistake in code example block. `class` declaration was used, instead of `interface`.
```ts
// not class but interface
class Animal {
  name: string;
}

// not class but interface
class Dog extends Animal {
  breed: string;
}

// Error: indexing with a numeric string might get you a completely separate type of Animal!
interface NotOkay {
  [x: number]: Animal;
  [x: string]: Dog;
}
``` 

**Recommended Fix:**
```ts
interface Animal {
  name: string;
}

// not class but interface
interface Dog extends Animal {
  breed: string;
}

// Error: indexing with a numeric string might get you a completely separate type of Animal!
interface NotOkay {
  [x: number]: Animal;
  [x: string]: Dog;
}
```