### PR TITLE
Remove repeated word from handbook-v1 / The Handbook.md page

### DIFF
--- a/packages/handbook-v1/en/The Handbook.md
+++ b/packages/handbook-v1/en/The Handbook.md
@@ -45,7 +45,7 @@ Specifically, the Handbook does not fully introduce core JavaScript basics like 
 
 The Handbook also isn't intended to be a replacement for a language specification. In some cases, edge cases or formal descriptions of behavior will be skipped in favor of high-level, easier-to-understand explanations. Instead, there are separate reference pages that more precisely and formally describe many aspects of TypeScript's behavior. The reference pages are not intended for readers unfamiliar with TypeScript, so they may use advanced terminology or reference topics you haven't read about yet.
 
-Finally, the Handbook won't cover how TypeScript interacts with other tools, except where necessary. Topics like how to configure TypeScript with webpack, rollup, parcel, react, babel, closure, lerna, rush, bazel, preact, vue, angular, svelte, jquery, rush, yarn, or npm are out of scope - you can find these resources elsewhere on the web.
+Finally, the Handbook won't cover how TypeScript interacts with other tools, except where necessary. Topics like how to configure TypeScript with webpack, rollup, parcel, react, babel, closure, lerna, rush, bazel, preact, vue, angular, svelte, jquery, yarn, or npm are out of scope - you can find these resources elsewhere on the web.
 
 ## Get Started
 


### PR DESCRIPTION
The word `rush` appears twice in the same sentence, but it looks redundant.