### PR TITLE
Make the error pane jut out less

### DIFF
--- a/packages/typescriptlang-org/src/templates/markdown-twoslash.scss
+++ b/packages/typescriptlang-org/src/templates/markdown-twoslash.scss
@@ -68,7 +68,7 @@ pre {
   /* This section keeps both of those in sync  */
   .error,
   .error-behind {
-    margin-left: -20px;
+    margin-left: -14px;
     margin-top: 8px;
     margin-bottom: 4px;
     padding: 6px;
@@ -82,7 +82,6 @@ pre {
     position: absolute;
     background-color: #ffeeee;
     border-left: 2px solid #bf1818;
-    width: calc(100% - 14px);
 
     /* Give the space to the error code  */
     display: flex;


### PR DESCRIPTION
**Warning: This was a very naive change**

Personally I prefer the more subtle outline

Before

![image](https://user-images.githubusercontent.com/972891/79106015-8e6da100-7d26-11ea-9dae-e96092821312.png)

After

![image](https://user-images.githubusercontent.com/972891/79105954-76961d00-7d26-11ea-9478-377db09e84a0.png)
