### PR TITLE
Update 3.9 release dates

### DIFF
--- a/packages/typescriptlang-org/src/lib/release-plan.json
+++ b/packages/typescriptlang-org/src/lib/release-plan.json
@@ -3,7 +3,7 @@
   "upcoming_version": "3.9",
   "iteration_plan_url": "https://github.com/microsoft/TypeScript/issues/37198",
   "last_release_date": "02/20/2020",
-  "upcoming_beta_date": "03/20/2020",
-  "upcoming_rc_date": "04/24/2020",
+  "upcoming_beta_date": "03/24/2020",
+  "upcoming_rc_date": "04/28/2020",
   "upcoming_release_date": "05/12/2020"
 }


### PR DESCRIPTION
Old dates were the build dates, not the release dates https://github.com/microsoft/TypeScript/issues/37198