### PR TITLE
[v2] Point the link for Ruby on Rails to the official rails/webpacker repo

### DIFF
--- a/packages/typescriptlang-org/src/templates/pages/docs/home.tsx
+++ b/packages/typescriptlang-org/src/templates/pages/docs/home.tsx
@@ -102,7 +102,7 @@ const Index: React.FC<Props> = (props) => {
               title: "Vue",
             },
             {
-              href: "https://github.com/typescript-ruby/typescript-rails",
+              href: "https://github.com/rails/webpacker/blob/master/docs/typescript.md",
               badge: "Plugin",
               blurb: i("doc_frameworks_ror_blurb"),
               title: "Ruby on Rails",


### PR DESCRIPTION
The repo https://github.com/typescript-ruby/typescript-rails doesn't seem to be very active these days, and Rail's official JS integration has evolved in the mean time. I think it's time to switch to [Rails official TS guide](https://github.com/rails/webpacker/blob/master/docs/typescript.md).