### PR TITLE
[v1] Point the link for Ruby on Rails to the official rails/webpacker repo

### DIFF
--- a/src/_docs/home.html
+++ b/src/_docs/home.html
@@ -110,7 +110,7 @@ templates which include TypeScript support.
     <h4>Vue</h4>
   </a>
 
-  <a href="https://github.com/typescript-ruby/typescript-rails" class="clicky-button">
+  <a href="https://github.com/rails/webpacker/blob/master/docs/typescript.md" class="clicky-button">
     <div class="badge">Plugin</div>
     <p>Convention over configuration web framework</p>
     <h4>Ruby on Rails</h4>


### PR DESCRIPTION
Basically the same change as https://github.com/microsoft/TypeScript-Website/pull/532 but for the current master.

The repo https://github.com/typescript-ruby/typescript-rails doesn't seem to be very active these days, and Rail's official JS integration has evolved in the mean time. I think it's time to switch to [Rails official TS guide](https://github.com/rails/webpacker/blob/master/docs/typescript.md).