### PR TITLE
Fix plugins being default - fixes #536

### DIFF
--- a/packages/playground/src/sidebar/plugins.ts
+++ b/packages/playground/src/sidebar/plugins.ts
@@ -46,7 +46,7 @@ export const optionsPlugin: PluginFactory = (i, utils) => {
   const plugin: PlaygroundPlugin = {
     id: "plugins",
     displayName: i("play_sidebar_plugins"),
-    shouldBeSelected: () => true, // uncomment to make this the first tab on reloads
+    // shouldBeSelected: () => true, // uncomment to make this the first tab on reloads
     willMount: (_sandbox, container) => {
       const ds = utils.createDesignSystem(container)
 


### PR DESCRIPTION
If it happens again I'll make a danger rule that no shipped playground plugins claim default focus by default.