### PR TITLE
Correct point example

### DIFF
--- a/packages/handbook-v1/en/tutorials/Migrating from JavaScript.md
+++ b/packages/handbook-v1/en/tutorials/Migrating from JavaScript.md
@@ -423,9 +423,9 @@ class Point {
 
 // Reopen the interface.
 interface Point {
-  distanceFromOrigin(point: Point): number;
+  distanceFromOrigin(): number;
 }
-Point.prototype.distanceFromOrigin = function(point: Point) {
+Point.prototype.distanceFromOrigin = function() {
   return this.getDistance({ x: 0, y: 0 });
 };
 ```
@@ -436,7 +436,7 @@ When that option is set, TypeScript will issue an error when `this` is used with
 The fix is to use a `this`-parameter to give an explicit type in the interface or in the function itself:
 
 ```ts
-Point.prototype.distanceFromOrigin = function(this: Point, point: Point) {
+Point.prototype.distanceFromOrigin = function(this: Point) {
   return this.getDistance({ x: 0, y: 0 });
 };
 ```


### PR DESCRIPTION
Replacement for https://github.com/microsoft/TypeScript-Handbook/pull/1315

```ts
interface Point {
    distanceFromOrigin(point: Point): number;
}
Point.prototype.distanceFromOrigin = function(point: Point) {
    return this.getDistance({ x: 0, y: 0});
}
```
```ts
Point.prototype.distanceFromOrigin = function(this: Point) {
    return this.getDistance({ x: 0, y: 0});
}
```

Trying to make sense of what the `point: Point` is supposed to be doing. It looks like it's an argument for the function, but the function doesn't use it. I suspect it's a typo, but would love to know for sure.

This PR removes it, under the assumption that it is a typo.