### PR TITLE
fix tsconfig include path

### DIFF
--- a/packages/tsconfig-reference/copy/ja/options/include.md
+++ b/packages/tsconfig-reference/copy/ja/options/include.md
@@ -8,7 +8,7 @@ oneline: "Files or patterns to include in this project"
 
 ```json
 {
-  "include": ["src/**", "tests/**"]
+  "include": ["src/**/*", "tests/**/*"]
 }
 ```
 


### PR DESCRIPTION
This does not work.
![スクリーンショット 2020-05-07 1 21 03](https://user-images.githubusercontent.com/15010907/81206578-48df8380-9007-11ea-9033-513e1d26a16d.png)


Deviation from the English version.
https://github.com/microsoft/TypeScript-Website/blob/v2/packages/tsconfig-reference/copy/en/options/include.md