### PR TITLE
Replace broken link to SystemJS@baseUrl

### DIFF
--- a/packages/handbook-v1/en/Module Resolution.md
+++ b/packages/handbook-v1/en/Module Resolution.md
@@ -209,7 +209,7 @@ Value of _baseUrl_ is determined as either:
 
 Note that relative module imports are not impacted by setting the baseUrl, as they are always resolved relative to their importing files.
 
-You can find more documentation on baseUrl in [RequireJS](http://requirejs.org/docs/api.html#config-baseUrl) and [SystemJS](https://github.com/systemjs/systemjs/blob/master/docs/config-api.md#baseurl) documentation.
+You can find more documentation on baseUrl in [RequireJS](http://requirejs.org/docs/api.html#config-baseUrl) and [SystemJS](https://github.com/systemjs/systemjs/blob/master/docs/api.md#baseurl) documentation.
 
 ### Path mapping
 


### PR DESCRIPTION
I [can no longer find any documentation about `baseUrl`](https://github.com/systemjs/systemjs/search?q=baseurl&unscoped_q=baseurl).