### PR TITLE
Switch button colors to blue.

### DIFF
--- a/packages/typescriptlang-org/src/templates/pages/index.scss
+++ b/packages/typescriptlang-org/src/templates/pages/index.scss
@@ -406,8 +406,8 @@
       width: 12rem;
       height: 1.4rem;
       line-height: 1.4rem;
-      background-color: white;
-      color: black;
+      background-color: #187abf;
+      color: #fff;
       text-align: center;
       padding: 1rem 0.5rem;
       text-decoration: none;


### PR DESCRIPTION
**Don't merge**: realized that the hover colors have to be fixed.

The second half of the screen on a page load is a bar of grey followed by white. I feel like (especially in light mode) this can feel very bland. I think we at least need an accent color here.

Before:

![image](https://user-images.githubusercontent.com/972891/81483736-3dea4600-91f5-11ea-94d7-8ec06dd3b9d8.png)

After:

![image](https://user-images.githubusercontent.com/972891/81483744-52c6d980-91f5-11ea-9569-3b34f137fcea.png)
