### PR TITLE
Fix wrong link

### DIFF
--- a/packages/typescriptlang-org/src/lib/oldHandbookNavigation.ts
+++ b/packages/typescriptlang-org/src/lib/oldHandbookNavigation.ts
@@ -146,7 +146,8 @@ export const oldHandbookNavigation: NavItem[] = [
       { id: "library-structures", title: "Library Structures" },
       {
         id: "global-plugin-d-ts",
-        href: "handbook/declaration-files/templates/global-plugin-d-ts.html",
+        href:
+          "/docs/handbook/declaration-files/templates/global-plugin-d-ts.html",
         title: "Template: Global Module",
       },
       {


### PR DESCRIPTION
I added `/docs/` to the href of `Template: Global Module`.

Clicking on `Template: Global Module` in the document does not jump to the corresponding page. 
After searching, it is found that the corresponding link in the source code is missing `/docs/`