### PR TITLE
Fix undefined class if className is undefined

### DIFF
--- a/packages/typescriptlang-org/src/templates/pages/index.tsx
+++ b/packages/typescriptlang-org/src/templates/pages/index.tsx
@@ -19,7 +19,7 @@ import { createIntlLink } from "../../components/IntlLink"
 import { IndexPageQuery } from "../../__generated__/gatsby-types"
 
 const Section = (props: { children: any, color: string, className?: string }) =>
-  <div key={props.color} className={props.color + " " + props.className ?? ""}><div className="container">{props.children}</div></div>
+  <div key={props.color} className={props.color + " " + (props.className ?? "")}><div className="container">{props.children}</div></div>
 
 const QuarterOrHalfRow = (props: { children: any, className?: string }) => <div className={[props.className, "split-row"].join(" ")}>{props.children}</div>
 const Row = (props: { children: any, className?: string }) => <div className={[props.className, "row"].join(" ")}>{props.children}</div>


### PR DESCRIPTION
Section will get 'undefined' class if no className is provided as property

![Anmerkung 2020-05-11 102637](https://user-images.githubusercontent.com/8657779/81540459-fd640700-9371-11ea-9031-4a8c9778c9b1.png)

This commit fixes the issue