### PR TITLE
Remove Location and clarify ImageControl error

### DIFF
--- a/packages/handbook-v1/en/Interfaces.md
+++ b/packages/handbook-v1/en/Interfaces.md
@@ -652,13 +652,10 @@ class TextBox extends Control {
   select() {}
 }
 
-// Error: Property 'state' is missing in type 'Image'.
 class ImageControl implements SelectableControl {
   private state: any;
   select() {}
 }
-
-class Location {}
 ```
 
 In the above example, `SelectableControl` contains all of the members of `Control`, including the private `state` property.
@@ -667,4 +664,4 @@ This is because only descendants of `Control` will have a `state` private member
 
 Within the `Control` class it is possible to access the `state` private member through an instance of `SelectableControl`.
 Effectively, a `SelectableControl` acts like a `Control` that is known to have a `select` method.
-The `Button` and `TextBox` classes are subtypes of `SelectableControl` (because they both inherit from `Control` and have a `select` method), but the `Image` and `Location` classes are not.
+The `Button` and `TextBox` classes are subtypes of `SelectableControl` (because they both inherit from `Control` and have a `select` method). The `ImageControl` class has it's own `state` private member rather than extending `Control`, so it cannot implement `SelectableControl`.


### PR DESCRIPTION
There seem to a few issues with this code, comments, and descriptions. I took a stab at fixing them. (But I'm brand new to TypeScript, so I might be interpreting it incorrectly).

The Location class doesn't seem to have anything to do with the rest of the example code, and it also throws an unrelated error "Duplicate identifier 'Location'.", which is confusing.

The comment on line 655 also seems incorrect - it seems vestigial from some previous iteration of code. The actual error shown is: "Class 'ImageControl' incorrectly implements interface 'SelectableControl'.  Types have separate declarations of a private property 'state'."