### PR TITLE
Add the missing closing brace in JSDoc Example

### DIFF
--- a/packages/playground-examples/copy/en/JavaScript/Modern JavaScript/JSDoc Support.js
+++ b/packages/playground-examples/copy/en/JavaScript/Modern JavaScript/JSDoc Support.js
@@ -61,7 +61,7 @@ const user = {};
 /** @type {{ owner: User, name: string }} */
 const resource;
 
-/** @typedef {{owner: User, name: string} Resource */
+/** @typedef {{owner: User, name: string}} Resource */
 
 /** @type {Resource} */
 const otherResource;


### PR DESCRIPTION
Hello,

I think there's a missing closing brace in the JSDoc Support code example.

```js
/** @typedef {{owner: User, name: string} Resource */
```

I fixed it by adding the brace.
```js
/** @typedef {{owner: User, name: string}} Resource */
```

