### PR TITLE
Adds a section recommending against the usage of `any`.

### DIFF
--- a/packages/handbook-v1/en/declaration files/Do's and Don'ts.md
+++ b/packages/handbook-v1/en/declaration files/Do's and Don'ts.md
@@ -35,7 +35,7 @@ See more details in [TypeScript FAQ page](https://github.com/Microsoft/TypeScrip
 
 _Don't_ use `any` as a type unless you are in the process of migrating a JavaScript project to TypeScript.  The compiler _effectively_ treats `any` as "please turn off type checking for this thing".  It is similar to putting an `@ts-ignore` comment around every usage of the variable.  This can be very helpful when you are first migrating a JavaScript project to TypeScript as you can set the type for stuff you haven't migrated yet as `any`, but in a full TypeScript project you are disabling type checking for any parts of your program that use it.
 
-In cases where you don't know what type you want to accept, or when you want to accept anything because you will be blindly passing it through without interacting with it, you can use [`unknown`](https://www.typescriptlang.org/play/index.html?e=136#example/unknown-and-never).
+In cases where you don't know what type you want to accept, or when you want to accept anything because you will be blindly passing it through without interacting with it, you can use [`unknown`](/play/index.html?e=136#example/unknown-and-never).
 
 <!-- TODO: More -->
 

--- a/packages/handbook-v1/en/declaration files/Do's and Don'ts.md
+++ b/packages/handbook-v1/en/declaration files/Do's and Don'ts.md
@@ -35,7 +35,7 @@ See more details in [TypeScript FAQ page](https://github.com/Microsoft/TypeScrip
 
 _Don't_ use `any` as a type unless you are in the process of migrating a JavaScript project to TypeScript.  The compiler _effectively_ treats `any` as "please turn off type checking for this thing".  It is similar to putting an `@ts-ignore` comment around every usage of the variable.  This can be very helpful when you are first migrating a JavaScript project to TypeScript as you can set the type for stuff you haven't migrated yet as `any`, but in a full TypeScript project you are disabling type checking for any parts of your program that use it.
 
-In cases where you don't know what type you want to accept, or when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`.
+In cases where you don't know what type you want to accept, or when you want to accept anything because you will be blindly passing it through without interacting with it, you can use [`unknown`](https://www.typescriptlang.org/play/index.html?e=136#example/unknown-and-never).
 
 <!-- TODO: More -->
 

--- a/packages/handbook-v1/en/declaration files/Do's and Don'ts.md
+++ b/packages/handbook-v1/en/declaration files/Do's and Don'ts.md
@@ -31,6 +31,12 @@ Instead of `Object`, use the non-primitive `object` type ([added in TypeScript 2
 _Don't_ ever have a generic type which doesn't use its type parameter.
 See more details in [TypeScript FAQ page](https://github.com/Microsoft/TypeScript/wiki/FAQ#why-doesnt-type-inference-work-on-this-interface-interface-foot---).
 
+## any
+
+_Don't_ use `any` as a type unless you are in the process of migrating a JavaScript project to TypeScript.  The compiler _effectively_ treats `any` as "please turn off type checking for this thing".  It is similar to putting an `@ts-ignore` comment around every usage of the variable.  This can be very helpful when you are first migrating a JavaScript project to TypeScript as you can set the type for stuff you haven't migrated yet as `any`, but in a full TypeScript project you are disabling type checking for any parts of your program that use it.
+
+In cases where you don't know what type you want to accept, or when you want to accept anything because you will be blindly passing it through without interacting with it, you can use `unknown`.
+
 <!-- TODO: More -->
 
 # Callback Types


### PR DESCRIPTION
Feedback definitely welcome for this section.  I tried to give a brief, but not too long-winded, overview of why it is a problem and provide the most common workaround (`unknown`) but I'm sure this could be improved.