### PR TITLE
Update getLength function example to return length

### DIFF
--- a/packages/handbook-v1/en/tutorials/TS for JS Programmers.md
+++ b/packages/handbook-v1/en/tutorials/TS for JS Programmers.md
@@ -150,7 +150,7 @@ Unions provide a way to handle different types too, for example you may have a f
 
 ```ts twoslash
 function getLength(obj: string | string[]) {
-  return obj;
+  return obj.length;
 }
 ```
 


### PR DESCRIPTION
From the name of the 'getLength' function it looks like it was intended to return 'obj.length' and not just 'obj'.