### PR TITLE
Explain bigint type in handbook

### DIFF
--- a/packages/handbook-v1/en/Basic Types.md
+++ b/packages/handbook-v1/en/Basic Types.md
@@ -25,6 +25,7 @@ These floating point numbers get the type `number`, while BigIntegers get the ty
 In addition to hexadecimal and decimal literals, TypeScript also supports binary and octal literals introduced in ECMAScript 2015.
 
 ```ts twoslash
+// @target: ES2020
 let decimal: number = 6;
 let hex: number = 0xf00d;
 let binary: number = 0b1010;

--- a/packages/handbook-v1/en/Basic Types.md
+++ b/packages/handbook-v1/en/Basic Types.md
@@ -20,8 +20,8 @@ let isDone: boolean = false;
 
 # Number
 
-As in JavaScript, all numbers in TypeScript are floating point values.
-These floating point numbers get the type `number`.
+As in JavaScript, all numbers in TypeScript are either floating point values or BigIntegers.
+These floating point numbers get the type `number`, while BigIntegers get the type `bigint`.
 In addition to hexadecimal and decimal literals, TypeScript also supports binary and octal literals introduced in ECMAScript 2015.
 
 ```ts twoslash
@@ -29,6 +29,7 @@ let decimal: number = 6;
 let hex: number = 0xf00d;
 let binary: number = 0b1010;
 let octal: number = 0o744;
+let big: bigint = 100n;
 ```
 
 # String


### PR DESCRIPTION
[Since typescript 3.2](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-2.html), ts supports a number type called `bigint` but the handbook says that the only numeric type supported is `number`. This PR fixes that.