### PR TITLE
Remove extra prepended spaces in addPrices() example

### DIFF
--- a/packages/typescriptlang-org/src/components/index/EditorExamples.tsx
+++ b/packages/typescriptlang-org/src/components/index/EditorExamples.tsx
@@ -99,15 +99,15 @@ addPrices(3, 4, 6);
   `
 
   const ts = `
-  function addPrices(items<span class='highlight'>: number[]</span>) { 
-    let sum = 0;
-    for (const item of items) {
-      sum += item;
-    }
-    return sum;
- }
- 
- addPrices(<span class='underline-error'>3, 4, 6</span>);
+function addPrices(items<span class='highlight'>: number[]</span>) { 
+  let sum = 0;
+  for (const item of items) {
+    sum += item;
+  }
+  return sum;
+}
+
+addPrices(<span class='underline-error'>3, 4, 6</span>);
 `
 
   return (


### PR DESCRIPTION
There are some extra spaces in the TypeScript `addPrices()` example on the main TypeScript website.

Current:
![image](https://user-images.githubusercontent.com/25834218/82745011-953bfa80-9d4d-11ea-9190-1c8ac2f95ce0.png)

PR changes:
![image](https://user-images.githubusercontent.com/25834218/82745019-a6850700-9d4d-11ea-9c74-bcc96c689683.png)