### PR TITLE
Limit tooltip width in gatsby-remark-shiki-twoslash

### DIFF
--- a/packages/gatsby-remark-shiki-twoslash/src/dom.ts
+++ b/packages/gatsby-remark-shiki-twoslash/src/dom.ts
@@ -28,6 +28,14 @@ const findOrCreateTooltip = () => {
   return globalPopover
 }
 
+const getRootRect = (element: HTMLElement): DOMRect => {
+  if (element.nodeName.toLowerCase() === 'pre') {
+    return element.getBoundingClientRect();
+  }
+
+  return getRootRect(element.parentElement!);
+}
+
 /**
  * Creates the main mouse over popup for LSP info using the DOM API.
  * It is expected to be run inside a `useEffect` block inside your main
@@ -71,6 +79,11 @@ export const setupTwoslashHovers = () => {
     tooltip.style.display = 'block'
     tooltip.style.top = `${position.top + yOffset}px`
     tooltip.style.left = `${position.left}px`
+
+    // limit the width of the tooltip to the outer container (pre)
+    const rootRect = getRootRect(hovered);
+    const relativeLeft = position.left - rootRect.x;
+    tooltip.style.maxWidth = `${rootRect.width - relativeLeft}px`;
   }
 
   twoslashes.forEach((codeblock) => {


### PR DESCRIPTION
As promised, part 1 of https://twitter.com/orta/status/1262782512260136962

The implementation can definitely be optimized as we're executing `getBoundingClientRect` to the parent node every time even though it probably never changes. But it works for now and I didn't notice any performance issue.

**Before**
![Kapture 2020-05-25 at 14 22 58](https://user-images.githubusercontent.com/1614415/82788897-895a5080-9e93-11ea-9869-7b9beb005296.gif)

**After**
![Kapture 2020-05-25 at 14 20 59](https://user-images.githubusercontent.com/1614415/82788940-a2fb9800-9e93-11ea-8070-77f1b341b024.gif)
