### PR TITLE
Fix Typescript 3.9 handbook navigation link

### DIFF
--- a/packages/typescriptlang-org/src/lib/handbookNavigation.ts
+++ b/packages/typescriptlang-org/src/lib/handbookNavigation.ts
@@ -111,7 +111,7 @@ export const handbookNavigation: NavItem[] = [
       "Find out how TypeScript has evolved and what's new in the releases.",
     items: [
       { id: "overview", title: "Overview" },
-      { id: "typescript-3-8", title: "TypeScript 3.9" },
+      { id: "typescript-3-9", title: "TypeScript 3.9" },
       { id: "typescript-3-8", title: "TypeScript 3.8" },
       { id: "typescript-3-7", title: "TypeScript 3.7" },
       { id: "typescript-3-6", title: "TypeScript 3.6" },


### PR DESCRIPTION
Updates the `What's New > Typescript 3.9` link in the handbook navigation sidebar to point at the proper page.