### PR TITLE
Fix external links

### DIFF
--- a/packages/handbook-v1/en/Advanced Types.md
+++ b/packages/handbook-v1/en/Advanced Types.md
@@ -189,7 +189,7 @@ We mentioned these briefly in [the Basic Types section](docs/handbook/basic-type
 By default, the type checker considers `null` and `undefined` assignable to anything.
 Effectively, `null` and `undefined` are valid values of every type.
 That means it's not possible to _stop_ them from being assigned to any type, even when you would like to prevent it.
-The inventor of `null`, Tony Hoare, calls this his ["billion dollar mistake"](https://en.wikipedia.org/wiki/Null_pointer#History).
+The inventor of `null`, Tony Hoare, calls this his ["billion dollar mistake"](https://wikipedia.org/wiki/Null_pointer#History).
 
 The `--strictNullChecks` flag fixes this: when you declare a variable, it doesn't automatically include `null` or `undefined`.
 You can include them explicitly using a union type:
@@ -363,7 +363,7 @@ declare function interfaced(arg: Interface): Interface;
 
 In older versions of TypeScript, type aliases couldn't be extended or implemented from (nor could they extend/implement other types). As of version 2.7, type aliases can be extended by creating a new intersection type e.g. `type Cat = Animal & { purrs: true }`.
 
-Because [an ideal property of software is being open to extension](https://en.wikipedia.org/wiki/Open/closed_principle), you should always use an interface over a type alias if possible.
+Because [an ideal property of software is being open to extension](https://wikipedia.org/wiki/Open/closed_principle), you should always use an interface over a type alias if possible.
 
 On the other hand, if you can't express some shape with an interface and you need to use a union or tuple type, type aliases are usually the way to go.
 
@@ -819,7 +819,7 @@ type Partial<T> = { [P in keyof T]?: T[P] };
 
 In these examples, the properties list is `keyof T` and the resulting type is some variant of `T[P]`.
 This is a good template for any general use of mapped types.
-That's because this kind of transformation is [homomorphic](https://en.wikipedia.org/wiki/Homomorphism), which means that the mapping applies only to properties of `T` and no others.
+That's because this kind of transformation is [homomorphic](https://wikipedia.org/wiki/Homomorphism), which means that the mapping applies only to properties of `T` and no others.
 The compiler knows that it can copy all the existing property modifiers before adding any new ones.
 For example, if `Person.name` was readonly, `Partial<Person>.name` would be readonly and optional.
 

--- a/packages/handbook-v1/en/Decorators.md
+++ b/packages/handbook-v1/en/Decorators.md
@@ -84,7 +84,7 @@ Multiple decorators can be applied to a declaration, as in the following example
   x
   ```
 
-When multiple decorators apply to a single declaration, their evaluation is similar to [function composition in mathematics](http://en.wikipedia.org/wiki/Function_composition). In this model, when composing functions _f_ and _g_, the resulting composite (_f_ ∘ _g_)(_x_) is equivalent to _f_(_g_(_x_)).
+When multiple decorators apply to a single declaration, their evaluation is similar to [function composition in mathematics](http://wikipedia.org/wiki/Function_composition). In this model, when composing functions _f_ and _g_, the resulting composite (_f_ ∘ _g_)(_x_) is equivalent to _f_(_g_(_x_)).
 
 As such, the following steps are performed when evaluating multiple decorators on a single declaration in TypeScript:
 

--- a/packages/handbook-v1/en/Modules.md
+++ b/packages/handbook-v1/en/Modules.md
@@ -16,7 +16,7 @@ Modules are declarative; the relationships between modules are specified in term
 
 Modules import one another using a module loader.
 At runtime the module loader is responsible for locating and executing all dependencies of a module before executing it.
-Well-known module loaders used in JavaScript are Node.js's loader for [CommonJS](https://en.wikipedia.org/wiki/CommonJS) modules and the [RequireJS](http://requirejs.org/) loader for [AMD](https://github.com/amdjs/amdjs-api/blob/master/AMD.md) modules in Web applications.
+Well-known module loaders used in JavaScript are Node.js's loader for [CommonJS](https://wikipedia.org/wiki/CommonJS) modules and the [RequireJS](http://requirejs.org/) loader for [AMD](https://github.com/amdjs/amdjs-api/blob/master/AMD.md) modules in Web applications.
 
 In TypeScript, just as in ECMAScript 2015, any file containing a top-level `import` or `export` is considered a module.
 Conversely, a file without any top-level `import` or `export` declarations is treated as a script whose contents are available in the global scope (and therefore to modules as well).

--- a/packages/handbook-v1/en/The Handbook.md
+++ b/packages/handbook-v1/en/The Handbook.md
@@ -11,7 +11,7 @@ Over 20 years after its introduction to the programming community, JavaScript is
 
 The most common kinds of errors that programmers write can be described as type errors: a certain kind of value was used where a different kind of value was expected. This could be due to simple typos, a failure to understand the API surface of a library, incorrect assumptions about runtime behavior, or other errors. The goal of TypeScript is to be a static typechecker for JavaScript programs - in other words, a tool that runs before your code runs (static) and ensure that the types of the program are correct (typechecked).
 
-If you are coming to TypeScript without a JavaScript background, with the intention of TypeScript being your first language, we recommend you first start reading the documentation [on JavaScript at the Mozilla Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide).
+If you are coming to TypeScript without a JavaScript background, with the intention of TypeScript being your first language, we recommend you first start reading the documentation [on JavaScript at the Mozilla Web Docs](https://developer.mozilla.org/docs/Web/JavaScript/Guide).
 If you have experience in other languages, you should be able to pick up JavaScript syntax quite quickly by reading the handbook.
 
 ## How is this Handbook Structured

--- a/packages/handbook-v1/en/Type Inference.md
+++ b/packages/handbook-v1/en/Type Inference.md
@@ -57,7 +57,7 @@ window.onmousedown = function (mouseEvent) {
 ```
 
 Here, the TypeScript type checker used the type of the `Window.onmousedown` function to infer the type of the function expression on the right hand side of the assignment.
-When it did so, it was able to infer the [type](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) of the `mouseEvent` parameter, which does contain a `button` property, but not a `kangaroo` property.
+When it did so, it was able to infer the [type](https://developer.mozilla.org/docs/Web/API/MouseEvent) of the `mouseEvent` parameter, which does contain a `button` property, but not a `kangaroo` property.
 
 TypeScript is smart enough to infer types in other contexts as well:
 
@@ -67,7 +67,7 @@ window.onscroll = function (uiEvent) {
 };
 ```
 
-Based on the fact that the above function is being assigned to `Window.onscroll`, TypeScript knows that `uiEvent` is a [UIEvent](https://developer.mozilla.org/en-US/docs/Web/API/UIEvent), and not a [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) like the previous example. `UIEvent` objects contain no `button` property, and so TypeScript will throw an error.
+Based on the fact that the above function is being assigned to `Window.onscroll`, TypeScript knows that `uiEvent` is a [UIEvent](https://developer.mozilla.org/docs/Web/API/UIEvent), and not a [MouseEvent](https://developer.mozilla.org/docs/Web/API/MouseEvent) like the previous example. `UIEvent` objects contain no `button` property, and so TypeScript will throw an error.
 
 If this function were not in a contextually typed position, the function's argument would implicitly have type `any`, and no error would be issued (unless you are using the `--noImplicitAny` option):
 

--- a/packages/handbook-v1/en/Utility Types.md
+++ b/packages/handbook-v1/en/Utility Types.md
@@ -53,7 +53,7 @@ const todo: Readonly<Todo> = {
 todo.title = "Hello"; // Error: cannot reassign a readonly property
 ```
 
-This utility is useful for representing assignment expressions that will fail at runtime (i.e. when attempting to reassign properties of a [frozen object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze)).
+This utility is useful for representing assignment expressions that will fail at runtime (i.e. when attempting to reassign properties of a [frozen object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze)).
 
 ##### `Object.freeze`
 

--- a/packages/handbook-v1/en/Variable Declarations.md
+++ b/packages/handbook-v1/en/Variable Declarations.md
@@ -262,7 +262,7 @@ foo();
 let a;
 ```
 
-For more information on temporal dead zones, see relevant content on the [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#Temporal_dead_zone_and_errors_with_let).
+For more information on temporal dead zones, see relevant content on the [Mozilla Developer Network](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/let#Temporal_dead_zone_and_errors_with_let).
 
 ## Re-declarations and Shadowing
 
@@ -437,7 +437,7 @@ The [chapter on Interfaces](/docs/handbook/interfaces.html) has the details.
 Given that we have two types of declarations with similar scoping semantics, it's natural to find ourselves asking which one to use.
 Like most broad questions, the answer is: it depends.
 
-Applying the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege), all declarations other than those you plan to modify should use `const`.
+Applying the [principle of least privilege](https://wikipedia.org/wiki/Principle_of_least_privilege), all declarations other than those you plan to modify should use `const`.
 The rationale is that if a variable didn't need to get written to, others working on the same codebase shouldn't automatically be able to write to the object, and will need to consider whether they really need to reassign to the variable.
 Using `const` also makes code more predictable when reasoning about flow of data.
 
@@ -448,7 +448,7 @@ The majority of this handbook uses `let` declarations.
 # Destructuring
 
 Another ECMAScript 2015 feature that TypeScript has is destructuring.
-For a complete reference, see [the article on the Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment).
+For a complete reference, see [the article on the Mozilla Developer Network](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment).
 In this section, we'll give a short overview.
 
 ## Array destructuring
@@ -689,7 +689,7 @@ Then the `food` property in `defaults` overwrites `food: "rich"`, which is not w
 
 Object spread also has a couple of other surprising limits.
 First, it only includes an objects'
-[own, enumerable properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties).
+[own, enumerable properties](https://developer.mozilla.org/docs/Web/JavaScript/Enumerability_and_ownership_of_properties).
 Basically, that means you lose methods when you spread instances of an object:
 
 ```ts

--- a/packages/handbook-v1/en/declaration files/Consumption.md
+++ b/packages/handbook-v1/en/declaration files/Consumption.md
@@ -38,7 +38,7 @@ _.padStart("Hello TypeScript!", 20, " ");
 # Searching
 
 For the most part, type declaration packages should always have the same name as the package name on `npm`, but prefixed with `@types/`,
-but if you need, you can check out [https://aka.ms/types](https://aka.ms/types) to find the package for your favorite library.
+but if you need, you can check out [this Type Search](https://aka.ms/types) to find the package for your favorite library.
 
 > Note: if the declaration file you are searching for is not present, you can always contribute one back and help out the next developer looking for it.
 > Please see the DefinitelyTyped [contribution guidelines page](http://definitelytyped.org/guides/contributing.html) for details.

--- a/packages/handbook-v1/en/declaration files/Publishing.md
+++ b/packages/handbook-v1/en/declaration files/Publishing.md
@@ -160,9 +160,5 @@ That means in the above example, even though both the `>=3.2` and the `>=3.1` ma
 # Publish to [@types](https://www.npmjs.com/~types)
 
 Packages under the [@types](https://www.npmjs.com/~types) organization are published automatically from [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) using the [types-publisher tool](https://github.com/Microsoft/types-publisher).
-To get your declarations published as an @types package, please submit a pull request to [https://github.com/DefinitelyTyped/DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped).
+To get your declarations published as an @types package, please submit a pull request to [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped).
 You can find more details in the [contribution guidelines page](http://definitelytyped.org/guides/contributing.html).
-
-```
-
-```

--- a/packages/handbook-v1/en/release notes/Overview.md
+++ b/packages/handbook-v1/en/release notes/Overview.md
@@ -1055,7 +1055,7 @@ let x = foo !== null && foo !== undefined ? foo : bar();
 ```
 
 The `??` operator can replace uses of `||` when trying to use a default value.
-For example, the following code snippet tries to fetch the volume that was last saved in [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) (if it ever was);
+For example, the following code snippet tries to fetch the volume that was last saved in [`localStorage`](https://developer.mozilla.org/docs/Web/API/Window/localStorage) (if it ever was);
 however, it has a bug because it uses `||`.
 
 ```ts
@@ -1266,7 +1266,7 @@ type Foo = Foo;
 This is a reasonable restriction because any use of `Foo` would need to be replaced with `Foo` which would need to be replaced with `Foo` which would need to be replaced with `Foo` which... well, hopefully you get the idea!
 In the end, there isn't a type that makes sense in place of `Foo`.
 
-This is fairly [consistent with how other languages treat type aliases](https://en.wikipedia.org/w/index.php?title=Recursive_data_type&oldid=913091335#in_type_synonyms), but it does give rise to some slightly surprising scenarios for how users leverage the feature.
+This is fairly [consistent with how other languages treat type aliases](https://wikipedia.org/w/index.php?title=Recursive_data_type&oldid=913091335#in_type_synonyms), but it does give rise to some slightly surprising scenarios for how users leverage the feature.
 For example, in TypeScript 3.6 and prior, the following causes an error.
 
 ```ts
@@ -5420,7 +5420,7 @@ See [Type checking JavaScript Files documentation](https://github.com/Microsoft/
 
 ## Support for Mix-in classes
 
-TypeScript 2.2 adds support for the ECMAScript 2015 mixin class pattern (see [MDN Mixin description](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#Mix-ins) and ["Real" Mixins with JavaScript Classes](http://justinfagnani.com/2015/12/21/real-mixins-with-javascript-classes/) for more details) as well as rules for combining mixin construct signatures with regular construct signatures in intersection types.
+TypeScript 2.2 adds support for the ECMAScript 2015 mixin class pattern (see [MDN Mixin description](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes#Mix-ins) and ["Real" Mixins with JavaScript Classes](http://justinfagnani.com/2015/12/21/real-mixins-with-javascript-classes/) for more details) as well as rules for combining mixin construct signatures with regular construct signatures in intersection types.
 
 ##### First some terminology:
 
@@ -7076,7 +7076,7 @@ interface Error {
 
 ## Type parameters as constraints
 
-With TypeScript 1.8 it becomes possible for a type parameter constraint to reference type parameters from the same type parameter list. Previously this was an error. This capability is usually referred to as [F-Bounded Polymorphism](https://en.wikipedia.org/wiki/Bounded_quantification#F-bounded_quantification).
+With TypeScript 1.8 it becomes possible for a type parameter constraint to reference type parameters from the same type parameter list. Previously this was an error. This capability is usually referred to as [F-Bounded Polymorphism](https://wikipedia.org/wiki/Bounded_quantification#F-bounded_quantification).
 
 ##### Example
 
@@ -7295,7 +7295,7 @@ Array.prototype.mapToNumbers = function () {
 ## String literal types
 
 It's not uncommon for an API to expect a specific set of strings for certain values.
-For instance, consider a UI library that can move elements across the screen while controlling the ["easing" of the animation.](https://en.wikipedia.org/wiki/Inbetweening)
+For instance, consider a UI library that can move elements across the screen while controlling the ["easing" of the animation.](https://wikipedia.org/wiki/Inbetweening)
 
 ```ts
 declare class UIElement {
@@ -7482,7 +7482,7 @@ for (var x in a) {
 
 ## Modules are now emitted with a `"use strict";` prologue
 
-Modules were always parsed in strict mode as per ES6, but for non-ES6 targets this was not respected in the generated code. Starting with TypeScript 1.8, emitted modules are always in strict mode. This shouldn't have any visible changes in most code as TS considers most strict mode errors as errors at compile time, but it means that some things which used to silently fail at runtime in your TS code, like assigning to `NaN`, will now loudly fail. You can reference the [MDN Article](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) on strict mode for a detailed list of the differences between strict mode and non-strict mode.
+Modules were always parsed in strict mode as per ES6, but for non-ES6 targets this was not respected in the generated code. Starting with TypeScript 1.8, emitted modules are always in strict mode. This shouldn't have any visible changes in most code as TS considers most strict mode errors as errors at compile time, but it means that some things which used to silently fail at runtime in your TS code, like assigning to `NaN`, will now loudly fail. You can reference the [MDN Article](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Strict_mode) on strict mode for a detailed list of the differences between strict mode and non-strict mode.
 
 ## Including `.js` files with `--allowJs`
 
@@ -7715,7 +7715,7 @@ TypeScript 1.7 adds `ES6` to the list of options available for the `--module` fl
 
 ## `this`-typing
 
-It is a common pattern to return the current object (i.e. `this`) from a method to create [fluent-style APIs](https://en.wikipedia.org/wiki/Fluent_interface).
+It is a common pattern to return the current object (i.e. `this`) from a method to create [fluent-style APIs](https://wikipedia.org/wiki/Fluent_interface).
 For instance, consider the following `BasicCalculator` module:
 
 ```ts

--- a/packages/handbook-v1/en/release notes/TypeScript 1.7.md
+++ b/packages/handbook-v1/en/release notes/TypeScript 1.7.md
@@ -38,7 +38,7 @@ printDelayed(["Hello", "beautiful", "asynchronous", "world"]).then(() => {
 });
 ```
 
-For more information see [async function reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) reference.
+For more information see [async function reference](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/async_function) reference.
 
 ## Support for `--target ES6` with `--module`
 
@@ -58,7 +58,7 @@ This provides more flexibility to target exactly the features you want in specif
 
 ## `this`-typing
 
-It is a common pattern to return the current object (i.e. `this`) from a method to create [fluent-style APIs](https://en.wikipedia.org/wiki/Fluent_interface).
+It is a common pattern to return the current object (i.e. `this`) from a method to create [fluent-style APIs](https://wikipedia.org/wiki/Fluent_interface).
 For instance, consider the following `BasicCalculator` module:
 
 ```ts

--- a/packages/handbook-v1/en/release notes/TypeScript 1.8.md
+++ b/packages/handbook-v1/en/release notes/TypeScript 1.8.md
@@ -9,7 +9,7 @@ oneline: TypeScript 1.8 Release Notes
 
 With TypeScript 1.8 it becomes possible for a type parameter constraint to reference type parameters from the same type parameter list.
 Previously this was an error.
-This capability is usually referred to as [F-Bounded Polymorphism](https://en.wikipedia.org/wiki/Bounded_quantification#F-bounded_quantification).
+This capability is usually referred to as [F-Bounded Polymorphism](https://wikipedia.org/wiki/Bounded_quantification#F-bounded_quantification).
 
 ##### Example
 
@@ -234,7 +234,7 @@ Array.prototype.mapToNumbers = function() {
 ## String literal types
 
 It's not uncommon for an API to expect a specific set of strings for certain values.
-For instance, consider a UI library that can move elements across the screen while controlling the ["easing" of the animation.](https://en.wikipedia.org/wiki/Inbetweening)
+For instance, consider a UI library that can move elements across the screen while controlling the ["easing" of the animation.](https://wikipedia.org/wiki/Inbetweening)
 
 ```ts
 declare class UIElement {
@@ -421,7 +421,7 @@ for (var x in a) {
 
 ## Modules are now emitted with a `"use strict";` prologue
 
-Modules were always parsed in strict mode as per ES6, but for non-ES6 targets this was not respected in the generated code. Starting with TypeScript 1.8, emitted modules are always in strict mode. This shouldn't have any visible changes in most code as TS considers most strict mode errors as errors at compile time, but it means that some things which used to silently fail at runtime in your TS code, like assigning to `NaN`, will now loudly fail. You can reference the [MDN Article](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) on strict mode for a detailed list of the differences between strict mode and non-strict mode.
+Modules were always parsed in strict mode as per ES6, but for non-ES6 targets this was not respected in the generated code. Starting with TypeScript 1.8, emitted modules are always in strict mode. This shouldn't have any visible changes in most code as TS considers most strict mode errors as errors at compile time, but it means that some things which used to silently fail at runtime in your TS code, like assigning to `NaN`, will now loudly fail. You can reference the [MDN Article](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Strict_mode) on strict mode for a detailed list of the differences between strict mode and non-strict mode.
 
 ## Including `.js` files with `--allowJs`
 

--- a/packages/handbook-v1/en/release notes/TypeScript 2.2.md
+++ b/packages/handbook-v1/en/release notes/TypeScript 2.2.md
@@ -7,7 +7,7 @@ oneline: TypeScript 2.2 Release Notes
 
 ## Support for Mix-in classes
 
-TypeScript 2.2 adds support for the ECMAScript 2015 mixin class pattern (see [MDN Mixin description](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#Mix-ins) and ["Real" Mixins with JavaScript Classes](http://justinfagnani.com/2015/12/21/real-mixins-with-javascript-classes/) for more details) as well as rules for combining mixin construct signatures with regular construct signatures in intersection types.
+TypeScript 2.2 adds support for the ECMAScript 2015 mixin class pattern (see [MDN Mixin description](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes#Mix-ins) and ["Real" Mixins with JavaScript Classes](http://justinfagnani.com/2015/12/21/real-mixins-with-javascript-classes/) for more details) as well as rules for combining mixin construct signatures with regular construct signatures in intersection types.
 
 ##### First some terminology
 

--- a/packages/handbook-v1/en/release notes/TypeScript 3.7.md
+++ b/packages/handbook-v1/en/release notes/TypeScript 3.7.md
@@ -134,7 +134,7 @@ let x = foo !== null && foo !== undefined ? foo : bar();
 ```
 
 The `??` operator can replace uses of `||` when trying to use a default value.
-For example, the following code snippet tries to fetch the volume that was last saved in [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) (if it ever was);
+For example, the following code snippet tries to fetch the volume that was last saved in [`localStorage`](https://developer.mozilla.org/docs/Web/API/Window/localStorage) (if it ever was);
 however, it has a bug because it uses `||`.
 
 ```ts
@@ -345,7 +345,7 @@ type Foo = Foo;
 This is a reasonable restriction because any use of `Foo` would need to be replaced with `Foo` which would need to be replaced with `Foo` which would need to be replaced with `Foo` which... well, hopefully you get the idea!
 In the end, there isn't a type that makes sense in place of `Foo`.
 
-This is fairly [consistent with how other languages treat type aliases](https://en.wikipedia.org/w/index.php?title=Recursive_data_type&oldid=913091335#in_type_synonyms), but it does give rise to some slightly surprising scenarios for how users leverage the feature.
+This is fairly [consistent with how other languages treat type aliases](https://wikipedia.org/w/index.php?title=Recursive_data_type&oldid=913091335#in_type_synonyms), but it does give rise to some slightly surprising scenarios for how users leverage the feature.
 For example, in TypeScript 3.6 and prior, the following causes an error.
 
 ```ts

--- a/packages/handbook-v1/en/tutorials/DOM Manipulation.md
+++ b/packages/handbook-v1/en/tutorials/DOM Manipulation.md
@@ -15,7 +15,7 @@ Website are made up of HTML and/or XML documents. These documents are static, th
 
 TypeScript is a typed superset of JavaScript, and it ships type definitions for the DOM API. These definitions are readily available in any default TypeScript project. Of the 20,000+ lines of definitions in _lib.dom.d.ts_, one stands out among the rest: `HTMLElement` . This type is the backbone for DOM manipulation with TypeScript.
 
-> Explore the source code for the DOM type definitions here: [https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts](https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts)
+> You can explore the source code for the [DOM type definitions](https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts)
 
 ## Basic Example
 
@@ -192,9 +192,9 @@ const all = document.querySelectorAll("li"); // returns the list of all li eleme
 
 ## Interested in learning more?
 
-The best part about the _lib.dom.d.ts_ type definitions is that they are reflective of the types annotated in the Mozilla Developer Network (MDN) documentation site. For example, the `HTMLElement` interface is documented by this [HTMLElement page](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement) on MDN. These pages list all available properties, methods, and sometimes even examples. Another great aspect of the pages is that they provide links to the corresponding standard documents. Here is the link to the [W3C Recommendation for HTMLElement](https://www.w3.org/TR/html52/dom.html#htmlelement).
+The best part about the _lib.dom.d.ts_ type definitions is that they are reflective of the types annotated in the Mozilla Developer Network (MDN) documentation site. For example, the `HTMLElement` interface is documented by this [HTMLElement page](https://developer.mozilla.org/docs/Web/API/HTMLElement) on MDN. These pages list all available properties, methods, and sometimes even examples. Another great aspect of the pages is that they provide links to the corresponding standard documents. Here is the link to the [W3C Recommendation for HTMLElement](https://www.w3.org/TR/html52/dom.html#htmlelement).
 
 Sources:
 
-- ECMA-262 Standard: [http://www.ecma-international.org/ecma-262/10.0/index.html#Title](http://www.ecma-international.org/ecma-262/10.0/index.html#Title)
-- Introduction to the DOM: [https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Introduction](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Introduction)
+- [ECMA-262 Standard](http://www.ecma-international.org/ecma-262/10.0/index.html)
+- [Introduction to the DOM](https://developer.mozilla.org/docs/Web/API/Document_Object_Model/Introduction)

--- a/packages/handbook-v1/en/tutorials/React.md
+++ b/packages/handbook-v1/en/tutorials/React.md
@@ -426,7 +426,7 @@ There's clearly boilerplate here, so you should feel free to look into libraries
 
 We're ready to write our first reducer!
 Reducers are just functions that generate changes by creating modified copies of our application's state, but that have _no side effects_.
-In other words, they're what we call _[pure functions](https://en.wikipedia.org/wiki/Pure_function)_.
+In other words, they're what we call _[pure functions](https://wikipedia.org/wiki/Pure_function)_.
 
 Our reducer will go under `src/reducers/index.tsx`.
 Its function will be to ensure that increments raise the enthusiasm level by 1, and that decrements reduce the enthusiasm level by 1, but that the level never falls below 1.

--- a/packages/handbook-v1/en/tutorials/TS for Functional Programmers.md
+++ b/packages/handbook-v1/en/tutorials/TS for Functional Programmers.md
@@ -55,7 +55,7 @@ JavaScript defines 7 built-in types:
 | `Undefined` | also equivalent to the unit type.           |
 | `Object`    | similar to records.                         |
 
-[See the MDN page for more detail](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures).
+[See the MDN page for more detail](https://developer.mozilla.org/docs/Web/JavaScript/Data_structures).
 
 TypeScript has corresponding primitive types for the built-in types:
 

--- a/packages/handbook-v1/en/tutorials/TS for the New Programmer.md
+++ b/packages/handbook-v1/en/tutorials/TS for the New Programmer.md
@@ -161,7 +161,7 @@ If you find a resource that uses TypeScript directly, that's great too, but don'
 
 ---
 
-From here, we'd recommend learning some of the JavaScript fundamentals (the [JavaScript guide at the Mozilla Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide) is a good starting point.)
+From here, we'd recommend learning some of the JavaScript fundamentals (the [JavaScript guide at the Mozilla Web Docs](https://developer.mozilla.org/docs/Web/JavaScript/Guide) is a good starting point.)
 
 Once you're feeling comfortable, you can come back to read [TypeScript for JavaScript Programmers](/docs/handbook/typescript-in-5-minutes.html), then start on [the handbook](/docs/handbook/intro.html) or explore the [Playground examples](/play#show-examples).
 

--- a/packages/handbook-v1/en/tutorials/tsconfig.json.md
+++ b/packages/handbook-v1/en/tutorials/tsconfig.json.md
@@ -12,7 +12,7 @@ The `tsconfig.json` file specifies the root files and the compiler options requi
 
 A project is compiled in one of the following ways:
 
-## Using tsconfig.json
+## Using `tsconfig.json`
 
 - By invoking tsc with no input files, in which case the compiler searches for the `tsconfig.json` file starting in the current directory and continuing up the parent directory chain.
 - By invoking tsc with no input files and a `--project` (or just `-p`) command line option that specifies the path of a directory containing a `tsconfig.json` file, or a path to a valid `.json` file containing the configurations.
@@ -79,4 +79,4 @@ To learn more about the hundreds of configuration options in the [TSConfig Refer
 
 ## Schema
 
-Schema can be found at: [http://json.schemastore.org/tsconfig](http://json.schemastore.org/tsconfig)
+The `tsconfig.json` Schema can be found at [the JSON Schema Store](http://json.schemastore.org/tsconfig).

--- a/packages/playground-examples/copy/en/3-7/Fixits/Big number literals.ts
+++ b/packages/playground-examples/copy/en/3-7/Fixits/Big number literals.ts
@@ -16,7 +16,7 @@ const oneBelowMin = -9007199254740992;
 // is to convert these numbers to BigInts instead
 // of a number:
 //
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt
+// https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt
 
 // TypeScript will now offer a fixit for number
 // literals which are above 2^52 (positive / negative)

--- a/packages/playground-examples/copy/en/TypeScript/Language/Type Guards.ts
+++ b/packages/playground-examples/copy/en/TypeScript/Language/Type Guards.ts
@@ -52,7 +52,7 @@ if (typeof possibleOrder === "undefined") {
 }
 
 // You can see a full list of possible typeof values
-// here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof
+// here: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/typeof
 
 // Using JavaScript operators can only get you so far. When
 // you want to check your own object types you can use

--- a/packages/playground-examples/copy/ja/3-7/Fixits/Big number literals.ts
+++ b/packages/playground-examples/copy/ja/3-7/Fixits/Big number literals.ts
@@ -14,7 +14,7 @@ const oneBelowMin = -9007199254740992
 // このサイズの数値を扱うための解決策は、
 // これらの数値を、number の代わりに BigInts に変換することです:
 //
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt
+// https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt
 
 // TypeScriptは、2の52乗以上の数値リテラル(正/負)の修正機能を提供するようになり、
 // 接尾辞 "n"を追加してJavaScriptにBigInt型であることを知らせるようになりました。

--- a/packages/playground-examples/copy/zh/TypeScript/Language/Type Guards.ts
+++ b/packages/playground-examples/copy/zh/TypeScript/Language/Type Guards.ts
@@ -48,7 +48,7 @@ if (typeof possibleOrder === "undefined") {
 }
 
 // 你可以在这里看到全部 typeof 的可能的值:
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof
+// https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/typeof
 
 // 使用 JavaScript 操作符仅仅可以帮助您实现一部分功能，
 // 当您希望检查自己定义的类型时，您可以使用类型谓词函数。

--- a/packages/tsconfig-reference/copy/en/options/alwaysStrict.md
+++ b/packages/tsconfig-reference/copy/en/options/alwaysStrict.md
@@ -5,4 +5,4 @@ oneline: "Ensure 'use strict' is always emitted"
 
 Ensures that your files are parsed in the ECMAScript strict mode, and emit "use strict" for each source file.
 
-[ECMAScript strict](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) mode was introduced in ES5 and provides behavior tweaks to the runtime of the JavaScript engine to improve performance, and makes a set of errors throw instead of silently ignoring them.
+[ECMAScript strict](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Strict_mode) mode was introduced in ES5 and provides behavior tweaks to the runtime of the JavaScript engine to improve performance, and makes a set of errors throw instead of silently ignoring them.

--- a/packages/tsconfig-reference/copy/en/options/emitBOM.md
+++ b/packages/tsconfig-reference/copy/en/options/emitBOM.md
@@ -3,6 +3,6 @@ display: "Emit BOM"
 oneline: "Include a byte order mark to output files"
 ---
 
-Controls whether TypeScript will emit a [byte order mark (BOM)](https://en.wikipedia.org/wiki/Byte_order_mark) when writing output files.
+Controls whether TypeScript will emit a [byte order mark (BOM)](https://wikipedia.org/wiki/Byte_order_mark) when writing output files.
 Some runtime environments require a BOM to correctly interpret a JavaScript files; others require that it is not present.
 The default value of `false` is generally best unless you have a reason to change it.

--- a/packages/tsconfig-reference/copy/en/options/lib.md
+++ b/packages/tsconfig-reference/copy/en/options/lib.md
@@ -26,9 +26,9 @@ You may want to change these for a few reasons:
 | `ES2019`     | Additional APIs available in ES2019 - `array.flat`, `array.flatMap`, `Object.fromEntries`, `string.trimStart`, `string.trimEnd`, etc.             |
 | `ES2020`     | Additional APIs available in ES2020 - `string.matchAll`, etc.                                                                                     |
 | `ESNext`     | Additional APIs available in ESNext - This changes as the JavaScript specification evolves                                                        |
-| `DOM`        | [DOM](https://developer.mozilla.org/en-US/docs/Glossary/DOM) definitions - `window`, `document`, etc.                                             |
-| `WebWorker`  | APIs available in [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers) contexts                        |
-| `ScriptHost` | APIs for the [Windows Script Hosting System](https://en.wikipedia.org/wiki/Windows_Script_Host)                                                   |
+| `DOM`        | [DOM](https://developer.mozilla.org/docs/Glossary/DOM) definitions - `window`, `document`, etc.                                                   |
+| `WebWorker`  | APIs available in [WebWorker](https://developer.mozilla.org/docs/Web/API/Web_Workers_API/Using_web_workers) contexts                              |
+| `ScriptHost` | APIs for the [Windows Script Hosting System](https://wikipedia.org/wiki/Windows_Script_Host)                                                      |
 
 ### Individual library components
 

--- a/packages/tsconfig-reference/copy/en/options/sourceMap.md
+++ b/packages/tsconfig-reference/copy/en/options/sourceMap.md
@@ -3,7 +3,7 @@ display: "Source Map"
 oneline: "Creates source map files for emitted JavaScript files"
 ---
 
-Enables the generation of [sourcemap files](https://developer.mozilla.org/en-US/docs/Tools/Debugger/How_to/Use_a_source_map).
+Enables the generation of [sourcemap files](https://developer.mozilla.org/docs/Tools/Debugger/How_to/Use_a_source_map).
 These files allow debuggers and other tools to display the original TypeScript source code when actually working with the emitted JavaScript files.
 Source map files are emitted as `.js.map` (or `.jsx.map`) files next to the corresponding `.js` output file.
 

--- a/packages/tsconfig-reference/copy/ja/options/alwaysStrict.md
+++ b/packages/tsconfig-reference/copy/ja/options/alwaysStrict.md
@@ -5,4 +5,4 @@ oneline: "Ensure 'use strict' is always emitted"
 
 ファイルをECMAScriptのstrictモードで解釈し、各ファイルへ"use strict"を出力することを保証します。
 
-[ECMAScript strict](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode)モードはES5で導入され、JavaScriptエンジンが実行時にパフォーマンスを改善できるよう微調整されます。代わりにいくつかのエラーが無視されずにスローされるようになります。
+[ECMAScript strict](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Strict_mode)モードはES5で導入され、JavaScriptエンジンが実行時にパフォーマンスを改善できるよう微調整されます。代わりにいくつかのエラーが無視されずにスローされるようになります。

--- a/packages/tsconfig-reference/copy/ja/options/emitBOM.md
+++ b/packages/tsconfig-reference/copy/ja/options/emitBOM.md
@@ -3,6 +3,6 @@ display: "Emit BOM"
 oneline: "Include a byte order mark to output files"
 ---
 
-TypeScriptがファイルを書き込むときに[バイトオーダーマーク（BOM）](https://en.wikipedia.org/wiki/Byte_order_mark)を出力するかどうかを制御します。
+TypeScriptがファイルを書き込むときに[バイトオーダーマーク（BOM）](https://wikipedia.org/wiki/Byte_order_mark)を出力するかどうかを制御します。
 一部の実行環境ではJavaScriptファイルを正しく解釈するために、BOMが必要となりますが、他の実行環境ではBOMの存在を許容しません。
 デフォルト値の`false`は一般的に最適な値ですが、必要であれば変更できます。

--- a/packages/tsconfig-reference/copy/ja/options/lib.md
+++ b/packages/tsconfig-reference/copy/ja/options/lib.md
@@ -26,9 +26,9 @@ TypeScriptには組み込みのJS API（例：`Math`）の型定義や、ブラ�
 | `ES2019`     | ES2019で利用可能なAPI - `array.flat`、`array.flatMap`、`Object.fromEntries`、`string.trimStart`、`string.trimEnd`など。                           |
 | `ES2020`     | ES2020で利用可能なAPI - `string.matchAll`など。                                                                                                   |
 | `ESNext`     | ESNextで利用可能なAPI - JavaScriptの仕様変遷によって内容は変化します。                                                                            |
-| `DOM`        | [DOM](https://developer.mozilla.org/en-US/docs/Glossary/DOM)の型定義 - `window`や`document`など。                                                 |
-| `WebWorker`  | [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers)コンテキストで利用可能なAPI                        |
-| `ScriptHost` | [Windows Script Hosting System](https://en.wikipedia.org/wiki/Windows_Script_Host)のAPI                                                           |
+| `DOM`        | [DOM](https://developer.mozilla.org/docs/Glossary/DOM)の型定義 - `window`や`document`など。                                                       |
+| `WebWorker`  | [WebWorker](https://developer.mozilla.org/docs/Web/API/Web_Workers_API/Using_web_workers)コンテキストで利用可能なAPI                              |
+| `ScriptHost` | [Windows Script Hosting System](https://wikipedia.org/wiki/Windows_Script_Host)のAPI                                                              |
 
 ### 個別のライブラリコンポーネント
 

--- a/packages/tsconfig-reference/copy/ja/options/sourceMap.md
+++ b/packages/tsconfig-reference/copy/ja/options/sourceMap.md
@@ -3,7 +3,7 @@ display: "Source Map"
 oneline: "Creates source map files for emitted JavaScript files"
 ---
 
-[ソースマップファイル](https://developer.mozilla.org/en-US/docs/Tools/Debugger/How_to/Use_a_source_map)の生成を有効化します。
+[ソースマップファイル](https://developer.mozilla.org/docs/Tools/Debugger/How_to/Use_a_source_map)の生成を有効化します。
 これらのファイルにより、出力されたJavaScriptファイルが実際に動作させるときに、デバッガーやその他のツールが元のTypeScriptソースファイルを表示できるようになります。
 ソースマップファイルは`.js.map`（または`.jsx.map`）として、対応する`.js`ファイルとともに出力されます。
 

--- a/packages/typescriptlang-org/src/lib/isTouchDevice.ts
+++ b/packages/typescriptlang-org/src/lib/isTouchDevice.ts
@@ -1,4 +1,4 @@
-/** Based on https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent */
+/** Based on https://developer.mozilla.org/docs/Web/HTTP/Browser_detection_using_the_user_agent */
 export function isTouchDevice() {
   var hasTouchScreen = false
   if ("maxTouchPoints" in navigator) {


### PR DESCRIPTION
* Drop `en`/`en-US` from mozilla and WP links.

* Change links with the url showing to text links.

* Note: Does this on `aka.ms/types` -- but maybe it was intended to show
  the url?

* Note: Changes links in release notes too -- but maybe these files
  should be unchanged?

* Note: random fix -- adds backticks around a `tsconfig.json` title

Fixes #636
Fixes #629