### PR TITLE
Fix mistake in TS for Functional Programmers doc

### DIFF
--- a/packages/handbook-v1/en/tutorials/TS for Functional Programmers.md
+++ b/packages/handbook-v1/en/tutorials/TS for Functional Programmers.md
@@ -111,8 +111,8 @@ needed, since their methods return primitives.
 Number.prototype.toExponential.call(1);
 ```
 
-Note that calling methods on numeric literals requires an additional
-`.` to aid the parser.
+Note that calling a method on a numeric literal requires it to be in
+parentheses to aid the parser.
 
 ## Gradual typing
 


### PR DESCRIPTION
There is no additional `.` in this syntax. I think the sentence was intended to refer to the parentheses (otherwise 1. looks like the beginning of a floating-point number literal)?