### PR TITLE
fix(handbook): Use correct import syntax

### DIFF
--- a/packages/handbook-v1/en/declaration files/Library Structures.md
+++ b/packages/handbook-v1/en/declaration files/Library Structures.md
@@ -103,7 +103,7 @@ var fs = require("fs");
 In TypeScript or ES6, the `import` keyword serves the same purpose:
 
 ```ts
-import fs = require("fs");
+import fs from "fs";
 ```
 
 You'll typically see modular libraries include one of these lines in their documentation:


### PR DESCRIPTION
I believe this is a copy and paste error from the above line.