### PR TITLE
docs(es): translation of TypeScript Meta-Types section

### DIFF
--- a/packages/playground-examples/copy/es/TypeScript/Meta-Types/Conditional Types.ts
+++ b/packages/playground-examples/copy/es/TypeScript/Meta-Types/Conditional Types.ts
@@ -70,9 +70,6 @@ declare function getID<T extends boolean>(fancy: T): T extends true ? string : n
 // Entonces, dependiendo de cuánto sepa el sistema de tipos
 // sobre el booleano, obtendrá diferentes tipos de retorno:
 
-// Then depending on how much the type-system knows about
-// the boolean, you will get different return types:
-
 let stringReturnValue = getID(true);
 let numberReturnValue = getID(false);
 let stringOrNumber = getID(Math.random() < 0.5);

--- a/packages/playground-examples/copy/es/TypeScript/Meta-Types/Conditional Types.ts
+++ b/packages/playground-examples/copy/es/TypeScript/Meta-Types/Conditional Types.ts
@@ -1,0 +1,117 @@
+// Los tipos condicionales proporcionan una forma de hacer
+// lógica simple en el sistema de tipos de TypeScript. Esta
+// es definitivamente una característica avanzada, y es
+// bastante factible que no necesites usar esto en tu código
+// del día a día.
+
+// Un tipo condicional se parece a:
+//
+//   A extends B ? C : D
+//
+// Donde la condición es si un tipo extiende una expresión
+// y, en caso afirmativo, qué tipo debe devolverse.
+
+// Veamos algunos ejemplos, para ser breves vamos a usar
+// letras simples para los genéricos. Esto es opcional, pero
+// al restringirnos a 60 caracteres es difícil que quepa en
+// la pantalla.
+
+type Cat = { meows: true };
+type Dog = { barks: true };
+type Cheetah = { meows: true; fast: true };
+type Wolf = { barks: true; howls: true };
+
+// Podemos crear un tipo condicional que permita extraer
+// tipos que sólo se ajusten a un animal que ladra.
+
+type ExtractDogish<A> = A extends { barks: true } ? A : never;
+
+// Entonces podemos crear tipos soportados por ExtractDogish:
+
+// Un gato no ladra, por lo que retorna `never`
+type NeverCat = ExtractDogish<Cat>;
+// Un lobo puede ladrar, por lo que retorna la forma del
+// objeto `Wolf`
+type Wolfish = ExtractDogish<Wolf>;
+
+// Esto resulta útil cuando se quiere trabajar con un unión
+// de muchos tipos y reducir el número de opciones
+// potenciales en una unión:
+
+type Animals = Cat | Dog | Cheetah | Wolf;
+
+// Cuando aplicas ExtractDogish a una unión de tipos, es
+// igual a ejecutar los condicionales en cada uno de los
+// miembros del tipo:
+
+type Dogish = ExtractDogish<Animals>;
+
+// = ExtractDogish<Cat> | ExtractDogish<Dog> |
+//   ExtractDogish<Cheetah> | ExtractDogish<Wolf>
+//
+// = never | Dog | never | Wolf
+//
+// = Dog | Wolf (Veasé example:unknown-and-never)
+
+// Se denomina tipo condicional distributivo porque el tipo
+// se distribuye sobre cada miembro de la unión.
+
+// Tipos Condicionales Diferidos
+
+// Los tipos condicionales pueden utilizarse para reforzar
+// sus APIs, que pueden devolver diferentes tipos en función
+// de las entradas.
+
+// Por ejemplo, esta función que puede devolver una cadena o
+// un número dependiendo del booleano pasado.
+
+declare function getID<T extends boolean>(fancy: T): T extends true ? string : number;
+
+// Entonces, dependiendo de cuánto sepa el sistema de tipos
+// sobre el booleano, obtendrá diferentes tipos de retorno:
+
+// Then depending on how much the type-system knows about
+// the boolean, you will get different return types:
+
+let stringReturnValue = getID(true);
+let numberReturnValue = getID(false);
+let stringOrNumber = getID(Math.random() < 0.5);
+
+// En este caso, TypeScript puede saber el valor de retorno
+// al instante. Sin embargo, puede usar tipos condicionales
+// en funciones donde el tipo no se conoce todavía. Esto se
+// denomina tipo condicional diferido.
+
+// Igual que nuestro "Dogish" anterior, pero como función
+declare function isCatish<T>(x: T): T extends { meows: true } ? T : undefined;
+
+// Hay una herramienta extra útil dentro de los tipos
+// condicionales, que es capaz de decirle específicamente a
+// TypeScript que debe inferir el tipo al diferir. Esa es la
+// palabra clave "infer".
+
+// "infer" se usa típicamente para crear meta-tipos que
+// inspeccionan los tipos existentes en tu código, piensa en
+// ello como crear una nueva variable dentro del tipo.
+
+type GetReturnValue<T> = T extends (...args: any[]) => infer R ? R : T;
+
+// Básicamente:
+//
+//  - Este es un tipo genérico condicional llamado
+//    GetReturnValue el cual acepta un tipo como su primer
+//    parámetro.
+//
+//  - El condicional revisa si el tipo es una función, y si
+//    es así crea un nuevo tipo llamado R basado en el valor
+//    retornado por esa función.
+//
+//  - Si la revisión pasa, el valor del tipo es el valor de
+//    retorno inferido, sino es el tipo original.
+//
+
+type getIDReturn = GetReturnValue<typeof getID>;
+
+// Esto falla en la comprobación de ser una función, y sólo
+// devolvería el tipo pasado a ella.
+type getCat = GetReturnValue<Cat>;

--- a/packages/playground-examples/copy/es/TypeScript/Meta-Types/Discriminate Types.ts
+++ b/packages/playground-examples/copy/es/TypeScript/Meta-Types/Discriminate Types.ts
@@ -1,0 +1,67 @@
+// Una unión de tipo discriminado es cuando se utiliza el
+// análisis de flujo de código para reducir un conjunto de
+// objetos potenciales a un objeto específico.
+//
+// Este patrón funciona muy bien para conjuntos de objetos
+// similares con una cadena o constante numérica diferente,
+// por ejemplo: una lista de eventos con nombre, o conjuntos
+// de objetos versionados.
+
+type TimingEvent = { name: "start"; userStarted: boolean } | { name: "closed"; duration: number };
+
+// Cuando el evento entra en esta función, podría ser
+// cualquiera de los dos potenciales tipos.
+
+const handleEvent = (event: TimingEvent) => {
+  // Mediante el uso de un interruptor en event.name el
+  // análisis de flujo de código de TypeScript puede
+  // determinar que un objeto sólo puede ser representado
+  // por un tipo en la unión.
+
+  switch (event.name) {
+    case "start":
+      // Esto significa que puedes acceder con seguridad a
+      // userStarted porque es el único tipo dentro de
+      // TimingEvent donde el nombre es "start".
+      const initiatedByUser = event.userStarted;
+      break;
+
+    case "closed":
+      const timespan = event.duration;
+      break;
+  }
+};
+
+// Este patrón es el mismo con los números que podemos usar
+// como el discriminador.
+
+// En este ejemplo, tenemos una unión discriminante y un
+// estado de error adicional que manejar.
+
+type APIResponses = { version: 0; msg: string } | { version: 1; message: string; status: number } | { error: string };
+
+const handleResponse = (response: APIResponses) => {
+  // Maneja el caso de error, y luego retorna
+  if ("error" in response) {
+    console.error(response.error);
+    return;
+  }
+
+  // TypeScript ahora sabe que APIResponse no puede ser el
+  // tipo de error. Si fuera el error, la función habría
+  // regresado. Puede verificar esto pasando el cursor sobre
+  // response a continuación.
+
+  if (response.version === 0) {
+    console.log(response.msg);
+  } else if (response.version === 1) {
+    console.log(response.status, response.message);
+  }
+};
+
+// Es mejor usar una declaración switch en lugar de
+// declaraciones if, porque puedes asegurarte de que todas
+// las partes de la unión son revisadas. Hay un buen patrón
+// para esto usando el tipo `never` en el manual:
+
+// https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions

--- a/packages/playground-examples/copy/es/TypeScript/Meta-Types/Discriminate Types.ts
+++ b/packages/playground-examples/copy/es/TypeScript/Meta-Types/Discriminate Types.ts
@@ -10,7 +10,7 @@
 type TimingEvent = { name: "start"; userStarted: boolean } | { name: "closed"; duration: number };
 
 // Cuando el evento entra en esta función, podría ser
-// cualquiera de los dos potenciales tipos.
+// cualquiera de los dos tipos potenciales.
 
 const handleEvent = (event: TimingEvent) => {
   // Mediante el uso de un interruptor en event.name el
@@ -49,7 +49,7 @@ const handleResponse = (response: APIResponses) => {
 
   // TypeScript ahora sabe que APIResponse no puede ser el
   // tipo de error. Si fuera el error, la función habría
-  // regresado. Puede verificar esto pasando el cursor sobre
+  // retornado. Puede verificar esto pasando el cursor sobre
   // response a continuación.
 
   if (response.version === 0) {

--- a/packages/playground-examples/copy/es/TypeScript/Meta-Types/Indexed Types.ts
+++ b/packages/playground-examples/copy/es/TypeScript/Meta-Types/Indexed Types.ts
@@ -1,0 +1,39 @@
+// Hay veces que te encuentras duplicando tipos. Un ejemplo
+// común es el de los recursos anidados en una respuesta API
+// autogenerada.
+
+interface ArtworkSearchResponse {
+  artists: {
+    name: string;
+    artworks: {
+      name: string;
+      deathdate: string | null;
+      bio: string;
+    }[];
+  }[];
+}
+
+// Si esta interfaz fuera hecha a mano, es bastante fácil
+// imaginar que se saca el tipo de artworks en una interfaz
+// como:
+
+interface Artwork {
+  name: string;
+  deathdate: string | null;
+  bio: string;
+}
+
+// Sin embargo, en este caso no controlamos la API, y si
+// creamos la interfaz a mano, es posible que la parte de
+// ArtworkSearchResponse y Artwork se desincronicen cuando
+// la respuesta cambie.
+
+// La solución para esto son los tipos indexados, que
+// replican la manera en que JavaScript permite el acceso a
+// las propiedades a través de cadenas.
+
+type InferredArtwork = ArtworkSearchResponse["artists"][0]["artworks"][0];
+
+// El InferredArtwork se genera mirando las propiedades del
+// tipo y dando un nuevo nombre al subconjunto que has
+// indexado.

--- a/packages/playground-examples/copy/es/TypeScript/Meta-Types/Mapped Types.ts
+++ b/packages/playground-examples/copy/es/TypeScript/Meta-Types/Mapped Types.ts
@@ -1,0 +1,58 @@
+// Los tipos mapeados son una forma de crear nuevos tipos
+// basados en otro tipo. Efectivamente un tipo
+// transformacional.
+
+// Los casos más comunes para usar un tipo mapeado es tratar
+// con subconjuntos parciales de un tipo existente. Por
+// ejemplo, una API puede devolver un objeto Artist:
+
+interface Artist {
+  id: number;
+  name: string;
+  bio: string;
+}
+
+// Sin embargo, si enviara una actualización a la API que
+// sólo cambiara un subconjunto del objeto Artist, normalmente
+// tendría que crear un tipo adicional:
+
+interface ArtistForEdit {
+  id: number;
+  name?: string;
+  bio?: string;
+}
+
+// Es muy probable que esto se desincronice con la interface
+// Artist de arriba. Los tipos mapeados permiten crear un
+// cambio en un tipo existente.
+
+type MyPartialType<Type> = {
+  // Para cada propiedad existente dentro del tipo Type
+  // conviértalo en su versión opcional ?:
+  [Property in keyof Type]?: Type[Property];
+};
+
+// Ahora podemos usar el tipo mapeado en su lugar para crear
+// nuestra interfaz de edición:
+type MappedArtistForEdit = MyPartialType<Artist>;
+
+// Esto es casi perfecto, pero permite que la propiedad id
+// sea nula, lo que nunca debería suceder. Así que, hagamos
+// una rápida mejora usando un tipo de intersección (veasé:
+// example:union-and-intersection-types )
+
+type MyPartialTypeForEdit<Type> = {
+  [Property in keyof Type]?: Type[Property];
+} & { id: number };
+
+// Esta toma el resultado parcial del tipo mapeado, y lo
+// fusiona con un objeto que tiene la propiedad id: number.
+// Con esto se fuerza a id a estar en el tipo.
+
+type CorrectMappedArtistForEdit = MyPartialTypeForEdit<Artist>;
+
+// Este es un ejemplo bastante simple de cómo funcionan los
+// tipos mapeados, pero cubre la mayoría de los aspectos
+// básicos. Si desea profundizar más, consulte el manual:
+//
+// https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types


### PR DESCRIPTION
References #232

- **TypeScript** -> **Meta-Types Section**
  - [x] [Conditional Types.ts](https://github.com/microsoft/TypeScript-Website/blob/v2/packages//playground-examples/copy/en/TypeScript/Meta-Types/Conditional%20Types.ts)
  - [x] [Discriminate Types.ts](https://github.com/microsoft/TypeScript-Website/blob/v2/packages//playground-examples/copy/en/TypeScript/Meta-Types/Discriminate%20Types.ts)
  - [x] [Indexed Types.ts](https://github.com/microsoft/TypeScript-Website/blob/v2/packages//playground-examples/copy/en/TypeScript/Meta-Types/Indexed%20Types.ts)
  - [x] [Mapped Types.ts](https://github.com/microsoft/TypeScript-Website/blob/v2/packages//playground-examples/copy/en/TypeScript/Meta-Types/Mapped%20Types.ts)