### PR TITLE
remove "js" postfix from "angular" reference on landing page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -259,7 +259,7 @@ keywords: "type checker, javascript, transpiler, compiler, static types"
                                             <p><em>We love TypeScript for many things&hellip; With TypeScript, several of our team members have said things like '<strong>I now actually understand most of our own code!</strong>' because they can easily traverse it and understand relationships much better. And we’ve <strong>found several bugs via TypeScript’s checks</strong>.”</em></p>
                                         </div>
                                         <div class="author-container">
-                                            <p><em>&mdash; Brad Green, Engineering Director - AngularJS</em></p>
+                                            <p><em>&mdash; Brad Green, Engineering Director - Angular</em></p>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
Brought up by @mgechev