### PR TITLE
fix: quick fix index path on spanish docs

### DIFF
--- a/packages/typescriptlang-org/src/copy/es.ts
+++ b/packages/typescriptlang-org/src/copy/es.ts
@@ -3,7 +3,7 @@ import { Copy, messages as englishMessages } from "./en"
 import { navCopy } from "./es/nav"
 import { headCopy } from "./es/head-seo"
 import { docCopy } from "./en/documentation"
-import { indexCopy } from "./en/index"
+import { indexCopy } from "./es/index"
 import { playCopy } from "./es/playground"
 import { comCopy } from "./en/community"
 


### PR DESCRIPTION
This solves the issue of spanish text on website index not being displayed. @orta 