### PR TITLE
Add links to JSDoc @type explanation.

### DIFF
--- a/packages/handbook-v1/en/JSDoc Supported Types.md
+++ b/packages/handbook-v1/en/JSDoc Supported Types.md
@@ -29,7 +29,7 @@ The code below describes the differences and gives some example usage of each ta
 ## `@type`
 
 You can use the "@type" tag and reference a type name (either primitive, defined in a TypeScript declaration, or in a JSDoc "@typedef" tag).
-You can use any Typescript type, and most JSDoc types.
+You can use most JSDoc types and any Typescript type, from [the most basic like `string`](/docs/handbook/basic-types.html) to [the most advanced, like conditional types](/docs/handbook/advanced-types.html).
 
 ```js
 /**


### PR DESCRIPTION
Should encourage people to think of using the full range of Typescript types in JSDoc.