### PR TITLE
JSDoc Reference Twoslash improvements

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -12,11 +12,11 @@ import lighthouse from "danger-plugin-lighthouse"
 // Spell check all the things
 spellcheck({
   settings: "artsy/peril-settings@spellcheck.json",
-  codeSpellCheck: ["Examples/**/*.ts", "Examples/**/*.js"],
+  codeSpellCheck: ["Examples/**/*.ts", "Examples/**/*.js"]
 })
 
 // Print out the PR url
-const deployURL = `https://typescript-v2-${danger.github.pr.number}.ortam.now.sh`
+const deployURL = `https://typescript-v2-${danger.github.pr.number}.vercel.app`
 message(
   `Deployed to [a PR branch](${deployURL}) - [playground](${deployURL}/play) [tsconfig](${deployURL}/tsconfig) [old handbook](${deployURL}/docs/handbook/integrating-with-build-tools.html)`
 )

--- a/packages/community-meta/scripts/meetups.js
+++ b/packages/community-meta/scripts/meetups.js
@@ -1,137 +1,137 @@
 const waitingCOC = [
   {
-    title: 'Dublin TypeScript Meetup',
-    twitter: 'https://twitter.com/DubTypeScript',
-    url: 'https://www.meetup.com/Dublin-TypeScript-Meetup',
-    image: 'dublin-ts.jpg',
-    country: '🇮🇪',
+    title: "Dublin TypeScript Meetup",
+    twitter: "https://twitter.com/DubTypeScript",
+    url: "https://www.meetup.com/Dublin-TypeScript-Meetup",
+    image: "dublin-ts.jpg",
+    country: "🇮🇪"
   },
   {
-    title: 'London TypeScript Meetup',
-    twitter: 'https://twitter.com/LndTypeScript',
-    url: 'https://www.meetup.com/London-Typescript-Meetup',
-    image: 'london-ts.jpg',
-    country: '🇬🇧',
+    title: "London TypeScript Meetup",
+    twitter: "https://twitter.com/LndTypeScript",
+    url: "https://www.meetup.com/London-Typescript-Meetup",
+    image: "london-ts.jpg",
+    country: "🇬🇧"
   },
   {
-    title: 'Warsaw TypeScript',
-    twitter: 'https://twitter.com/wwatypescript',
-    url: 'https://www.meetup.com/Warsaw-Typescript',
-    image: 'warsaw-ts.jpg',
-    country: '🇵🇱',
-  },
+    title: "Warsaw TypeScript",
+    twitter: "https://twitter.com/wwatypescript",
+    url: "https://www.meetup.com/Warsaw-Typescript",
+    image: "warsaw-ts.jpg",
+    country: "🇵🇱"
+  }
 ]
 
 const meetups = [
   {
-    title: 'Hamburg TypeScript',
-    url: 'https://www.meetup.com/Hamburg-TypeScript-Meetup-Group',
-    image: 'hamburg-ts.png',
-    country: '🇩🇪',
-    continentish: 'Europe',
+    title: "Hamburg TypeScript",
+    url: "https://www.meetup.com/Hamburg-TypeScript-Meetup-Group",
+    image: "hamburg-ts.png",
+    country: "🇩🇪",
+    continentish: "Europe"
   },
   {
-    title: 'Krakow TypeScript User Group',
-    url: 'https://www.meetup.com/typescript-krakow',
-    image: 'ktug.jpg',
-    country: '🇵🇱',
-    continentish: 'Europe',
+    title: "Krakow TypeScript User Group",
+    url: "https://www.meetup.com/typescript-krakow",
+    image: "ktug.jpg",
+    country: "🇵🇱",
+    continentish: "Europe"
   },
   {
-    title: 'Melbourne TypeScript',
-    url: 'https://www.meetup.com/Melbourne-TypeScript-Meetup',
-    image: 'melbourne.jpg',
-    country: '🇦🇺',
-    continentish: 'Europe',
+    title: "Melbourne TypeScript",
+    url: "https://www.meetup.com/Melbourne-TypeScript-Meetup",
+    image: "melbourne.jpg",
+    country: "🇦🇺",
+    continentish: "Europe"
   },
   {
-    title: 'Milano TS',
-    twitter: 'https://twitter.com/Milano_TS',
-    url: 'https://www.meetup.com/MilanoTS/',
-    image: 'milano-ts.jpg',
-    country: '🇮🇹',
-    continentish: 'Europe',
+    title: "Milano TS",
+    twitter: "https://twitter.com/Milano_TS",
+    url: "https://www.meetup.com/MilanoTS/",
+    image: "milano-ts.jpg",
+    country: "🇮🇹",
+    continentish: "Europe"
   },
   {
-    title: 'Seattle TypeScript',
-    url: 'https://www.meetup.com/seattle-ts',
-    image: 'seattle.jpg',
-    country: '🇺🇸',
-    continentish: 'North America',
+    title: "Seattle TypeScript",
+    url: "https://www.meetup.com/seattle-ts",
+    image: "seattle.jpg",
+    country: "🇺🇸",
+    continentish: "North America"
   },
   {
-    title: 'Sevilla TypeScript',
-    twitter: 'https://twitter.com/SVQTypeScript',
-    url: 'https://www.meetup.com/Sevilla-TypeScript',
-    image: 'sqvts.jpg',
-    country: '🇪🇸',
-    continentish: 'Europe',
+    title: "Sevilla TypeScript",
+    twitter: "https://twitter.com/SVQTypeScript",
+    url: "https://www.meetup.com/Sevilla-TypeScript",
+    image: "sqvts.jpg",
+    country: "🇪🇸",
+    continentish: "Europe"
   },
   {
-    title: 'San Francisco TypeScript Meetup',
-    url: 'https://www.meetup.com/San-Francisco-TypeScript-Meetup',
-    image: 'san-fran-ts.jpg',
-    country: '🇺🇸',
-    continentish: 'North America',
+    title: "San Francisco TypeScript Meetup",
+    url: "https://www.meetup.com/San-Francisco-TypeScript-Meetup",
+    image: "san-fran-ts.jpg",
+    country: "🇺🇸",
+    continentish: "North America"
   },
   {
-    title: 'Sydney TypeScript',
-    twitter: 'https://twitter.com/SydTypeScript',
-    url: 'https://www.meetup.com/Sydney-TypeScript',
-    image: 'sydney.jpg',
-    country: '🇦🇺',
-    continentish: 'Australia',
+    title: "Sydney TypeScript",
+    twitter: "https://twitter.com/SydTypeScript",
+    url: "https://www.meetup.com/Sydney-TypeScript",
+    image: "sydney.jpg",
+    country: "🇦🇺",
+    continentish: "Australia"
   },
   {
-    title: 'TypeScript NYC',
-    url: 'https://www.meetup.com/TypeScriptNYC',
-    image: 'typescript-nyc.jpg',
-    country: '🇺🇸',
-    continentish: 'North America',
+    title: "TypeScript NYC",
+    url: "https://www.meetup.com/TypeScriptNYC",
+    image: "typescript-nyc.jpg",
+    country: "🇺🇸",
+    continentish: "North America"
   },
   {
-    title: 'Typescript Brazil Meetup',
-    twitter: 'https://twitter.com/tsbrmeetup',
-    url: 'https://www.meetup.com/typescriptbr',
-    image: 'brazil-ts.jpg',
-    country: '🇧🇷',
-    continentish: 'South America',
+    title: "TypeScript Brazil Meetup",
+    twitter: "https://twitter.com/tsbrmeetup",
+    url: "https://www.meetup.com/typescriptbr",
+    image: "brazil-ts.jpg",
+    country: "🇧🇷",
+    continentish: "South America"
   },
   {
-    title: 'TypeScript JP',
-    twitter: 'https://twitter.com/typescriptjp',
-    url: 'https://typescript-jp.dev',
-    image: 'typescript-jp.jpg',
-    country: '🇯🇵',
-    continentish: 'Asia',
+    title: "TypeScript JP",
+    twitter: "https://twitter.com/typescriptjp",
+    url: "https://typescript-jp.dev",
+    image: "typescript-jp.jpg",
+    country: "🇯🇵",
+    continentish: "Asia"
   },
   {
-    title: 'Paris TypeScript',
-    twitter: 'https://twitter.com/ParisTypeScript',
-    url: 'https://www.meetup.com/Paris-Typescript',
-    image: 'paris-ts.jpg',
-    country: '🇫🇷',
-    continentish: 'Europe',
+    title: "Paris TypeScript",
+    twitter: "https://twitter.com/ParisTypeScript",
+    url: "https://www.meetup.com/Paris-Typescript",
+    image: "paris-ts.jpg",
+    country: "🇫🇷",
+    continentish: "Europe"
   },
   {
-    title: 'Phoenix TypeScript',
-    url: 'https://www.meetup.com/Phoenix-TypeScript',
-    image: 'phx-ts.jpg',
-    country: '🇺🇸',
-    continentish: 'North America',
+    title: "Phoenix TypeScript",
+    url: "https://www.meetup.com/Phoenix-TypeScript",
+    image: "phx-ts.jpg",
+    country: "🇺🇸",
+    continentish: "North America"
   },
   {
-    title: 'Wroclaw TypeScript',
-    twitter: 'https://twitter.com/WrocTypeScript',
-    url: 'https://typescript.community/',
-    meetup: 'https://www.meetup.com/WrocTypeScript',
-    image: 'wroclaw-ts.jpg',
-    country: '🇵🇱',
-    continentish: 'Europe',
-  },
+    title: "Wroclaw TypeScript",
+    twitter: "https://twitter.com/WrocTypeScript",
+    url: "https://typescript.community/",
+    meetup: "https://www.meetup.com/WrocTypeScript",
+    image: "wroclaw-ts.jpg",
+    country: "🇵🇱",
+    continentish: "Europe"
+  }
 ]
 
 module.exports = {
   meetups,
-  waitingCOC,
+  waitingCOC
 }

--- a/packages/create-typescript-playground-plugin/template/.gitignore
+++ b/packages/create-typescript-playground-plugin/template/.gitignore
@@ -36,7 +36,7 @@ build/Release
 node_modules/
 jspm_packages/
 
-# Typescript v1 declaration files
+# TypeScript v1 declaration files
 typings/
 
 # Optional npm cache directory

--- a/packages/handbook-v1/en/JSDoc Supported Types.md
+++ b/packages/handbook-v1/en/JSDoc Supported Types.md
@@ -437,6 +437,8 @@ c.size;
 var result = C(1);
 ```
 
+> Note: Error messages only show up in JS codebases with [a JSConfig](/docs/handbook/tsconfig-json.html) and [`checkJs`](/tsconfig#checkJs) enabled.
+
 With `@constructor`, `this` is checked inside the constructor function `C`, so you will get suggestions for the `initialize` method and an error if you pass it a number. Your editor may also show warnings if you call `C` instead of constructing it.
 
 Unfortunately, this means that constructor functions that are also callable cannot use `@constructor`.
@@ -490,13 +492,13 @@ Note that `@enum` is quite different from, and much simpler than, TypeScript's `
 
 ```js twoslash
 /** @enum {function(number): number} */
-const Math = {
+const MathFuncs = {
   add1: n => n + 1,
   id: n => -n,
   sub1: n => n - 1
 };
 
-Math.add1;
+MathFuncs.add1;
 ```
 
 ## More examples

--- a/packages/handbook-v1/en/JSDoc Supported Types.md
+++ b/packages/handbook-v1/en/JSDoc Supported Types.md
@@ -2,7 +2,7 @@
 title: JSDoc Supported Types
 layout: docs
 permalink: /docs/handbook/jsdoc-supported-types.html
-oneline: Using JSDoc with TypeScript
+oneline: Using JSDoc with TypeScript-powered JavaScript
 ---
 
 The list below outlines which constructs are currently supported
@@ -29,9 +29,9 @@ The code below describes the differences and gives some example usage of each ta
 ## `@type`
 
 You can use the "@type" tag and reference a type name (either primitive, defined in a TypeScript declaration, or in a JSDoc "@typedef" tag).
-You can use any Typescript type, and most JSDoc types.
+You can use any TypeScript type, and most JSDoc types.
 
-```js
+```js twoslash
 /**
  * @type {string}
  */
@@ -51,7 +51,7 @@ element.dataset.myData = "";
 
 `@type` can specify a union type &mdash; for example, something can be either a string or a boolean.
 
-```js
+```js twoslash
 /**
  * @type {(string | boolean)}
  */
@@ -60,7 +60,7 @@ var sb;
 
 Note that parentheses are optional for union types.
 
-```js
+```js twoslash
 /**
  * @type {string | boolean}
  */
@@ -69,7 +69,7 @@ var sb;
 
 You can specify array types using a variety of syntaxes:
 
-```js
+```js twoslash
 /** @type {number[]} */
 var ns;
 /** @type {Array.<number>} */
@@ -81,14 +81,14 @@ var nas;
 You can also specify object literal types.
 For example, an object with properties 'a' (string) and 'b' (number) uses the following syntax:
 
-```js
+```js twoslash
 /** @type {{ a: string, b: number }} */
 var var9;
 ```
 
-You can specify map-like and array-like objects using string and number index signatures, using either standard JSDoc syntax or Typescript syntax.
+You can specify map-like and array-like objects using string and number index signatures, using either standard JSDoc syntax or TypeScript syntax.
 
-```js
+```js twoslash
 /**
  * A map-like object that maps arbitrary `string` properties to `number`s.
  *
@@ -100,20 +100,20 @@ var stringToNumber;
 var arrayLike;
 ```
 
-The preceding two types are equivalent to the Typescript types `{ [x: string]: number }` and `{ [x: number]: any }`. The compiler understands both syntaxes.
+The preceding two types are equivalent to the TypeScript types `{ [x: string]: number }` and `{ [x: number]: any }`. The compiler understands both syntaxes.
 
-You can specify function types using either Typescript or Closure syntax:
+You can specify function types using either TypeScript or Closure syntax:
 
-```js
+```js twoslash
 /** @type {function(string, boolean): number} Closure syntax */
 var sbn;
-/** @type {(s: string, b: boolean) => number} Typescript syntax */
+/** @type {(s: string, b: boolean) => number} TypeScript syntax */
 var sbn2;
 ```
 
 Or you can just use the unspecified `Function` type:
 
-```js
+```js twoslash
 /** @type {Function} */
 var fn7;
 /** @type {function} */
@@ -122,7 +122,7 @@ var fn6;
 
 Other types from Closure also work:
 
-```js
+```js twoslash
 /**
  * @type {*} - can be 'any' type
  */
@@ -135,10 +135,10 @@ var question;
 
 ### Casts
 
-Typescript borrows cast syntax from Closure.
+TypeScript borrows cast syntax from Closure.
 This lets you cast types to other types by adding a `@type` tag before any parenthesized expression.
 
-```js
+```js twoslash
 /**
  * @type {number | string}
  */
@@ -149,11 +149,17 @@ var typeAssertedNumber = /** @type {number} */ (numberOrString);
 ### Import types
 
 You can also import declarations from other files using import types.
-This syntax is Typescript-specific and differs from the JSDoc standard:
+This syntax is TypeScript-specific and differs from the JSDoc standard:
 
-```js
+```js twoslash
+// @filename: types.d.ts
+export type Pet = {
+  name: string
+};
+
+// @filename: main.js
 /**
- * @param p { import("./a").Pet }
+ * @param p { import("./types").Pet }
  */
 function walk(p) {
   console.log(`Walking ${p.name}...`);
@@ -162,9 +168,15 @@ function walk(p) {
 
 import types can also be used in type alias declarations:
 
-```js
+```js twoslash
+// @filename: types.d.ts
+export type Pet = {
+  name: string
+};
+// @filename: main.js
+// ---cut---
 /**
- * @typedef { import("./a").Pet } Pet
+ * @typedef { import("./types").Pet } Pet
  */
 
 /**
@@ -176,11 +188,24 @@ myPet.name;
 
 import types can be used to get the type of a value from a module if you don't know the type, or if it has a large type that is annoying to type:
 
-```js
+```js twoslash
+// @filename: types.d.ts
+export const userAccount = {
+  name: "Name",
+  address: "An address",
+  postalCode: "",
+  country: "",
+  planet: "",
+  system: "",
+  galaxy: "",
+  universe: ""
+};
+// @filename: main.js
+// ---cut---
 /**
- * @type {typeof import("./a").x }
+ * @type {typeof import("./types").userAccount }
  */
-var x = require("./a").x;
+var x = require("./a").userAccount;
 ```
 
 ## `@param` and `@returns`
@@ -188,7 +213,7 @@ var x = require("./a").x;
 `@param` uses the same type syntax as `@type`, but adds a parameter name.
 The parameter may also be declared optional by surrounding the name with square brackets:
 
-```js
+```js twoslash
 // Parameters may be declared in a variety of syntactic forms
 /**
  * @param {string}  p1 - A string param.
@@ -204,7 +229,7 @@ function stringsStringStrings(p1, p2, p3, p4) {
 
 Likewise, for the return type of a function:
 
-```js
+```js twoslash
 /**
  * @return {PromiseLike<string>}
  */
@@ -221,7 +246,7 @@ function ab() {}
 `@typedef` may be used to define complex types.
 Similar syntax works with `@param`.
 
-```js
+```js twoslash
 /**
  * @typedef {Object} SpecialType - creates a new type named 'SpecialType'
  * @property {string} prop1 - a string property of SpecialType
@@ -230,19 +255,22 @@ Similar syntax works with `@param`.
  * @prop {number} [prop4] - an optional number property of SpecialType
  * @prop {number} [prop5=42] - an optional number property of SpecialType with default
  */
+
 /** @type {SpecialType} */
 var specialTypeObject;
+specialTypeObject.prop3;
 ```
 
 You can use either `object` or `Object` on the first line.
 
-```js
+```js twoslash
 /**
  * @typedef {object} SpecialType1 - creates a new type named 'SpecialType'
  * @property {string} prop1 - a string property of SpecialType
  * @property {number} prop2 - a number property of SpecialType
  * @property {number=} prop3 - an optional number property of SpecialType
  */
+
 /** @type {SpecialType1} */
 var specialTypeObject1;
 ```
@@ -250,7 +278,7 @@ var specialTypeObject1;
 `@param` allows a similar syntax for one-off type specifications.
 Note that the nested property names must be prefixed with the name of the parameter:
 
-```js
+```js twoslash
 /**
  * @param {Object} options - The shape is the same as SpecialType above
  * @param {string} options.prop1
@@ -266,18 +294,19 @@ function special(options) {
 
 `@callback` is similar to `@typedef`, but it specifies a function type instead of an object type:
 
-```js
+```js twoslash
 /**
  * @callback Predicate
  * @param {string} data
  * @param {number} [index]
  * @returns {boolean}
  */
+
 /** @type {Predicate} */
 const ok = s => !(s.length % 2);
 ```
 
-Of course, any of these types can be declared using Typescript syntax in a single-line `@typedef`:
+Of course, any of these types can be declared using TypeScript syntax in a single-line `@typedef`:
 
 ```js
 /** @typedef {{ prop1: string, prop2: string, prop3?: number }} SpecialType */
@@ -288,15 +317,19 @@ Of course, any of these types can be declared using Typescript syntax in a singl
 
 You can declare generic functions with the `@template` tag:
 
-```js
+```js twoslash
 /**
  * @template T
- * @param {T} p1 - A generic parameter that flows through to the return type
+ * @param {T} x - A generic parameter that flows through to the return type
  * @return {T}
  */
 function id(x) {
   return x;
 }
+
+const a = id("string");
+const b = id(123);
+const c = id({});
 ```
 
 Use comma or multiple tags to declare multiple type parameters:
@@ -311,7 +344,7 @@ Use comma or multiple tags to declare multiple type parameters:
 You can also specify a type constraint before the type parameter name.
 Only the first type parameter in a list is constrained:
 
-```js
+```js twoslash
 /**
  * @template {string} K - K must be a string or string literal
  * @template {{ serious(): string }} Seriousalizable - must have a serious method
@@ -329,7 +362,7 @@ Declaring generic classes or types is unsupported.
 
 Classes can be declared as ES6 classes.
 
-```js
+```js twoslash
 class C {
   /**
    * @param {number} data
@@ -357,7 +390,11 @@ class C {
 }
 
 var c = new C(0);
-var result = C(1); // C should only be called with new
+
+// C should only be called with new, but
+// because it is JavaScript, this is allowed and
+// considered an 'any'.
+var result = C(1);
 ```
 
 They can also be declared as constructor functions, as described in the next section:
@@ -366,7 +403,9 @@ They can also be declared as constructor functions, as described in the next sec
 
 The compiler infers constructor functions based on this-property assignments, but you can make checking stricter and suggestions better if you add a `@constructor` tag:
 
-```js
+```js twoslash
+// @checkJs
+// @errors: 2345 2348
 /**
  * @constructor
  * @param {number} data
@@ -383,7 +422,7 @@ function C(data) {
   /** @type {number} */
   this.size;
 
-  this.initialize(data); // Should error, initializer expects a string
+  this.initialize(data);
 }
 /**
  * @param {string} s
@@ -393,10 +432,12 @@ C.prototype.initialize = function(s) {
 };
 
 var c = new C(0);
-var result = C(1); // C should only be called with new
+c.size;
+
+var result = C(1);
 ```
 
-With `@constructor`, `this` is checked inside the constructor function `C`, so you will get suggestions for the `initialize` method and an error if you pass it a number. You will also get an error if you call `C` instead of constructing it.
+With `@constructor`, `this` is checked inside the constructor function `C`, so you will get suggestions for the `initialize` method and an error if you pass it a number. Your editor may also show warnings if you call `C` instead of constructing it.
 
 Unfortunately, this means that constructor functions that are also callable cannot use `@constructor`.
 
@@ -404,7 +445,7 @@ Unfortunately, this means that constructor functions that are also callable cann
 
 The compiler can usually figure out the type of `this` when it has some context to work with. When it doesn't, you can explicitly specify the type of `this` with `@this`:
 
-```js
+```js twoslash
 /**
  * @this {HTMLElement}
  * @param {*} e
@@ -418,7 +459,7 @@ function callbackForLater(e) {
 
 When Javascript classes extend a generic base class, there is nowhere to specify what the type parameter should be. The `@extends` tag provides a place for that type parameter:
 
-```js
+```js twoslash
 /**
  * @template T
  * @extends {Set<T>}
@@ -434,29 +475,35 @@ Note that `@extends` only works with classes. Currently, there is no way for a c
 
 The `@enum` tag allows you to create an object literal whose members are all of a specified type. Unlike most object literals in Javascript, it does not allow other members.
 
-```js
+```js twoslash
 /** @enum {number} */
 const JSDocState = {
   BeginningOfLine: 0,
   SawAsterisk: 1,
   SavingComments: 2
 };
+
+JSDocState.SawAsterisk;
 ```
 
-Note that `@enum` is quite different from, and much simpler than, Typescript's `enum`. However, unlike Typescript's enums, `@enum` can have any type:
+Note that `@enum` is quite different from, and much simpler than, TypeScript's `enum`. However, unlike TypeScript's enums, `@enum` can have any type:
 
-```js
+```js twoslash
 /** @enum {function(number): number} */
 const Math = {
   add1: n => n + 1,
   id: n => -n,
   sub1: n => n - 1
 };
+
+Math.add1;
 ```
 
 ## More examples
 
-```js
+```js twoslash
+class Foo {}
+// ---cut---
 var someObj = {
   /**
    * @param {string} param1 - Docs on property assignments work
@@ -512,7 +559,7 @@ function fn9(p1) {
 
 Referring to objects in the value space as types doesn't work unless the object also creates a type, like a constructor function.
 
-```js
+```js twoslash
 function aNormalFunction() {}
 /**
  * @type {aNormalFunction}
@@ -527,7 +574,7 @@ var right;
 
 Postfix equals on a property type in an object literal type doesn't specify an optional property:
 
-```js
+```js twoslash
 /**
  * @type {{ a: string, b: number= }}
  */
@@ -541,7 +588,7 @@ var right;
 
 Nullable types only have meaning if `strictNullChecks` is on:
 
-```js
+```js twoslash
 /**
  * @type {?number}
  * With strictNullChecks: true  -- number | null
@@ -552,7 +599,7 @@ var nullable;
 
 You can also use a union type:
 
-```js
+```js twoslash
 /**
  * @type {number | null}
  * With strictNullChecks: true  -- number | null
@@ -563,7 +610,7 @@ var unionNullable;
 
 Non-nullable types have no meaning and are treated just as their original type:
 
-```js
+```js twoslash
 /**
  * @type {!number}
  * Just has type number
@@ -571,7 +618,7 @@ Non-nullable types have no meaning and are treated just as their original type:
 var normal;
 ```
 
-Unlike JSDoc's type system, Typescript only allows you to mark types as containing null or not.
+Unlike JSDoc's type system, TypeScript only allows you to mark types as containing null or not.
 There is no explicit non-nullability -- if strictNullChecks is on, then `number` is not nullable.
 If it is off, then `number` is nullable.
 

--- a/packages/handbook-v1/en/JSDoc Supported Types.md
+++ b/packages/handbook-v1/en/JSDoc Supported Types.md
@@ -189,7 +189,7 @@ myPet.name;
 import types can be used to get the type of a value from a module if you don't know the type, or if it has a large type that is annoying to type:
 
 ```js twoslash
-// @filename: types.d.ts
+// @filename: accounts.d.ts
 export const userAccount = {
   name: "Name",
   address: "An address",
@@ -203,9 +203,9 @@ export const userAccount = {
 // @filename: main.js
 // ---cut---
 /**
- * @type {typeof import("./types").userAccount }
+ * @type {typeof import("./accounts").userAccount }
  */
-var x = require("./a").userAccount;
+var x = require("./accounts").userAccount;
 ```
 
 ## `@param` and `@returns`

--- a/packages/handbook-v1/en/Type Checking JavaScript Files.md
+++ b/packages/handbook-v1/en/Type Checking JavaScript Files.md
@@ -16,7 +16,7 @@ Here are some notable differences on how checking works in `.js` files compared 
 
 In a `.js` file, types can often be inferred just like in `.ts` files.
 Likewise, when types can't be inferred, they can be specified using JSDoc the same way that type annotations are used in a `.ts` file.
-Just like Typescript, `--noImplicitAny` will give you errors on the places that the compiler could not infer a type.
+Just like TypeScript, `--noImplicitAny` will give you errors on the places that the compiler could not infer a type.
 (With the exception of open-ended object literals; see below for details.)
 
 JSDoc annotations adorning a declaration will be used to set the type of that declaration. For example:
@@ -87,7 +87,7 @@ function C() {
   this.constructorOnly = 0;
   this.constructorUnknown = undefined;
 }
-C.prototype.method = function () {
+C.prototype.method = function() {
   this.constructorOnly = false; // error
   this.constructorUnknown = "plunkbat"; // OK, the type is string | undefined
 };
@@ -95,7 +95,7 @@ C.prototype.method = function () {
 
 ## CommonJS modules are supported
 
-In a `.js` file, Typescript understands the CommonJS module format.
+In a `.js` file, TypeScript understands the CommonJS module format.
 Assignments to `exports` and `module.exports` are recognized as export declarations.
 Similarly, `require` function calls are recognized as module imports. For example:
 
@@ -104,12 +104,12 @@ Similarly, `require` function calls are recognized as module imports. For exampl
 const fs = require("fs");
 
 // same as `export function readFile`
-module.exports.readFile = function (f) {
+module.exports.readFile = function(f) {
   return fs.readFileSync(f);
 };
 ```
 
-The module support in Javascript is much more syntactically forgiving than Typescript's module support.
+The module support in Javascript is much more syntactically forgiving than TypeScript's module support.
 Most combinations of assignments and declarations are supported.
 
 ## Classes, functions, and object literals are namespaces
@@ -128,7 +128,7 @@ And, for pre-ES2015 code, it can be used to simulate static methods:
 function Outer() {
   this.y = 2;
 }
-Outer.Inner = function () {
+Outer.Inner = function() {
   this.yy = 2;
 };
 ```
@@ -138,14 +138,14 @@ It can also be used to create simple namespaces:
 ```js
 var ns = {};
 ns.C = class {};
-ns.func = function () {};
+ns.func = function() {};
 ```
 
 Other variants are allowed as well:
 
 ```js
 // IIFE
-var ns = (function (n) {
+var ns = (function(n) {
   return n || {};
 })();
 ns.CONST = 1;
@@ -153,7 +153,7 @@ ns.CONST = 1;
 // defaulting to global
 var assign =
   assign ||
-  function () {
+  function() {
     // code goes here
   };
 assign.extra = 1;
@@ -337,7 +337,7 @@ The code below describes the differences and gives some example usage of each ta
 ## `@type`
 
 You can use the "@type" tag and reference a type name (either primitive, defined in a TypeScript declaration, or in a JSDoc "@typedef" tag).
-You can use any Typescript type, and most JSDoc types.
+You can use any TypeScript type, and most JSDoc types.
 
 ```js
 /**
@@ -394,7 +394,7 @@ For example, an object with properties 'a' (string) and 'b' (number) uses the fo
 var var9;
 ```
 
-You can specify map-like and array-like objects using string and number index signatures, using either standard JSDoc syntax or Typescript syntax.
+You can specify map-like and array-like objects using string and number index signatures, using either standard JSDoc syntax or TypeScript syntax.
 
 ```js
 /**
@@ -408,14 +408,14 @@ var stringToNumber;
 var arrayLike;
 ```
 
-The preceding two types are equivalent to the Typescript types `{ [x: string]: number }` and `{ [x: number]: any }`. The compiler understands both syntaxes.
+The preceding two types are equivalent to the TypeScript types `{ [x: string]: number }` and `{ [x: number]: any }`. The compiler understands both syntaxes.
 
-You can specify function types using either Typescript or Closure syntax:
+You can specify function types using either TypeScript or Closure syntax:
 
 ```js
 /** @type {function(string, boolean): number} Closure syntax */
 var sbn;
-/** @type {(s: string, b: boolean) => number} Typescript syntax */
+/** @type {(s: string, b: boolean) => number} TypeScript syntax */
 var sbn2;
 ```
 
@@ -443,7 +443,7 @@ var question;
 
 ### Casts
 
-Typescript borrows cast syntax from Closure.
+TypeScript borrows cast syntax from Closure.
 This lets you cast types to other types by adding a `@type` tag before any parenthesized expression.
 
 ```js
@@ -457,7 +457,7 @@ var typeAssertedNumber = /** @type {number} */ (numberOrString);
 ### Import types
 
 You can also import declarations from other files using import types.
-This syntax is Typescript-specific and differs from the JSDoc standard:
+This syntax is TypeScript-specific and differs from the JSDoc standard:
 
 ```js
 /**
@@ -582,10 +582,10 @@ function special(options) {
  * @returns {boolean}
  */
 /** @type {Predicate} */
-const ok = (s) => !(s.length % 2);
+const ok = s => !(s.length % 2);
 ```
 
-Of course, any of these types can be declared using Typescript syntax in a single-line `@typedef`:
+Of course, any of these types can be declared using TypeScript syntax in a single-line `@typedef`:
 
 ```js
 /** @typedef {{ prop1: string, prop2: string, prop3?: number }} SpecialType */
@@ -647,7 +647,7 @@ function C(data) {
 /**
  * @param {string} s
  */
-C.prototype.initialize = function (s) {
+C.prototype.initialize = function(s) {
   this.size = s.length;
 };
 
@@ -698,18 +698,18 @@ The `@enum` tag allows you to create an object literal whose members are all of 
 const JSDocState = {
   BeginningOfLine: 0,
   SawAsterisk: 1,
-  SavingComments: 2,
+  SavingComments: 2
 };
 ```
 
-Note that `@enum` is quite different from, and much simpler than, Typescript's `enum`. However, unlike Typescript's enums, `@enum` can have any type:
+Note that `@enum` is quite different from, and much simpler than, TypeScript's `enum`. However, unlike TypeScript's enums, `@enum` can have any type:
 
 ```js
 /** @enum {function(number): number} */
 const Math = {
-  add1: (n) => n + 1,
-  id: (n) => -n,
-  sub1: (n) => n - 1,
+  add1: n => n + 1,
+  id: n => -n,
+  sub1: n => n - 1
 };
 ```
 
@@ -720,32 +720,32 @@ var someObj = {
   /**
    * @param {string} param1 - Docs on property assignments work
    */
-  x: function (param1) {},
+  x: function(param1) {}
 };
 
 /**
  * As do docs on variable assignments
  * @return {Window}
  */
-let someFunc = function () {};
+let someFunc = function() {};
 
 /**
  * And class methods
  * @param {string} greeting The greeting to use
  */
-Foo.prototype.sayHi = (greeting) => console.log("Hi!");
+Foo.prototype.sayHi = greeting => console.log("Hi!");
 
 /**
  * And arrow functions expressions
  * @param {number} x - A multiplier
  */
-let myArrow = (x) => x * x;
+let myArrow = x => x * x;
 
 /**
  * Which means it works for stateless function components in JSX too
  * @param {{a: string, b: number}} test - Some param
  */
-var fc = (test) => <div>{test.a.charAt(0)}</div>;
+var fc = test => <div>{test.a.charAt(0)}</div>;
 
 /**
  * A parameter can be a class constructor, using Closure syntax.
@@ -819,6 +819,6 @@ Non-nullable types have no meaning and are treated just as their original type:
 var normal;
 ```
 
-Unlike JSDoc's type system, Typescript only allows you to mark types as containing null or not.
+Unlike JSDoc's type system, TypeScript only allows you to mark types as containing null or not.
 There is no explicit non-nullability -- if strictNullChecks is on, then `number` is not nullable.
 If it is off, then `number` is nullable.

--- a/packages/handbook-v1/en/release notes/Overview.md
+++ b/packages/handbook-v1/en/release notes/Overview.md
@@ -7569,7 +7569,7 @@ if (fso.isFile()) {
 
 ## Official TypeScript NuGet package
 
-Starting with TypeScript 1.8, official NuGet packages are available for the Typescript Compiler (`tsc.exe`) as well as the MSBuild integration (`Microsoft.TypeScript.targets` and `Microsoft.TypeScript.Tasks.dll`).
+Starting with TypeScript 1.8, official NuGet packages are available for the TypeScript Compiler (`tsc.exe`) as well as the MSBuild integration (`Microsoft.TypeScript.targets` and `Microsoft.TypeScript.Tasks.dll`).
 
 Stable packages are available here:
 

--- a/packages/handbook-v1/en/release notes/TypeScript 1.8.md
+++ b/packages/handbook-v1/en/release notes/TypeScript 1.8.md
@@ -508,7 +508,7 @@ if (fso.isFile()) {
 
 ## Official TypeScript NuGet package
 
-Starting with TypeScript 1.8, official NuGet packages are available for the Typescript Compiler (`tsc.exe`) as well as the MSBuild integration (`Microsoft.TypeScript.targets` and `Microsoft.TypeScript.Tasks.dll`).
+Starting with TypeScript 1.8, official NuGet packages are available for the TypeScript Compiler (`tsc.exe`) as well as the MSBuild integration (`Microsoft.TypeScript.targets` and `Microsoft.TypeScript.Tasks.dll`).
 
 Stable packages are available here:
 

--- a/packages/handbook-v1/en/tutorials/Gulp.md
+++ b/packages/handbook-v1/en/tutorials/Gulp.md
@@ -61,7 +61,7 @@ npm install -g gulp-cli
 ```
 
 Then install `typescript`, `gulp` and `gulp-typescript` in your project's dev dependencies.
-[Gulp-typescript](https://www.npmjs.com/package/gulp-typescript) is a gulp plugin for Typescript.
+[Gulp-typescript](https://www.npmjs.com/package/gulp-typescript) is a gulp plugin for TypeScript.
 
 ```shell
 npm install --save-dev typescript gulp@4.0.0 gulp-typescript

--- a/packages/handbook-v1/en/tutorials/TS for Functional Programmers.md
+++ b/packages/handbook-v1/en/tutorials/TS for Functional Programmers.md
@@ -67,7 +67,7 @@ TypeScript has corresponding primitive types for the built-in types:
 - `undefined`
 - `object`
 
-### Other important Typescript types
+### Other important TypeScript types
 
 | Type           | Explanation                                                 |
 | -------------- | ----------------------------------------------------------- |

--- a/packages/handbook-v1/en/tutorials/tsconfig.json.md
+++ b/packages/handbook-v1/en/tutorials/tsconfig.json.md
@@ -10,9 +10,11 @@ oneline: Learn about how a TSConfig works
 The presence of a `tsconfig.json` file in a directory indicates that the directory is the root of a TypeScript project.
 The `tsconfig.json` file specifies the root files and the compiler options required to compile the project.
 
+JavaScript projects can use a `jsconfig.json` file instead, which acts almost the same but has some JavaScript-related compiler flags enabled by default.
+
 A project is compiled in one of the following ways:
 
-## Using `tsconfig.json`
+## Using `tsconfig.json` or `jsconfig.json`
 
 - By invoking tsc with no input files, in which case the compiler searches for the `tsconfig.json` file starting in the current directory and continuing up the parent directory chain.
 - By invoking tsc with no input files and a `--project` (or just `-p`) command line option that specifies the path of a directory containing a `tsconfig.json` file, or a path to a valid `.json` file containing the configurations.

--- a/packages/handbook-v1/scripts/handbookAttribution.json
+++ b/packages/handbook-v1/scripts/handbookAttribution.json
@@ -412,8 +412,8 @@
   "pages/JSDoc Supported Types.md": {
     "top": [
       {
-        "name": "Orta Therox",
-        "gravatar": "f116cb3be23153ec08b94e8bd4dbcfeb",
+        "name": "Nathan Shively-Sanders",
+        "gravatar": "8c5596e6ef2b41132cee585c9b146116",
         "count": 52
       }
     ],

--- a/packages/typescriptlang-org/.gitignore
+++ b/packages/typescriptlang-org/.gitignore
@@ -36,7 +36,7 @@ build/Release
 node_modules/
 jspm_packages/
 
-# Typescript v1 declaration files
+# TypeScript v1 declaration files
 typings/
 
 # Optional npm cache directory

--- a/packages/typescriptlang-org/src/lib/handbookNavigation.ts
+++ b/packages/typescriptlang-org/src/lib/handbookNavigation.ts
@@ -68,6 +68,7 @@ export const handbookNavigation: NavItem[] = [
       { id: "decorators", title: "Decorators" },
       { id: "utility-types", title: "Global Utility Types" },
       { id: "iterators-and-generators", title: "Iterators and Generators" },
+      { id: "jsdoc-supported-types", title: "JSDoc Supported Types" },
       { id: "jsx", title: "JSX" },
       { id: "mixins", title: "Mixins" },
       { id: "modules", title: "Modules" },


### PR DESCRIPTION
and converts "Typescript" to "TypeScript" everywhere 