### PR TITLE
Incorrect description fixed

### DIFF
--- a/Examples/en/TypeScript/Primitives/Union and Intersection Types.ts
+++ b/Examples/en/TypeScript/Primitives/Union and Intersection Types.ts
@@ -71,10 +71,14 @@ type CreateArtistBioRequest
    = CreateArtistBioBase & { html: string } | { markdown: string }
 
 // Now you can only create a request when you include
-// artistID and either html or markdown
+// either (or both) artistID and html, or markdown
 
-const workingRequest: CreateArtistBioRequest = {
+const workingRequestArtist: CreateArtistBioRequest = {
   artistID: "banksy",
+  html: "https://www.banksy.co.uk/"
+}
+
+const workingRequestMarkdown: CreateArtistBioRequest = {
   markdown: "Banksy is an anonymous England-based graffiti artist..."
 }
 


### PR DESCRIPTION
The description was wrong, it didn't follow the precedence rules of logical operators: 
https://www.c-sharpcorner.com/UploadFile/c63ec5/precedence-and-associativity-of-logical-operators-in-typescr/

I updated the examples as well to make my point clearer


Alternative solution would be to add parentheses and change the type to:

type CreateArtistBioRequest
   = CreateArtistBioBase & ({ html: string } | { markdown: string })