### PR TITLE
Dispatch is no longer part of the react-redux library

### DIFF
--- a/packages/handbook-v1/en/tutorials/React.md
+++ b/packages/handbook-v1/en/tutorials/React.md
@@ -514,7 +514,8 @@ Let's create a file named `src/containers/Hello.tsx` and start off with the foll
 import Hello from "../components/Hello";
 import * as actions from "../actions/";
 import { StoreState } from "../types/index";
-import { connect, Dispatch } from "react-redux";
+import { Dispatch } from 'redux';
+import { connect } from 'react-redux';
 ```
 
 The real two key pieces here are the original `Hello` component as well as the `connect` function from react-redux.


### PR DESCRIPTION
The Dispatch symbol is no longer exported from react-redux, instead import it directly from redux.