### PR TITLE
fix: Remove debugger calls

### DIFF
--- a/packages/sandbox/src/typeAcquisition.ts
+++ b/packages/sandbox/src/typeAcquisition.ts
@@ -23,7 +23,6 @@ const packageJSONURL = (name: string) => unpkgURL(name, "package.json")
 
 const errorMsg = (msg: string, response: any, config: ATAConfig) => {
   config.logger.error(`${msg} - will not try again in this session`, response.status, response.statusText, response)
-  debugger
 }
 
 /**

--- a/packages/typescriptlang-org/src/pages/dev/twoslash.tsx
+++ b/packages/typescriptlang-org/src/pages/dev/twoslash.tsx
@@ -47,7 +47,6 @@ const Index: React.FC<Props> = (props) => {
         re(["vs/language/typescript/lib/typescriptServices"], async (_ts) => {
           const ts = (global as any).ts
           const isOK = main && ts && sandboxEnv
-          debugger
 
           if (isOK) {
             document.getElementById("loader")!.parentNode?.removeChild(document.getElementById("loader")!)


### PR DESCRIPTION
The playground `debugger` gets in my way frequently since I like to keep devtools open while in the playground and this triggers on almost every character typed when importing modules. The twoslash call was removed for completeness.