### PR TITLE
Adds unknown as a basic type in place of any and cautions against using any.

### DIFF
--- a/packages/handbook-v1/en/Basic Types.md
+++ b/packages/handbook-v1/en/Basic Types.md
@@ -175,45 +175,36 @@ let colorName: string = Color[2];
 console.log(colorName); // Displays 'Green' as its value is 2 above
 ```
 
-# Any
+# Unknown
 
 We may need to describe the type of variables that we do not know when we are writing an application.
 These values may come from dynamic content, e.g. from the user or a 3rd party library.
-In these cases, we want to opt-out of type checking and let the values pass through compile-time checks.
-To do so, we label these with the `any` type:
+In these cases, we want to provide a type that tells the compiler and future readers that this variable could be anything so we give it the `unknown` type.
 
 ```ts twoslash
-let notSure: any = 4;
+let notSure: unknown = 4;
 notSure = "maybe a string instead";
 notSure = false; // okay, definitely a boolean
 ```
 
-The `any` type is a powerful way to work with existing JavaScript, allowing you to gradually opt-in and opt-out of type checking during compilation.
-You might expect `Object` to play a similar role, as it does in other languages.
-However, variables of type `Object` only allow you to assign any value to them. You can't call arbitrary methods on them, even ones that actually exist:
+If you have a variable with an unknown type, you can narrow it to something more specific by doing `typeof` checks, comparison checks, or more advanced type guards that will be discussed in a later chapter:
 
 ```ts twoslash
-// @errors: 2339
-let notSure: any = 4;
-notSure.ifItExists(); // okay, ifItExists might exist at runtime
-notSure.toFixed(); // okay, toFixed exists (but the compiler doesn't check)
-
-let prettySure: Object = 4;
-prettySure.toFixed(); // Error: Property 'toFixed' doesn't exist on type 'Object'.
-```
-
-The `any` type is also handy if you know some part of the type, but perhaps not all of it.
-For example, you may have an array but the array has a mix of different types:
-
-```ts twoslash
-let list: any[] = [1, true, "free"];
-
-list[1] = 100;
+declare const maybe: unknown
+const aNumber: number = maybe // error, 'maybe' could be a string, object, boolean, undefined, or an array
+if (maybe === true) {
+  const aBoolean: boolean = maybe // ok
+  const aString: string = maybe // error, 'maybe' is definitely a boolean, so definitely NOT a string
+}
+if (typeof maybe === 'string') {
+  const aString: string = maybe // ok
+  const aBoolean: boolean = maybe // error, 'maybe' is definitely a string, so definitely NOT a boolean
+}
 ```
 
 # Void
 
-`void` is a little like the opposite of `any`: the absence of having any type at all.
+`void` is the absence of having any type at all.
 You may commonly see this as the return type of functions that do not return a value:
 
 ```ts twoslash
@@ -244,7 +235,7 @@ let n: null = null;
 By default `null` and `undefined` are subtypes of all other types.
 That means you can assign `null` and `undefined` to something like `number`.
 
-However, when using the `--strictNullChecks` flag, `null` and `undefined` are only assignable to `any` and their respective types (the one exception being that `undefined` is also assignable to `void`).
+However, when using the `--strictNullChecks` flag, `null` and `undefined` are only assignable to `unknown` and their respective types (the one exception being that `undefined` is also assignable to `void`).
 This helps avoid _many_ common errors.
 In cases where you want to pass in either a `string` or `null` or `undefined`, you can use the union type `string | null | undefined`.
 
@@ -264,7 +255,7 @@ Even `any` isn't assignable to `never`.
 Some examples of functions returning `never`:
 
 ```ts twoslash
-// Function returning never must have unreachable end point
+// Function returning never must not have any reachable end point
 function error(message: string): never {
   throw new Error(message);
 }
@@ -274,7 +265,7 @@ function fail() {
   return error("Something failed");
 }
 
-// Function returning never must have unreachable end point
+// Function returning never must not have a reachable end point
 function infiniteLoop(): never {
   while (true) {}
 }
@@ -298,6 +289,25 @@ create("string"); // Error
 create(false); // Error
 create(undefined); // Error
 ```
+
+# Any
+
+In some situations, you may want to tell the TypeScript compiler to turn off type checking for a variable entirely.  Normally, this is a bad idea because you will lose all type safety, but sometimes it can make sense such as when converting a JavaScript application into TypeScript and you need to get things compiling while you slowly work on improving type safety of your application over time.
+You might expect `Object` to play a similar role, as it does in other languages.
+However, variables of type `Object` only allow you to assign any value to them. You can't call arbitrary methods on them, even ones that actually exist:
+
+```ts twoslash
+// @errors: 2339
+let notSure: any = 4;
+notSure.ifItExists(); // okay, ifItExists might exist at runtime
+notSure.toFixed(); // okay, toFixed exists (but the compiler doesn't check)
+
+let prettySure: Object = 4;
+prettySure.toFixed(); // Error: Property 'toFixed' doesn't exist on type 'Object'.
+```
+
+In general, you should try to avoid the `any` type if you can and instead use `unknown` for variables that you don't know the type of at compile time, or the more advanced Mapped Types and Index Types which will be discussed in a later chapter.
+
 
 # Type assertions
 

--- a/packages/handbook-v1/en/Basic Types.md
+++ b/packages/handbook-v1/en/Basic Types.md
@@ -190,6 +190,7 @@ notSure = false; // okay, definitely a boolean
 If you have a variable with an unknown type, you can narrow it to something more specific by doing `typeof` checks, comparison checks, or more advanced type guards that will be discussed in a later chapter:
 
 ```ts twoslash
+// @errors: 2322 2322 2322
 declare const maybe: unknown
 const aNumber: number = maybe // error, 'maybe' could be a string, object, boolean, undefined, or an array
 if (maybe === true) {

--- a/packages/handbook-v1/en/Basic Types.md
+++ b/packages/handbook-v1/en/Basic Types.md
@@ -236,7 +236,7 @@ let n: null = null;
 By default `null` and `undefined` are subtypes of all other types.
 That means you can assign `null` and `undefined` to something like `number`.
 
-However, when using the `--strictNullChecks` flag, `null` and `undefined` are only assignable to `unknown` and their respective types (the one exception being that `undefined` is also assignable to `void`).
+However, when using the `--strictNullChecks` flag, `null` and `undefined` are only assignable to `unknown`, `any` and their respective types (the one exception being that `undefined` is also assignable to `void`).
 This helps avoid _many_ common errors.
 In cases where you want to pass in either a `string` or `null` or `undefined`, you can use the union type `string | null | undefined`.
 


### PR DESCRIPTION
`any` should really only be used as a last resort or when porting JS code.  The docs prior to this PR held `any` in a pretty positive light and suggested some uses for it that really weren't appropriate (`unknown` would have been better).  This PR swaps in `unknown` in the spot `any` previously held in the basic types section, moves `any` to the bottom of the list, and includes language that discourages the usage of `any` in favor of other options like `unknown`, Mapped Types, and Index Types.  Fixed up some references to `any` as well, redirecting them to `unknown`.

Also adjusted the wording on one of the `never` comments while I was in here.