### PR TITLE
Fix twoslash tooltip flicker on border hover

### DIFF
--- a/packages/typescriptlang-org/src/templates/markdown-twoslash.scss
+++ b/packages/typescriptlang-org/src/templates/markdown-twoslash.scss
@@ -166,4 +166,5 @@ pre:hover data-lsp {
   white-space: pre-wrap;
   border-radius: 2px;
   z-index: 100;
+  pointer-events: none;
 }


### PR DESCRIPTION
Made the twoslash tooltip not flicker when hovering the cursor on the border