### PR TITLE
Adds unknown as a basic type

### DIFF
--- a/packages/handbook-v1/en/Basic Types.md
+++ b/packages/handbook-v1/en/Basic Types.md
@@ -107,8 +107,10 @@ When accessing an element with a known index, the correct type is retrieved:
 let x: [string, number];
 x = ["hello", 10]; // OK
 /// ---cut---
-console.log(x[0].substring(1)); // OK
-console.log(x[1].substring(1)); // Error, 'number' does not have 'substring'
+// OK
+console.log(x[0].substring(1));
+
+console.log(x[1].substring(1));
 ```
 
 Accessing an element outside the set of known indices fails with an error:
@@ -118,9 +120,9 @@ Accessing an element outside the set of known indices fails with an error:
 let x: [string, number];
 x = ["hello", 10]; // OK
 /// ---cut---
-x[3] = "world"; // Error, Property '3' does not exist on type '[string, number]'.
+x[3] = "world";
 
-console.log(x[5].toString()); // Error, Property '5' does not exist on type '[string, number]'.
+console.log(x[5].toString());
 ```
 
 # Enum
@@ -172,27 +174,22 @@ enum Color {
 }
 let colorName: string = Color[2];
 
-console.log(colorName); // Displays 'Green' as its value is 2 above
+// Displays 'Green'
+console.log(colorName);
 ```
 
 # Unknown
 
 We may need to describe the type of variables that we do not know when we are writing an application.
-These values may come from dynamic content &ndash; e.g. from the user &ndash; or we may want to intentionally accept all value in our API.
+These values may come from dynamic content &ndash; e.g. from the user &ndash; or we may want to intentionally accept all values in our API.
 In these cases, we want to provide a type that tells the compiler and future readers that this variable could be anything, so we give it the `unknown` type.
 
 ```ts twoslash
 let notSure: unknown = 4;
 notSure = "maybe a string instead";
-notSure = false; // okay, definitely a boolean
-```
 
-You might expect `Object` to play a similar role, as it does in other languages.
-However, variables of type `Object` do not allow you to assign `null` or `undefined` when `--strictNullChecks` is specified.
-
-```ts twoslash
-// @errors: 2322
-const notSure: Object = null; // error, type 'null' is not assignable to type 'Object'
+// OK, definitely a boolean
+notSure = false;
 ```
 
 If you have a variable with an unknown type, you can narrow it to something more specific by doing `typeof` checks, comparison checks, or more advanced type guards that will be discussed in a later chapter:
@@ -200,14 +197,21 @@ If you have a variable with an unknown type, you can narrow it to something more
 ```ts twoslash
 // @errors: 2322 2322 2322
 declare const maybe: unknown;
-const aNumber: number = maybe; // error, 'maybe' could be a string, object, boolean, undefined, or an array
+// 'maybe' could be a string, object, boolean, undefined, or an array
+const aNumber: number = maybe;
+
 if (maybe === true) {
-  const aBoolean: boolean = maybe; // ok
-  const aString: string = maybe; // error, 'maybe' is definitely a boolean, so definitely NOT a string
+  // TypeScript knows that maybe is a boolean now
+  const aBoolean: boolean = maybe;
+  // So, it cannot be a string
+  const aString: string = maybe;
 }
+
 if (typeof maybe === "string") {
-  const aString: string = maybe; // ok
-  const aBoolean: boolean = maybe; // error, 'maybe' is definitely a string, so definitely NOT a boolean
+  // TypeScript knows that maybe is a string
+  const aString: string = maybe;
+  // So, it cannot be a boolean
+  const aBoolean: boolean = maybe;
 }
 ```
 
@@ -220,33 +224,36 @@ To do so, we label these values with the `any` type:
 
 ```ts twoslash
 declare function getValue(key: string): any;
-const str: string = getValue("myString"); // ok, return value of 'getValue' is not checked
+// OK, return value of 'getValue' is not checked
+const str: string = getValue("myString");
 ```
 
 The `any` type is a powerful way to work with existing JavaScript, allowing you to gradually opt-in and opt-out of type checking during compilation.
-Just like `unknown`, variables of type `any` allow you to assign any value to them.
-Unlike `unknown`, TypeScript let you can call arbitrary methods on them, even ones that don't exist:
+
+Unlike `unknown`, TypeScript lets you call arbitrary methods, even ones that don't exist:
 
 ```ts twoslash
 // @errors: 2571
 let looselyTyped: any = 4;
-looselyTyped.ifItExists(); // okay, ifItExists might exist at runtime
-looselyTyped.toFixed(); // okay, toFixed exists (but the compiler doesn't check)
+// OK, ifItExists might exist at runtime
+looselyTyped.ifItExists();
+// OK, toFixed exists (but the compiler doesn't check)
+looselyTyped.toFixed();
 
 let strictlyTyped: unknown = 4;
-strictlyTyped.toFixed(); // Error: Property 'toFixed' doesn't exist on type 'unknown'.
+strictlyTyped.toFixed();
 ```
 
-The `any` type is also handy if you know some part of the type, but perhaps not all of it.
-For example, you may have an array but the array has a mix of different types:
+The `any` will continue to propagate through your objects:
 
 ```ts twoslash
-let list: any[] = [1, true, "free"];
-list[1] = 100;
+let looselyTyped: any = {};
+let d = looselyTyped.a.b.c.d;
+//  ^?
 ```
 
-After all, remember that all the convenience of `any` comes at the coast of loosing type safety.
-Type safety is the main motivation for using TypeScript and you should try to avoid using `any` when not necessary.
+After all, remember that all the convenience of `any` comes at the cost of loosing type safety.
+Type safety is one of the main motivations for using TypeScript and you should try to avoid using `any` when not necessary.
 
 # Void
 
@@ -264,7 +271,8 @@ Declaring variables of type `void` is not useful because you can only assign `nu
 ```ts twoslash
 // @strict: false
 let unusable: void = undefined;
-unusable = null; // OK if `--strictNullChecks` is not given
+// OK if `--strictNullChecks` is not given
+unusable = null;
 ```
 
 # Null and Undefined
@@ -327,14 +335,17 @@ With `object` type, APIs like `Object.create` can be better represented. For exa
 // @errors: 2345
 declare function create(o: object | null): void;
 
-create({ prop: 0 }); // OK
-create(null); // OK
+// OK
+create({ prop: 0 });
+create(null);
 
-create(42); // Error
-create("string"); // Error
-create(false); // Error
-create(undefined); // Error
+create(42);
+create("string");
+create(false);
+create(undefined);
 ```
+
+Generally, you won't need to use this.
 
 # Type assertions
 
@@ -347,20 +358,21 @@ It has no runtime impact, and is used purely by the compiler.
 TypeScript assumes that you, the programmer, have performed any special checks that you need.
 
 Type assertions have two forms.
-One is the "angle-bracket" syntax:
 
-```ts twoslash
-let someValue: any = "this is a string";
-
-let strLength: number = (<string>someValue).length;
-```
-
-And the other is the `as`-syntax:
+One is the `as`-syntax:
 
 ```ts twoslash
 let someValue: any = "this is a string";
 
 let strLength: number = (someValue as string).length;
+```
+
+The other version is the "angle-bracket" syntax:
+
+```ts twoslash
+let someValue: any = "this is a string";
+
+let strLength: number = (<string>someValue).length;
 ```
 
 The two samples are equivalent.

--- a/packages/handbook-v1/en/Basic Types.md
+++ b/packages/handbook-v1/en/Basic Types.md
@@ -175,45 +175,36 @@ let colorName: string = Color[2];
 console.log(colorName); // Displays 'Green' as its value is 2 above
 ```
 
-# Any
+# Unknown
 
 We may need to describe the type of variables that we do not know when we are writing an application.
 These values may come from dynamic content, e.g. from the user or a 3rd party library.
-In these cases, we want to opt-out of type checking and let the values pass through compile-time checks.
-To do so, we label these with the `any` type:
+In these cases, we want to provide a type that tells the compiler and future readers that this variable could be anything so we give it the `unknown` type.
 
 ```ts twoslash
-let notSure: any = 4;
+let notSure: unknown = 4;
 notSure = "maybe a string instead";
 notSure = false; // okay, definitely a boolean
 ```
 
-The `any` type is a powerful way to work with existing JavaScript, allowing you to gradually opt-in and opt-out of type checking during compilation.
-You might expect `Object` to play a similar role, as it does in other languages.
-However, variables of type `Object` only allow you to assign any value to them. You can't call arbitrary methods on them, even ones that actually exist:
+If you have a variable with an unknown type, you can narrow it to something more specific by doing `typeof` checks, comparison checks, or more advanced type guards that will be discussed in a later chapter:
 
 ```ts twoslash
-// @errors: 2339
-let notSure: any = 4;
-notSure.ifItExists(); // okay, ifItExists might exist at runtime
-notSure.toFixed(); // okay, toFixed exists (but the compiler doesn't check)
-
-let prettySure: Object = 4;
-prettySure.toFixed(); // Error: Property 'toFixed' doesn't exist on type 'Object'.
-```
-
-The `any` type is also handy if you know some part of the type, but perhaps not all of it.
-For example, you may have an array but the array has a mix of different types:
-
-```ts twoslash
-let list: any[] = [1, true, "free"];
-
-list[1] = 100;
+declare const maybe: unknown
+const aNumber: number = maybe // error, 'maybe' could be a string, object, boolean, undefined, or an array
+if (maybe === true) {
+  const aBoolean: boolean = maybe // ok
+  const aString: string = maybe // error, 'maybe' is definitely a boolean, so definitely NOT a string
+}
+if (typeof maybe === 'string') {
+  const aString: string = maybe // ok
+  const aBoolean: boolean = maybe // error, 'maybe' is definitely a string, so definitely NOT a boolean
+}
 ```
 
 # Void
 
-`void` is a little like the opposite of `any`: the absence of having any type at all.
+`void` is the absence of having any type at all.
 You may commonly see this as the return type of functions that do not return a value:
 
 ```ts twoslash
@@ -244,7 +235,7 @@ let n: null = null;
 By default `null` and `undefined` are subtypes of all other types.
 That means you can assign `null` and `undefined` to something like `number`.
 
-However, when using the `--strictNullChecks` flag, `null` and `undefined` are only assignable to `any` and their respective types (the one exception being that `undefined` is also assignable to `void`).
+However, when using the `--strictNullChecks` flag, `null` and `undefined` are only assignable to `unknown` and their respective types (the one exception being that `undefined` is also assignable to `void`).
 This helps avoid _many_ common errors.
 In cases where you want to pass in either a `string` or `null` or `undefined`, you can use the union type `string | null | undefined`.
 
@@ -264,7 +255,7 @@ Even `any` isn't assignable to `never`.
 Some examples of functions returning `never`:
 
 ```ts twoslash
-// Function returning never must have unreachable end point
+// Function returning never must not have any reachable end point
 function error(message: string): never {
   throw new Error(message);
 }
@@ -274,7 +265,7 @@ function fail() {
   return error("Something failed");
 }
 
-// Function returning never must have unreachable end point
+// Function returning never must not have a reachable end point
 function infiniteLoop(): never {
   while (true) {}
 }
@@ -298,6 +289,25 @@ create("string"); // Error
 create(false); // Error
 create(undefined); // Error
 ```
+
+# Any
+
+In some situations, you may want to tell the TypeScript compiler to turn off type checking for a variable entirely.  Normally, this is a bad idea because you will lose all type safety, but sometimes it can make sense such as when converting a JavaScript application into TypeScript and you need to get things compiling while you slowly work on improving type safety of your application over time.
+You might expect `Object` to play a similar role, as it does in other languages.
+However, variables of type `Object` only allow you to assign any value to them. You can't call arbitrary methods on them, even ones that actually exist:
+
+```ts twoslash
+// @errors: 2339
+let notSure: any = 4;
+notSure.ifItExists(); // okay, ifItExists might exist at runtime
+notSure.toFixed(); // okay, toFixed exists (but the compiler doesn't check)
+
+let prettySure: Object = 4;
+prettySure.toFixed(); // Error: Property 'toFixed' doesn't exist on type 'Object'.
+```
+
+In general, you should try to avoid the `any` type if you can and instead use `unknown` for variables that you don't know the type of at compile time, or the more advanced Mapped Types and Index Types which will be discussed in a later chapter.
+
 
 # Type assertions
 

--- a/packages/handbook-v1/en/Basic Types.md
+++ b/packages/handbook-v1/en/Basic Types.md
@@ -197,7 +197,7 @@ If you have a variable with an unknown type, you can narrow it to something more
 ```ts twoslash
 // @errors: 2322 2322 2322
 declare const maybe: unknown;
-// 'maybe' could be a string, object, boolean, undefined, or an array
+// 'maybe' could be a string, object, boolean, undefined, or other types
 const aNumber: number = maybe;
 
 if (maybe === true) {
@@ -230,7 +230,8 @@ const str: string = getValue("myString");
 
 The `any` type is a powerful way to work with existing JavaScript, allowing you to gradually opt-in and opt-out of type checking during compilation.
 
-Unlike `unknown`, TypeScript lets you call arbitrary methods, even ones that don't exist:
+Unlike `unknown`, variables of type `any` allow you to access arbitrary properties, even ones that don't exist.
+These properties include functions and TypeScript will not check their existence or type:
 
 ```ts twoslash
 // @errors: 2571

--- a/packages/handbook-v1/en/Basic Types.md
+++ b/packages/handbook-v1/en/Basic Types.md
@@ -178,8 +178,8 @@ console.log(colorName); // Displays 'Green' as its value is 2 above
 # Unknown
 
 We may need to describe the type of variables that we do not know when we are writing an application.
-These values may come from dynamic content, e.g. from the user or a 3rd party library.
-In these cases, we want to provide a type that tells the compiler and future readers that this variable could be anything so we give it the `unknown` type.
+These values may come from dynamic content &ndash; e.g. from the user &ndash; or we may want to intentionally accept all value in our API.
+In these cases, we want to provide a type that tells the compiler and future readers that this variable could be anything, so we give it the `unknown` type.
 
 ```ts twoslash
 let notSure: unknown = 4;
@@ -187,25 +187,70 @@ notSure = "maybe a string instead";
 notSure = false; // okay, definitely a boolean
 ```
 
+You might expect `Object` to play a similar role, as it does in other languages.
+However, variables of type `Object` do not allow you to assign `null` or `undefined` when `--strictNullChecks` is specified.
+
+```ts twoslash
+// @errors: 2322
+const notSure: Object = null; // error, type 'null' is not assignable to type 'Object'
+```
+
 If you have a variable with an unknown type, you can narrow it to something more specific by doing `typeof` checks, comparison checks, or more advanced type guards that will be discussed in a later chapter:
 
 ```ts twoslash
 // @errors: 2322 2322 2322
-declare const maybe: unknown
-const aNumber: number = maybe // error, 'maybe' could be a string, object, boolean, undefined, or an array
+declare const maybe: unknown;
+const aNumber: number = maybe; // error, 'maybe' could be a string, object, boolean, undefined, or an array
 if (maybe === true) {
-  const aBoolean: boolean = maybe // ok
-  const aString: string = maybe // error, 'maybe' is definitely a boolean, so definitely NOT a string
+  const aBoolean: boolean = maybe; // ok
+  const aString: string = maybe; // error, 'maybe' is definitely a boolean, so definitely NOT a string
 }
-if (typeof maybe === 'string') {
-  const aString: string = maybe // ok
-  const aBoolean: boolean = maybe // error, 'maybe' is definitely a string, so definitely NOT a boolean
+if (typeof maybe === "string") {
+  const aString: string = maybe; // ok
+  const aBoolean: boolean = maybe; // error, 'maybe' is definitely a string, so definitely NOT a boolean
 }
 ```
 
+# Any
+
+In some situations, not all type information is available or it's declaration would take an inappropriate amount of effort.
+These may occur for values from code that has been written without TypeScript or a 3rd party library.
+In these cases, we might want to opt-out of type checking.
+To do so, we label these values with the `any` type:
+
+```ts twoslash
+declare function getValue(key: string): any;
+const str: string = getValue("myString"); // ok, return value of 'getValue' is not checked
+```
+
+The `any` type is a powerful way to work with existing JavaScript, allowing you to gradually opt-in and opt-out of type checking during compilation.
+Just like `unknown`, variables of type `any` allow you to assign any value to them.
+Unlike `unknown`, TypeScript let you can call arbitrary methods on them, even ones that don't exist:
+
+```ts twoslash
+// @errors: 2571
+let looselyTyped: any = 4;
+looselyTyped.ifItExists(); // okay, ifItExists might exist at runtime
+looselyTyped.toFixed(); // okay, toFixed exists (but the compiler doesn't check)
+
+let strictlyTyped: unknown = 4;
+strictlyTyped.toFixed(); // Error: Property 'toFixed' doesn't exist on type 'unknown'.
+```
+
+The `any` type is also handy if you know some part of the type, but perhaps not all of it.
+For example, you may have an array but the array has a mix of different types:
+
+```ts twoslash
+let list: any[] = [1, true, "free"];
+list[1] = 100;
+```
+
+After all, remember that all the convenience of `any` comes at the coast of loosing type safety.
+Type safety is the main motivation for using TypeScript and you should try to avoid using `any` when not necessary.
+
 # Void
 
-`void` is the absence of having any type at all.
+`void` is a little like the opposite of `any`: the absence of having any type at all.
 You may commonly see this as the return type of functions that do not return a value:
 
 ```ts twoslash
@@ -256,7 +301,7 @@ Even `any` isn't assignable to `never`.
 Some examples of functions returning `never`:
 
 ```ts twoslash
-// Function returning never must not have any reachable end point
+// Function returning never must not have a reachable end point
 function error(message: string): never {
   throw new Error(message);
 }
@@ -290,25 +335,6 @@ create("string"); // Error
 create(false); // Error
 create(undefined); // Error
 ```
-
-# Any
-
-In some situations, you may want to tell the TypeScript compiler to turn off type checking for a variable entirely.  Normally, this is a bad idea because you will lose all type safety, but sometimes it can make sense such as when converting a JavaScript application into TypeScript and you need to get things compiling while you slowly work on improving type safety of your application over time.
-You might expect `Object` to play a similar role, as it does in other languages.
-However, variables of type `Object` only allow you to assign any value to them. You can't call arbitrary methods on them, even ones that actually exist:
-
-```ts twoslash
-// @errors: 2339
-let notSure: any = 4;
-notSure.ifItExists(); // okay, ifItExists might exist at runtime
-notSure.toFixed(); // okay, toFixed exists (but the compiler doesn't check)
-
-let prettySure: Object = 4;
-prettySure.toFixed(); // Error: Property 'toFixed' doesn't exist on type 'Object'.
-```
-
-In general, you should try to avoid the `any` type if you can and instead use `unknown` for variables that you don't know the type of at compile time, or the more advanced Mapped Types and Index Types which will be discussed in a later chapter.
-
 
 # Type assertions
 

--- a/packages/handbook-v1/en/Basic Types.md
+++ b/packages/handbook-v1/en/Basic Types.md
@@ -190,6 +190,7 @@ notSure = false; // okay, definitely a boolean
 If you have a variable with an unknown type, you can narrow it to something more specific by doing `typeof` checks, comparison checks, or more advanced type guards that will be discussed in a later chapter:
 
 ```ts twoslash
+// @errors: 2322 2322 2322
 declare const maybe: unknown
 const aNumber: number = maybe // error, 'maybe' could be a string, object, boolean, undefined, or an array
 if (maybe === true) {

--- a/packages/handbook-v1/en/Basic Types.md
+++ b/packages/handbook-v1/en/Basic Types.md
@@ -236,7 +236,7 @@ let n: null = null;
 By default `null` and `undefined` are subtypes of all other types.
 That means you can assign `null` and `undefined` to something like `number`.
 
-However, when using the `--strictNullChecks` flag, `null` and `undefined` are only assignable to `unknown` and their respective types (the one exception being that `undefined` is also assignable to `void`).
+However, when using the `--strictNullChecks` flag, `null` and `undefined` are only assignable to `unknown`, `any` and their respective types (the one exception being that `undefined` is also assignable to `void`).
 This helps avoid _many_ common errors.
 In cases where you want to pass in either a `string` or `null` or `undefined`, you can use the union type `string | null | undefined`.
 


### PR DESCRIPTION
I created a new suggestion for adding `unknown` based on #742. It adds `unknown` as basic type to the handbook. I combined parts of the original version and parts of #742 and rearranged them. I moved the section about `unknown` and `any` next to each other to provide a direct comparison.

PS: While editing the document, I was wondering if `unknown` has the same properties as `Object | null | undefined`.