### PR TITLE
Make it possible to set noErrors and showEmit to true

### DIFF
--- a/packages/gatsby-remark-shiki-twoslash/package.json
+++ b/packages/gatsby-remark-shiki-twoslash/package.json
@@ -19,7 +19,7 @@
     "lint": "tsdx lint"
   },
   "dependencies": {
-    "@typescript/twoslash": "0.5.2",
+    "@typescript/twoslash": "0.5.3",
     "@typescript/vfs": "1.0.1",
     "shiki": "^0.1.6",
     "shiki-languages": "^0.1.6",

--- a/packages/ts-twoslasher/package.json
+++ b/packages/ts-twoslasher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript/twoslash",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "license": "MIT",
   "author": "TypeScript team",
   "main": "dist/index.js",

--- a/packages/ts-twoslasher/src/index.ts
+++ b/packages/ts-twoslasher/src/index.ts
@@ -190,12 +190,12 @@ function filterCompilerOptions(codeLines: string[], defaultCompilerOptions: Comp
 
 /** Available inline flags which are not compiler flags */
 export interface ExampleOptions {
-  /** Let's the sample suppress all error diagnostics */
-  noErrors: false
+  /** Lets the sample suppress all error diagnostics */
+  noErrors: boolean
   /** An array of TS error codes, which you write as space separated - this is so the tool can know about unexpected errors */
   errors: number[]
   /** Shows the JS equivalent of the TypeScript code instead */
-  showEmit: false
+  showEmit: boolean
   /**
    * Must be used with showEmit, lets you choose the file to present instead of the source - defaults to index.js which
    * means when you just use `showEmit` above it shows the transpiled JS.

--- a/packages/typescriptlang-org/package.json
+++ b/packages/typescriptlang-org/package.json
@@ -25,7 +25,7 @@
     "@mdx-js/react": "^1.5.5",
     "@types/node-fetch": "^2.5.3",
     "@types/react-helmet": "^5.0.15",
-    "@typescript/twoslash": "0.5.2",
+    "@typescript/twoslash": "0.5.3",
     "@uifabric/fluent-theme": "^7.1.22",
     "@uifabric/react-cards": "^0.109.23",
     "canvas": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4077,7 +4077,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/twoslash@0.5.2, @typescript/twoslash@workspace:packages/ts-twoslasher":
+"@typescript/twoslash@0.5.3, @typescript/twoslash@workspace:packages/ts-twoslasher":
   version: 0.0.0-use.local
   resolution: "@typescript/twoslash@workspace:packages/ts-twoslasher"
   dependencies:
@@ -12113,7 +12113,7 @@ fsevents@^1.2.7:
   resolution: "gatsby-remark-shiki-twoslash@workspace:packages/gatsby-remark-shiki-twoslash"
   dependencies:
     "@types/jest": ^25.1.3
-    "@typescript/twoslash": 0.5.2
+    "@typescript/twoslash": 0.5.3
     "@typescript/vfs": 1.0.1
     rehype-stringify: ^6.0.1
     shiki: ^0.1.6
@@ -25726,7 +25726,7 @@ resolve@^1.17.0:
     "@types/react": ^16.9.20
     "@types/react-dom": ^16.9.5
     "@types/react-helmet": ^5.0.15
-    "@typescript/twoslash": 0.5.2
+    "@typescript/twoslash": 0.5.3
     "@uifabric/fluent-theme": ^7.1.22
     "@uifabric/react-cards": ^0.109.23
     canvas: ^2.6.1


### PR DESCRIPTION
In twoslash, you can only set `noErrors` and `showEmit` to `false` in `defaultOptions`. I changed that to `boolean` and also fixed a small typo in the doc comment.