### PR TITLE
Adds custom config for GitHub CodeSpaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:14
+
+# The javascript-node image includes a non-root node user with sudo access. Use 
+# the "remoteUser" property in devcontainer.json to use it. On Linux, the container 
+# user's GID/UIDs will be updated to match your local UID/GID when using the image
+# or dockerFile property. Update USER_UID/USER_GID below if you are using the
+# dockerComposeFile property or want the image itself to start with different ID
+# values. See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=node
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Alter node user as needed, install tslint, typescript. eslint is installed by javascript image
+RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then \
+        groupmod --gid $USER_GID $USERNAME \
+        && usermod --uid $USER_UID --gid $USER_GID $USERNAME \
+        && chmod -R $USER_UID:$USER_GID /home/$USERNAME \
+        && chmod -R $USER_UID:root /usr/local/share/nvm /usr/local/share/npm-global; \
+    fi \
+    #
+    # Install tslint, typescript. eslint is installed by javascript image
+    && sudo -u ${USERNAME} npm install -g tslint typescript yarn

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+    "name": "TypeScript website codespace",
+    "extensions": [
+        "streetsidesoftware.code-spell-checker",
+        "emmanuelbeziat.vscode-great-icons",
+        "dbaeumer.vscode-eslint",
+		"ms-vscode.vscode-typescript-tslint-plugin"
+    ],
+	"dockerFile": "Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+    },
+    
+    "forwardPorts": [8000],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "sudo yarn install && sudo yarn bootstrap",
+}

--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,5 +1,5 @@
 const tasks = arr => arr.join(' && ')
-const isOrta = process.env.USER.includes("orta")
+const isOrta = process.env.USER && process.env.USER.includes("orta")
 
 // Everyone else gets a NO-OP
 module.exports = !isOrta ? {} : {

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["esbenp.prettier-vscode"]
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "streetsidesoftware.code-spell-checker-portuguese-brazilian",
+    "streetsidesoftware.code-spell-checker-spanish"
+  ]
 }

--- a/packages/ts-twoslasher/README.md
+++ b/packages/ts-twoslasher/README.md
@@ -96,12 +96,12 @@ The twoslash markup API lives inside your code samples code as comments, which c
 ```ts
 /** Available inline flags which are not compiler flags */
 export interface ExampleOptions {
-  /** Let's the sample suppress all error diagnostics */
-  noErrors: false
+  /** Lets the sample suppress all error diagnostics */
+  noErrors: boolean
   /** An array of TS error codes, which you write as space separated - this is so the tool can know about unexpected errors */
   errors: number[]
   /** Shows the JS equivalent of the TypeScript code instead */
-  showEmit: false
+  showEmit: boolean
   /**
    * Must be used with showEmit, lets you choose the file to present instead of the source - defaults to index.js which
    * means when you just use `showEmit` above it shows the transpiled JS.


### PR DESCRIPTION
GH Codespaces is out for a lot of people (including me) and one of the cool features it has is too apply custom configs to different repos. 

I thought this could make the onboarding process easier, so I created the `.devcontainer` folder following [the default TS container template from MS](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/typescript-node-14) to integrate in codespaces.

This container:

- Comes with Node 14 and TS
- Install yarn globally
- Installs Code Spell Checker extension for translating purposes
  - It'd be nice to suggest other extensions based on the language the person is translating/using
- Runs `yarn install` and `yarn bootstrap` after start
- Forwards port `8000` to the client