### PR TITLE
change twoslasher to take an options object, add compilerOptions option

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       # Get local dependencies
+      - run: sudo apt-get update
       - run: sudo apt install calibre
       - run: yarn install
         env:

--- a/packages/gatsby-remark-shiki-twoslash/package.json
+++ b/packages/gatsby-remark-shiki-twoslash/package.json
@@ -19,9 +19,8 @@
     "lint": "tsdx lint"
   },
   "dependencies": {
-    "@typescript/twoslash": "0.5.2",
+    "@typescript/twoslash": "0.6.0",
     "@typescript/vfs": "1.1.0",
-    "@typescript/twoslash": "0.5.3",
     "shiki": "^0.1.6",
     "shiki-languages": "^0.1.6",
     "typescript": "*",

--- a/packages/gatsby-remark-shiki-twoslash/src/index.ts
+++ b/packages/gatsby-remark-shiki-twoslash/src/index.ts
@@ -121,7 +121,7 @@ export const runTwoSlashOnNode = (settings: ShikiTwoslashSettings) => (node: Ric
       addAllFilesFromFolder(map, settings.nodeModulesTypesPath || "node_modules/@types")
     }
 
-    const results = twoslasher(node.value, node.lang, undefined, undefined, undefined, map)
+    const results = twoslasher(node.value, node.lang, { fsMap: map })
     node.value = results.code
     node.lang = results.extension as TLang
     node.twoslash = results

--- a/packages/ts-twoslasher/README.md
+++ b/packages/ts-twoslasher/README.md
@@ -694,23 +694,30 @@ The API is one main exported function:
  *
  * @param code The twoslash markup'd code
  * @param extension For example: "ts", "tsx", "typescript", "javascript" or "js".
- * @param defaultOptions Allows setting any of the handbook options from outside the function, useful if you don't want LSP identifiers
- * @param tsModule An optional copy of the TypeScript import, if missing it will be require'd.
- * @param lzstringModule An optional copy of the lz-string import, if missing it will be require'd.
- * @param fsMap An optional Map object which is passed into @typescript/vfs - if you are using twoslash on the
- *              web then you'll need this to set up your lib *.d.ts files. If missing, it will use your fs.
+ * @param options Additional options for twoslash
  */
-export function twoslasher(
-  code: string,
-  extension: string,
-  defaultOptions?: Partial<ExampleOptions>,
-  tsModule?: TS,
-  lzstringModule?: LZ,
-  fsMap?: Map<string, string>
-): TwoSlashReturn
+export function twoslasher(code: string, extension: string, options: TwoSlashOptions = {}): TwoSlashReturn
 ```
 
-Which returns:
+Which takes the options:
+
+```ts
+export interface TwoSlashOptions {
+  /** Allows setting any of the handbook options from outside the function, useful if you don't want LSP identifiers */
+  defaultOptions?: Partial<ExampleOptions>
+  /** An optional copy of the TypeScript import, if missing it will be require'd. */
+  tsModule?: TS
+  /** An optional copy of the lz-string import, if missing it will be require'd. */
+  lzstringModule?: LZ
+  /**
+   * An optional Map object which is passed into @typescript/vfs - if you are using twoslash on the
+   * web then you'll need this to set up your lib *.d.ts files. If missing, it will use your fs.
+   */
+  fsMap?: Map<string, string>
+}
+```
+
+And returns:
 
 ```ts
 export interface TwoSlashReturn {

--- a/packages/ts-twoslasher/README.md
+++ b/packages/ts-twoslasher/README.md
@@ -705,6 +705,8 @@ Which takes the options:
 export interface TwoSlashOptions {
   /** Allows setting any of the handbook options from outside the function, useful if you don't want LSP identifiers */
   defaultOptions?: Partial<ExampleOptions>
+  /** Allows setting any of the compiler options from outside the function */
+  defaultCompilerOptions?: CompilerOptions
   /** An optional copy of the TypeScript import, if missing it will be require'd. */
   tsModule?: TS
   /** An optional copy of the lz-string import, if missing it will be require'd. */

--- a/packages/ts-twoslasher/package.json
+++ b/packages/ts-twoslasher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript/twoslash",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "license": "MIT",
   "author": "TypeScript team",
   "main": "dist/index.js",

--- a/packages/ts-twoslasher/scripts/inline-results.js
+++ b/packages/ts-twoslasher/scripts/inline-results.js
@@ -18,12 +18,16 @@ module.exports = {
       let program = ts.createProgram([fileToParse], {})
 
       const sourceFile = program.getSourceFile(fileToParse)
-      let optionsInterface, mainExport, returnInterface
+      let exampleOptionsInterface, optionsInterface, mainExport, returnInterface
 
       ts.forEachChild(sourceFile, (node) => {
         if (node.name && node.name.escapedText) {
           const name = node.name.escapedText
           if (name === 'ExampleOptions') {
+            exampleOptionsInterface = node
+          }
+
+          if (name === 'TwoSlashOptions') {
             optionsInterface = node
           }
 
@@ -40,13 +44,14 @@ module.exports = {
 
       const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed })
       const twoslasher = printer.printNode(ts.EmitHint.Unspecified, mainExport, sourceFile) + '\n'
-      const returnObj = printer.printNode(ts.EmitHint.Unspecified, returnInterface, sourceFile) + '\n'
       const optionsObj = printer.printNode(ts.EmitHint.Unspecified, optionsInterface, sourceFile) + '\n'
+      const returnObj = printer.printNode(ts.EmitHint.Unspecified, returnInterface, sourceFile) + '\n'
+      const exampleOptionsObj = printer.printNode(ts.EmitHint.Unspecified, exampleOptionsInterface, sourceFile) + '\n'
 
       mds.push(
         'The twoslash markup API lives inside your code samples code as comments, which can do special commands. There are the following commands:'
       )
-      mds.push(wrapCode(optionsObj, 'ts'))
+      mds.push(wrapCode(exampleOptionsObj, 'ts'))
 
       mds.push('In addition to this set, you can use `@filename` which allow for exporting between files.')
 
@@ -87,7 +92,9 @@ module.exports = {
       mds.push('### API')
       mds.push('The API is one main exported function:')
       mds.push(wrapCode(twoslasher, 'ts'))
-      mds.push('Which returns:')
+      mds.push('Which takes the options:')
+      mds.push(wrapCode(optionsObj, 'ts'))
+      mds.push('And returns:')
       mds.push(wrapCode(returnObj, 'ts'))
 
       return mds.join('\n\n')

--- a/packages/ts-twoslasher/src/index.ts
+++ b/packages/ts-twoslasher/src/index.ts
@@ -325,6 +325,9 @@ export interface TwoSlashOptions {
   /** Allows setting any of the handbook options from outside the function, useful if you don't want LSP identifiers */
   defaultOptions?: Partial<ExampleOptions>
 
+  /** Allows setting any of the compiler options from outside the function */
+  defaultCompilerOptions?: CompilerOptions
+
   /** An optional copy of the TypeScript import, if missing it will be require'd. */
   tsModule?: TS
 
@@ -363,7 +366,8 @@ export function twoslasher(
   const defaultCompilerOptions = {
     strict: true,
     target: ts.ScriptTarget.ES2016,
-    allowJs: true
+    allowJs: true,
+    ...(options.defaultCompilerOptions ?? {})
   }
 
   validateInput(code)

--- a/packages/ts-twoslasher/test/compiler_options.test.ts
+++ b/packages/ts-twoslasher/test/compiler_options.test.ts
@@ -1,0 +1,19 @@
+import { twoslasher } from "../src/index"
+import { ModuleKind } from "typescript"
+
+it("emits CommonJS", () => {
+  const files = `
+// @filename: file-with-export.ts
+export const helloWorld = "Example string";
+
+// @filename: index.ts
+import {helloWorld} from "./file-with-export"
+console.log(helloWorld)
+`
+  const result = twoslasher(files, "ts", {
+    defaultOptions: { showEmit: true },
+    defaultCompilerOptions: { module: ModuleKind.CommonJS }
+  })
+  expect(result.errors).toEqual([])
+  expect(result.code!).toContain('require("./file-with-export")')
+})

--- a/packages/ts-twoslasher/test/modules.test.ts
+++ b/packages/ts-twoslasher/test/modules.test.ts
@@ -17,7 +17,7 @@ import glob from "glob"
 glob.hasMagic("OK")
 //   ^?
   `
-  const result = twoslasher(file, "ts", undefined, undefined, undefined, fsMap)
+  const result = twoslasher(file, "ts", { fsMap })
   expect(result.errors).toEqual([])
   expect(result.queries[0].text!.includes("hasMagic")).toBeTruthy()
 })

--- a/packages/typescriptlang-org/package.json
+++ b/packages/typescriptlang-org/package.json
@@ -25,7 +25,7 @@
     "@mdx-js/react": "^1.5.5",
     "@types/node-fetch": "^2.5.3",
     "@types/react-helmet": "^5.0.15",
-    "@typescript/twoslash": "0.5.3",
+    "@typescript/twoslash": "0.6.0",
     "@uifabric/fluent-theme": "^7.1.22",
     "@uifabric/react-cards": "^0.109.23",
     "canvas": "^2.6.1",

--- a/packages/typescriptlang-org/src/pages/dev/bug-workbench.tsx
+++ b/packages/typescriptlang-org/src/pages/dev/bug-workbench.tsx
@@ -144,7 +144,7 @@ const Play: React.FC<Props> = (props) => {
             const twoslashConfig = { noStaticSemanticInfo: true, emit: true, noErrorValidation: true } as const
             const ext = sandboxEnv.filepath.split(".")[1]
             const twoslash = twoslasher(code, ext, {
-              exampleConfig: twoslashConfig,
+              defaultOptions: twoslashConfig,
               tsModule: ts,
               lzstringModule: sandboxEnv.lzstring as any,
               fsMap: currentDTSMap

--- a/packages/typescriptlang-org/src/pages/dev/bug-workbench.tsx
+++ b/packages/typescriptlang-org/src/pages/dev/bug-workbench.tsx
@@ -111,7 +111,7 @@ const Play: React.FC<Props> = (props) => {
           })
         }
 
-        // When the compiler notices a twoslash compiler flag change, this will get triggered and reset the DTS map 
+        // When the compiler notices a twoslash compiler flag change, this will get triggered and reset the DTS map
         sandboxEnv.setDidUpdateCompilerSettings(updateDTSEnv)
         updateDTSEnv(sandboxEnv.getCompilerOptions())
 
@@ -143,7 +143,12 @@ const Play: React.FC<Props> = (props) => {
             currentDTSMap = new Map(dtsMap)
             const twoslashConfig = { noStaticSemanticInfo: true, emit: true, noErrorValidation: true } as const
             const ext = sandboxEnv.filepath.split(".")[1]
-            const twoslash = twoslasher(code, ext, twoslashConfig, ts, sandboxEnv.lzstring as any, currentDTSMap)
+            const twoslash = twoslasher(code, ext, {
+              exampleConfig: twoslashConfig,
+              tsModule: ts,
+              lzstringModule: sandboxEnv.lzstring as any,
+              fsMap: currentDTSMap
+            })
             currentTwoslashResults = twoslash
 
             const currentPlugin = playgroundEnv.getCurrentPlugin()
@@ -170,7 +175,7 @@ const Play: React.FC<Props> = (props) => {
           sandboxEnv.monaco.editor.setTheme("sandbox-dark");
         }
 
-        // On the chance you change your dark mode settings 
+        // On the chance you change your dark mode settings
         darkModeEnabled.addListener((e) => {
           const darkModeOn = e.matches;
           const newTheme = darkModeOn ? "sandbox-dark" : "sandbox-light"

--- a/packages/typescriptlang-org/src/pages/dev/twoslash.tsx
+++ b/packages/typescriptlang-org/src/pages/dev/twoslash.tsx
@@ -69,7 +69,11 @@ const Index: React.FC<Props> = (props) => {
             mapWithLibFiles.set("index.ts", newContent)
 
             try {
-              const newResults = twoslasher(newContent, "tsx", {}, ts, sandbox.lzstring as any, mapWithLibFiles)
+              const newResults = twoslasher(newContent, "tsx", {
+                tsModule: ts,
+                lzstringModule: sandbox.lzstring as any,
+                fsMap: mapWithLibFiles
+              })
               const codeAsFakeShikiTokens = newResults.code.split("\n").map(line => [{ content: line }])
               const html = renderToHTML(codeAsFakeShikiTokens, {}, newResults)
 


### PR DESCRIPTION
After the conversation on Discord, here's the change that converts the `twoslasher` parameters to an options object. I also added the compilerOptions option.