### PR TITLE
twoslash: add support for custom transformers

### DIFF
--- a/packages/gatsby-remark-shiki-twoslash/package.json
+++ b/packages/gatsby-remark-shiki-twoslash/package.json
@@ -19,8 +19,8 @@
     "lint": "tsdx lint"
   },
   "dependencies": {
-    "@typescript/twoslash": "0.6.1",
-    "@typescript/vfs": "1.1.1",
+    "@typescript/twoslash": "0.6.2",
+    "@typescript/vfs": "1.1.2",
     "shiki": "^0.1.6",
     "shiki-languages": "^0.1.6",
     "typescript": "*",

--- a/packages/ts-twoslasher/README.md
+++ b/packages/ts-twoslasher/README.md
@@ -707,6 +707,8 @@ export interface TwoSlashOptions {
   defaultOptions?: Partial<ExampleOptions>
   /** Allows setting any of the compiler options from outside the function */
   defaultCompilerOptions?: CompilerOptions
+  /** Allows applying custom transformers to the emit result, only useful with the showEmit output */
+  customTransformers?: CustomTransformers
   /** An optional copy of the TypeScript import, if missing it will be require'd. */
   tsModule?: TS
   /** An optional copy of the lz-string import, if missing it will be require'd. */

--- a/packages/ts-twoslasher/package.json
+++ b/packages/ts-twoslasher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript/twoslash",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "license": "MIT",
   "author": "TypeScript team",
   "main": "dist/index.js",
@@ -40,7 +40,7 @@
     "lz-string": false
   },
   "dependencies": {
-    "@typescript/vfs": "1.1.1",
+    "@typescript/vfs": "1.1.2",
     "debug": "^4.1.1",
     "lz-string": "^1.4.4"
   }

--- a/packages/ts-twoslasher/src/index.ts
+++ b/packages/ts-twoslasher/src/index.ts
@@ -8,6 +8,7 @@ const shouldDebug = (hasLocalStorage && localStorage.getItem("DEBUG")) || (hasPr
 type LZ = typeof import("lz-string")
 type TS = typeof import("typescript")
 type CompilerOptions = import("typescript").CompilerOptions
+type CustomTransformers = import("typescript").CustomTransformers
 
 import {
   parsePrimitive,
@@ -331,6 +332,9 @@ export interface TwoSlashOptions {
   /** Allows setting any of the compiler options from outside the function */
   defaultCompilerOptions?: CompilerOptions
 
+  /** Allows applying custom transformers to the emit result, only useful with the showEmit output */
+  customTransformers?: CustomTransformers
+
   /** An optional copy of the TypeScript import, if missing it will be require'd. */
   tsModule?: TS
 
@@ -381,7 +385,7 @@ export function twoslasher(code: string, extension: string, options: TwoSlashOpt
 
   const vfs = options.fsMap ?? createLocallyPoweredVFS(compilerOptions, ts)
   const system = createSystem(vfs)
-  const env = createVirtualTypeScriptEnvironment(system, [], ts, compilerOptions)
+  const env = createVirtualTypeScriptEnvironment(system, [], ts, compilerOptions, options.customTransformers)
   const ls = env.languageService
 
   code = codeLines.join("\n")

--- a/packages/ts-twoslasher/test/custom_transformers.test.ts
+++ b/packages/ts-twoslasher/test/custom_transformers.test.ts
@@ -1,0 +1,25 @@
+import { isStringLiteral, SourceFile, TransformationContext, TransformerFactory, visitEachChild, visitNode, Visitor } from "typescript"
+import { twoslasher } from "../src/index"
+
+it("applies custom transformers", () => {
+  const code = "console.log('Hello World!')"
+  // A simple transformer that uppercases all string literals
+  const transformer: TransformerFactory<SourceFile> = (ctx: TransformationContext) => {
+    const visitor: Visitor = node => {
+      if (isStringLiteral(node)) {
+        return ctx.factory.createStringLiteral(node.text.toUpperCase());
+      }
+      return visitEachChild(node, visitor, ctx);
+    };
+    return node => visitNode(node, visitor);
+  };
+
+  const result = twoslasher(code, "ts", {
+    defaultOptions: { showEmit: true },
+    customTransformers: {
+      before: [transformer]
+    }
+  })
+  expect(result.errors).toEqual([])
+  expect(result.code).toContain('console.log("HELLO WORLD!")')
+})

--- a/packages/typescript-vfs/package.json
+++ b/packages/typescript-vfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript/vfs",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "author": "TypeScript team",
   "homepage": "https://github.com/microsoft/TypeScript-Website/",

--- a/packages/typescriptlang-org/package.json
+++ b/packages/typescriptlang-org/package.json
@@ -25,7 +25,7 @@
     "@mdx-js/react": "^1.5.5",
     "@types/node-fetch": "^2.5.3",
     "@types/react-helmet": "^5.0.15",
-    "@typescript/twoslash": "0.6.1",
+    "@typescript/twoslash": "0.6.2",
     "@uifabric/fluent-theme": "^7.1.22",
     "@uifabric/react-cards": "^0.109.23",
     "canvas": "^2.6.1",


### PR DESCRIPTION
This adds support for passing custom transformers, in the same object form (`before`/`after`/`afterDeclarations`) as you'd pass to `Program#emit` and friends, as a new configuration option named `customTransformers`.