### PR TITLE
Fix some comments on handbook and playground

### DIFF
--- a/packages/documentation/copy/en/Utility Types.md
+++ b/packages/documentation/copy/en/Utility Types.md
@@ -201,7 +201,7 @@ type T2 = ReturnType<<T>() => T>; // {}
 type T3 = ReturnType<<T extends U, U extends number[]>() => T>; // number[]
 type T4 = ReturnType<typeof f1>; // { a: number, b: string }
 type T5 = ReturnType<any>; // any
-type T6 = ReturnType<never>; // any
+type T6 = ReturnType<never>; // never
 type T7 = ReturnType<string>; // Error
 type T8 = ReturnType<Function>; // Error
 ```

--- a/packages/documentation/copy/en/Utility Types.md
+++ b/packages/documentation/copy/en/Utility Types.md
@@ -168,11 +168,11 @@ declare function f1(arg: { a: number; b: string }): void;
 type T0 = Parameters<() => string>; // []
 type T1 = Parameters<(s: string) => void>; // [string]
 type T2 = Parameters<<T>(arg: T) => T>; // [unknown]
-type T4 = Parameters<typeof f1>; // [{ a: number, b: string }]
-type T5 = Parameters<any>; // unknown[]
-type T6 = Parameters<never>; // never
-type T7 = Parameters<string>; // Error
-type T8 = Parameters<Function>; // Error
+type T3 = Parameters<typeof f1>; // [{ a: number, b: string }]
+type T4 = Parameters<any>; // unknown[]
+type T5 = Parameters<never>; // never
+type T6 = Parameters<string>; // Error
+type T7 = Parameters<Function>; // Error
 ```
 
 # `ConstructorParameters<T>`

--- a/packages/documentation/copy/en/Utility Types.md
+++ b/packages/documentation/copy/en/Utility Types.md
@@ -184,7 +184,7 @@ The `ConstructorParameters<T>` type lets us extract all parameter types of a con
 ```ts
 type T0 = ConstructorParameters<ErrorConstructor>; // [(string | undefined)?]
 type T1 = ConstructorParameters<FunctionConstructor>; // string[]
-type T2 = ConstructorParameters<RegExpConstructor>; // [string, (string | undefined)?]
+type T2 = ConstructorParameters<RegExpConstructor>; // [string | RegExp, (string | undefined)?]
 ```
 
 # `ReturnType<T>`

--- a/packages/documentation/copy/en/Utility Types.md
+++ b/packages/documentation/copy/en/Utility Types.md
@@ -220,7 +220,7 @@ class C {
 
 type T0 = InstanceType<typeof C>; // C
 type T1 = InstanceType<any>; // any
-type T2 = InstanceType<never>; // any
+type T2 = InstanceType<never>; // never
 type T3 = InstanceType<string>; // Error
 type T4 = InstanceType<Function>; // Error
 ```

--- a/packages/playground-examples/copy/en/3-8/Breaking Changes/Checking Unions with Index Signatures.ts
+++ b/packages/playground-examples/copy/en/3-8/Breaking Changes/Checking Unions with Index Signatures.ts
@@ -5,7 +5,7 @@
 
 // You can learn about indexed types here: example:indexed-types
 
-// For example, the TimingCache below indicates that any
+// For example, the IdentifierCache below indicates that any
 // key on the object will be a number:
 
 type IdentifierCache = { [key: string]: number };


### PR DESCRIPTION
**Page URL:** <!-- Where can we find the wrong docs? -->
- handbook(Utility Types)
    - https://www.staging-typescript.org/docs/handbook/utility-types.html
- playground(Checking Unions with Index Signatures)
	- https://www.staging-typescript.org/play/?ts=3.8.3&q=413#example/checking-unions-with-index-signatures

**Changes:**

- Fixed some wrong types on Utility Types.
	- Here is a playground link what I've checked.
	- https://www.staging-typescript.org/play?#code/C4TwDgpgBAKgjFAvFAwgewHYGdgCcCuAxsGrgAoCGuFAthMBLlgDwBKEA5gKIAeY62PERK4AfAG4oAeilQA2jlwBLDBwA0UABSKVHKAB8o+DABMIAMxUQTASgD8AXQCQAKFCRYAJiRR2wfLgYMOAQzBgQAG6MEtKyFBggru7QMADMPgCSgvGEEMGQYZHRkjJQ8YlAA
- Fixed a comment of Checking Unions with Index Signatures.
	- ref: https://github.com/microsoft/TypeScript-Website/pull/797#discussion_r460385401

Thanks.