### PR TITLE
Propose new translation to go

### DIFF
--- a/packages/typescriptlang-org/src/copy/inYourLanguage.ts
+++ b/packages/typescriptlang-org/src/copy/inYourLanguage.ts
@@ -17,7 +17,7 @@ export const inYourLanguage: Record<
   pt: {
     shorthand: "Em Pt",
     body: "Esta página está disponível em Português",
-    open: "Ir",
+    open: "Visitar",
     cancel: "Não perguntar novamente",
   },
   ja: {

--- a/packages/typescriptlang-org/src/copy/inYourLanguage.ts
+++ b/packages/typescriptlang-org/src/copy/inYourLanguage.ts
@@ -17,7 +17,7 @@ export const inYourLanguage: Record<
   pt: {
     shorthand: "Em Pt",
     body: "Esta página está disponível em Português",
-    open: "Trocar Língua",
+    open: "Trocar língua",
     cancel: "Não perguntar novamente",
   },
   ja: {

--- a/packages/typescriptlang-org/src/copy/inYourLanguage.ts
+++ b/packages/typescriptlang-org/src/copy/inYourLanguage.ts
@@ -17,7 +17,7 @@ export const inYourLanguage: Record<
   pt: {
     shorthand: "Em Pt",
     body: "Esta página está disponível em Português",
-    open: "Visitar",
+    open: "Trocar Língua",
     cancel: "Não perguntar novamente",
   },
   ja: {


### PR DESCRIPTION
Just proposing a new translation to the button: "Go" in the `in your language` pop-up (as refered in https://github.com/microsoft/TypeScript-Website/issues/805). 

In my opinion, "Go" in the meaning of just "Ir" in Portuguese seems kinda vague. I believe the term "Visitar" (or "Visit") might be a better option.

What do you think @orta @danilofuchs?