### PR TITLE
translate(pt): Documentation home page

### DIFF
--- a/packages/typescriptlang-org/src/components/QuickJump.tsx
+++ b/packages/typescriptlang-org/src/components/QuickJump.tsx
@@ -25,6 +25,7 @@ export const QuickJump = (props: Props) => {
 
   const IntlLink = createIntlLink(props.lang, props.allSitePage);
 
+  // TODO: Internationalize these strings
   return <div className="main-content-block">
     <h2 style={{ textAlign: "center" }}>{props.title}</h2>
     <div className="columns">

--- a/packages/typescriptlang-org/src/copy/en/community.ts
+++ b/packages/typescriptlang-org/src/copy/en/community.ts
@@ -25,8 +25,4 @@ export const comCopy = {
   com_person: "Connect in person",
   com_conferences: "Conferences",
   com_conferences_alt_img: "logo of ",
-  nav_: {
-    id: "foo",
-    defaultMessage: "foo",
-  },
 }

--- a/packages/typescriptlang-org/src/copy/en/documentation.ts
+++ b/packages/typescriptlang-org/src/copy/en/documentation.ts
@@ -6,16 +6,16 @@ export const docCopy = {
   doc_bootstrap_description:
     "Toolchains for building CLIs, Web Apps, APIs, and Apps.",
   doc_headline: "Learning Resources",
-  doc_headline_ts_for_js_title: "TS for JS",
+  doc_headline_ts_for_js_title: "TS for JS", // TODO: Remove, unused
   doc_headline_ts_for_js_blurb:
-    "An overview of TypeScript for engineers with a JavaScript background",
-  doc_headline_ts_first_title: "Start with TS",
+    "An overview of TypeScript for engineers with a JavaScript background", // TODO: Remove, unused
+  doc_headline_ts_first_title: "Start with TS", // TODO: Remove, unused
   doc_headline_ts_first_blurb:
-    "A beginners introduction to JavaScript and TypeScript",
-  doc_headline_handbook_title: "Handbook",
+    "A beginners introduction to JavaScript and TypeScript", // TODO: Remove, unused
+  doc_headline_handbook_title: "Handbook", // TODO: This is not actually used on headline section, should be moved to the doc_learn section
   doc_headline_handbook_blurb: "The TypeScript language reference",
-  doc_headline_examples_title: "Examples",
-  doc_headline_examples_blurb: "Comprehensive hands-on playground tutorials",
+  doc_headline_examples_title: "Examples", // TODO: Remove, unused
+  doc_headline_examples_blurb: "Comprehensive hands-on playground tutorials", // TODO: Remove, unused
   doc_start_a_project: "Start a New Project",
   doc_start_a_project_desc:
     "Because TypeScript is a super-set of JavaScript, it doesn't have a default template - there would be too many. Instead, other projects have their own TypeScript bootstrap templates with their own context. These projects provide templates which include TypeScript support.",
@@ -56,7 +56,8 @@ export const docCopy = {
   doc_react_toolchains_title: "Recommended Toolchains",
   doc_react_toolchains_blurb: "Recommendations from the React Team",
   doc_apps: "Building Apps",
-  doc_apps_electron_blurb: "Set up a modern web app by running one command",
+  doc_apps_electron_blurb:
+    "Build cross-platform desktop apps with JavaScript, HTML, and CSS",
   doc_apps_expo_blurb: "The fastest way to build an app",
   doc_apps_react_native_blurb: "Learn once, write anywhere",
   doc_apps_native_script_blurb:
@@ -70,12 +71,8 @@ export const docCopy = {
   doc_tooling_webpack_blurb: "Bundle your assets, scripts, images and styles",
   doc_learn: "Familiar With TypeScript already?",
   doc_learn_3_5_release_notes_title: "Release Notes",
-  doc_learn_handbook_blurb: "The TypeScript language reference",
+  doc_learn_handbook_blurb: "The TypeScript language reference", // TODO: Remove, unused
   doc_learn_d_ts_title: "d.ts Guide",
   doc_learn_d_ts_blurb: "Learn how to declare the shape of JS",
   doc_learn_playground_blurb: "Explore and share TypeScript online",
-  nav_: {
-    id: "foo",
-    defaultMessage: "foo",
-  },
 }

--- a/packages/typescriptlang-org/src/copy/es/community.ts
+++ b/packages/typescriptlang-org/src/copy/es/community.ts
@@ -24,8 +24,4 @@ export const comCopy = {
   com_person: "Conéctate en persona",
   com_conferences: "Conferencias",
   com_conferences_alt_img: "logo de ",
-  nav_: {
-    id: "foo",
-    defaultMessage: "foo",
-  },
 }

--- a/packages/typescriptlang-org/src/copy/es/documentation.ts
+++ b/packages/typescriptlang-org/src/copy/es/documentation.ts
@@ -79,8 +79,4 @@ export const docCopy = {
   doc_learn_d_ts_title: "Guía para definiciones en TypeScript (d.ts)",
   doc_learn_d_ts_blurb: "Aprende a declarar la forma de JS",
   doc_learn_playground_blurb: "Explora y comparte TypeScript en línea",
-  nav_: {
-    id: "foo",
-    defaultMessage: "foo",
-  },
 }

--- a/packages/typescriptlang-org/src/copy/pt.ts
+++ b/packages/typescriptlang-org/src/copy/pt.ts
@@ -1,0 +1,8 @@
+import { defineMessages } from "react-intl"
+import { Copy, messages as englishMessages } from "./en"
+import { docCopy } from "./pt/documentation"
+
+export const lang: Copy = defineMessages({
+  ...englishMessages,
+  ...docCopy,
+})

--- a/packages/typescriptlang-org/src/copy/pt/documentation.ts
+++ b/packages/typescriptlang-org/src/copy/pt/documentation.ts
@@ -1,7 +1,7 @@
 export const docCopy = {
   doc_layout_title: "O ponto inicial para aprender Typescript",
   doc_layout_description:
-    "Encontre projetos para começar Typescript: de Angular a React ou Node.js e CLIs.",
+    "Encontre projetos para começar com Typescript: de Angular a React ou Node.js e CLIs.",
   doc_headline: "Recursos para estudo",
   doc_headline_ts_for_js_title: "TS para JS",
   doc_headline_ts_for_js_blurb:
@@ -12,7 +12,7 @@ export const docCopy = {
   doc_headline_handbook_title: "Manual",
   doc_headline_handbook_blurb: "Referência da linguagem TypeScript",
   doc_headline_examples_title: "Exemplos",
-  doc_headline_examples_blurb: "Tutoriais práticos compreensivos",
+  doc_headline_examples_blurb: "Tutoriais práticos e compreensivos",
   doc_start_a_project: "Comece um projeto",
   doc_start_a_project_desc:
     "Como Typescript é uma extensão do JavaScript, não existe um único molde. Ao invés disso, outros projetos tem seus próprios esqueletos para começar com TypeScript, de acordo com cada contexto. Esses projetos fornecem estruturas básicas que incluem suporte a Typescript.",
@@ -25,12 +25,13 @@ export const docCopy = {
     "Uma maravilhosa coleção de ferramentas para construir aplicativos de linha de comando em Typescript",
   doc_frameworks: "Frameworks Web",
   doc_frameworks_angular_blurb:
-    "Torna escrever apps lindos em algo alegre e divertido",
+    "Transforme o trabalho de escrever apps lindos em algo alegre e divertido",
   doc_frameworks_ember_blurb: "Framework para desenvolvedores web ambiciosos",
   doc_frameworks_react_blurb:
     "Uma biblioteca JavaScript para construir interfaces de usuário",
   doc_frameworks_vue_blurb: "O framework JavaScript progressivo",
-  doc_frameworks_ror_blurb: "Framework Web da convenção acima da configuração",
+  doc_frameworks_ror_blurb:
+    "Framework Web com preferência por convenção ao invés de configuração",
   doc_frameworks_asp_blurb:
     "Framework para aplicações modernas, conectadas à internet e baseadas na nuvem",
   doc_apis: "APIs Node",
@@ -39,24 +40,24 @@ export const docCopy = {
   doc_apis_feather_blurb: "Framework para aplicações em tempo real e APIs REST",
   doc_apis_graphql_blurb: "Comece seu próprio servidor GraphQL em segundos",
   doc_apis_nest_blurb:
-    "Uma framework Node.js progressiva para construir aplicações de servidor eficientes e escaláveis",
+    "Um framework Node.js progressivo para construir aplicações de servidor eficientes e escaláveis",
   doc_apis_node_blurb:
     "Um modelo bem documentado, cortesia do time do TypeScript",
   doc_apis_wechat_blurb: "Use o JSSDK do WeChat com TypeScript",
   doc_apis_loopback_blurb:
-    "Uma framework Node.js e Typescript altamente expansível para construir APIs e microserviços",
+    "Um framework Node.js e Typescript altamente expansível para construir APIs e microsserviços",
   doc_apis_fastify_blurb:
-    "Uma framework web rápida e de baixo custo computacional para Node.js",
+    "Um framework web rápido e de baixo custo computacional para Node.js",
   doc_react: "Projetos em React",
   doc_react_create_blurb: "Crie uma aplicação web moderna com um só comando",
   doc_react_gatsby_blurb:
     "Ajuda desenvolvedores a construir sites e apps web incrivelmente rápidos",
-  doc_react_next_blurb: "A framework React",
+  doc_react_next_blurb: "O framework React",
   doc_react_razzle_blurb:
     "Aplicações universais em JavaScript, renderizadas em servidor - nenhuma configuração necessária",
   doc_react_toolchains_title: "Ferramentas recomendadas",
   doc_react_toolchains_blurb: "Recomendadas pelo time do React",
-  doc_apps: "Construíndo aplicativos",
+  doc_apps: "Construindo aplicativos",
   doc_apps_electron_blurb:
     "Construa aplicativos para desktop multi-plataforma com JavaScript, HTML e CSS",
   doc_apps_expo_blurb: "A maneira mais rápida de se construir um app",
@@ -70,7 +71,7 @@ export const docCopy = {
   doc_tooling_parcel_blurb:
     "Bundler de aplicações web incrivelmente rápido, sem configuração necessária",
   doc_tooling_webpack_blurb: "Agrupe seus recursos, scripts, images e estilos",
-  doc_learn: "Já é familiar com Typescript?",
+  doc_learn: "Já conhece Typescript?",
   doc_learn_3_5_release_notes_title: "Notas de versão",
   doc_learn_3_5_release_notes_blurb: "Notas da versão 3.5",
   doc_learn_handbook_blurb: "Referência da linguagem TypeScript",

--- a/packages/typescriptlang-org/src/copy/pt/documentation.ts
+++ b/packages/typescriptlang-org/src/copy/pt/documentation.ts
@@ -1,0 +1,80 @@
+export const docCopy = {
+  doc_layout_title: "O ponto inicial para aprender Typescript",
+  doc_layout_description:
+    "Encontre projetos para começar Typescript: de Angular a React ou Node.js e CLIs.",
+  doc_headline: "Recursos para estudo",
+  doc_headline_ts_for_js_title: "TS para JS",
+  doc_headline_ts_for_js_blurb:
+    "Um resumo de Typescript para engenheiros com experiência em JavaScript",
+  doc_headline_ts_first_title: "Comece com TS",
+  doc_headline_ts_first_blurb:
+    "Uma introdução para iniciantes a JavaScript e TypeScript",
+  doc_headline_handbook_title: "Manual",
+  doc_headline_handbook_blurb: "Referência da linguagem TypeScript",
+  doc_headline_examples_title: "Exemplos",
+  doc_headline_examples_blurb: "Tutoriais práticos compreensivos",
+  doc_start_a_project: "Comece um projeto",
+  doc_start_a_project_desc:
+    "Como Typescript é uma extensão do JavaScript, não existe um único molde. Ao invés disso, outros projetos tem seus próprios esqueletos para começar com TypeScript, de acordo com cada contexto. Esses projetos fornecem estruturas básicas que incluem suporte a Typescript.",
+  doc_node_npm: "Node com npm",
+  doc_node_npm_tsdx_blurb:
+    "Ferramenta sem necessidade de configuração para construir bibliotecas TypeScript",
+  doc_node_npm_oclif_blurb:
+    "Crie ferramentas de linha de comando que seus usuários amam",
+  doc_node_npm_gluegun_blurb:
+    "Uma maravilhosa coleção de ferramentas para construir aplicativos de linha de comando em Typescript",
+  doc_frameworks: "Frameworks Web",
+  doc_frameworks_angular_blurb:
+    "Torna escrever apps lindos em algo alegre e divertido",
+  doc_frameworks_ember_blurb: "Framework para desenvolvedores web ambiciosos",
+  doc_frameworks_react_blurb:
+    "Uma biblioteca JavaScript para construir interfaces de usuário",
+  doc_frameworks_vue_blurb: "O framework JavaScript progressivo",
+  doc_frameworks_ror_blurb: "Framework Web da convenção acima da configuração",
+  doc_frameworks_asp_blurb:
+    "Framework para aplicações modernas, conectadas à internet e baseadas na nuvem",
+  doc_apis: "APIs Node",
+  doc_apis_azure_blurb:
+    "Construa e distribua dentro do VS Code em questão de minutos",
+  doc_apis_feather_blurb: "Framework para aplicações em tempo real e APIs REST",
+  doc_apis_graphql_blurb: "Comece seu próprio servidor GraphQL em segundos",
+  doc_apis_nest_blurb:
+    "Uma framework Node.js progressiva para construir aplicações de servidor eficientes e escaláveis",
+  doc_apis_node_blurb:
+    "Um modelo bem documentado, cortesia do time do TypeScript",
+  doc_apis_wechat_blurb: "Use o JSSDK do WeChat com TypeScript",
+  doc_apis_loopback_blurb:
+    "Uma framework Node.js e Typescript altamente expansível para construir APIs e microserviços",
+  doc_apis_fastify_blurb:
+    "Uma framework web rápida e de baixo custo computacional para Node.js",
+  doc_react: "Projetos em React",
+  doc_react_create_blurb: "Crie uma aplicação web moderna com um só comando",
+  doc_react_gatsby_blurb:
+    "Ajuda desenvolvedores a construir sites e apps web incrivelmente rápidos",
+  doc_react_next_blurb: "A framework React",
+  doc_react_razzle_blurb:
+    "Aplicações universais em JavaScript, renderizadas em servidor - nenhuma configuração necessária",
+  doc_react_toolchains_title: "Ferramentas recomendadas",
+  doc_react_toolchains_blurb: "Recomendadas pelo time do React",
+  doc_apps: "Construíndo aplicativos",
+  doc_apps_electron_blurb:
+    "Construa aplicativos para desktop multi-plataforma com JavaScript, HTML e CSS",
+  doc_apps_expo_blurb: "A maneira mais rápida de se construir um app",
+  doc_apps_react_native_blurb: "Aprenda uma vez, escreva em qualquer lugar",
+  doc_apps_native_script_blurb:
+    "Framework de código aberto para construir aplicativos móveis verdadeiramente nativos",
+  doc_apps_make_code_blurb:
+    "Traga à vida ciência da computação para qualquer estudante com projetos divertidos",
+  doc_tooling: "Ferramentas",
+  doc_tooling_babel_blurb: "Use Javascript da próxima geração, hoje",
+  doc_tooling_parcel_blurb:
+    "Bundler de aplicações web incrivelmente rápido, sem configuração necessária",
+  doc_tooling_webpack_blurb: "Agrupe seus recursos, scripts, images e estilos",
+  doc_learn: "Já é familiar com Typescript?",
+  doc_learn_3_5_release_notes_title: "Notas de versão",
+  doc_learn_3_5_release_notes_blurb: "Notas da versão 3.5",
+  doc_learn_handbook_blurb: "Referência da linguagem TypeScript",
+  doc_learn_d_ts_title: "Guia d.ts",
+  doc_learn_d_ts_blurb: "Aprenda como declarar a forma de JS",
+  doc_learn_playground_blurb: "Explore and compartilhe TypeScript online",
+}

--- a/packages/typescriptlang-org/src/copy/zh/documentation.ts
+++ b/packages/typescriptlang-org/src/copy/zh/documentation.ts
@@ -7,7 +7,8 @@ export const docCopy = {
   doc_headline_ts_for_js_blurb: "给 JavaScript 工程师的 TypeScript 概述",
   doc_headline_ts_first_title: "从 TS 开始",
   doc_headline_ts_first_blurb: "针对初学者的 JavaScript 和 TypeScript 的介绍",
-  doc_apis_loopback_blurb: "一个高度可扩展、用于构建 API 和微服务的 TypeScript Node.js 框架",
+  doc_apis_loopback_blurb:
+    "一个高度可扩展、用于构建 API 和微服务的 TypeScript Node.js 框架",
   doc_apis_fastify_blurb: "一个快速且低开销的 Node.js Web 框架",
   doc_headline_handbook_title: "手册",
   doc_headline_handbook_blurb: "TypeScript 语言参考",
@@ -59,8 +60,4 @@ export const docCopy = {
   doc_learn_d_ts_title: "d.ts 指南",
   doc_learn_d_ts_blurb: "学习如何定义 JS 的形状",
   doc_learn_playground_blurb: "在线查看并分享 TypeScript",
-  nav_: {
-    id: "foo",
-    defaultMessage: "foo",
-  },
 }

--- a/packages/typescriptlang-org/src/templates/pages/docs/bootstrap.tsx
+++ b/packages/typescriptlang-org/src/templates/pages/docs/bootstrap.tsx
@@ -182,7 +182,7 @@ const Index: React.FC<Props> = (props) => {
         <ButtonGrid
           buttons={[
             {
-              href: "https://babeljs.io/docs/en/babel-preset-typescript",
+              href: "https://www.electronjs.org/",
               badge: "Plugin",
               blurb: i("doc_apps_electron_blurb"),
               title: "Electron",
@@ -244,7 +244,7 @@ const Index: React.FC<Props> = (props) => {
             {
               href: "/docs/handbook/basic-types.html",
               blurb: i("doc_headline_handbook_blurb"),
-              title: "Handbook",
+              title: i("doc_headline_handbook_title"),
             },
             {
               href: "/docs/handbook/declaration-files/introduction.html",


### PR DESCRIPTION
Documentation home page is translated to Portuguese! @orta, @khaosdoctor, @alvarocamillont

Related to https://github.com/microsoft/TypeScript-Website/pull/822, tracked by https://github.com/microsoft/TypeScript-Website/issues/233

Some notes:

- The headline links are not internationalized. I added a TODO comment
- Some keys are declared but unused
- The link for Electron was invalid
- The title of the `Handbook` tile was hard-coded

- I had some to make some translation decisions/trade-offs:
    - `Framework`, `Web`, `Bundler` are some technical terms with no meaningful equivalent in Portuguese, so I kept them as-is
    - `Zero config` is not an expression we do have in Portuguese, so I tried to make some contextual translations

# 📄  📷 
![image](https://user-images.githubusercontent.com/17657014/89107990-715efa00-d40b-11ea-832f-95c0fff3e892.png)
