### PR TITLE
docs(es): translation of TypeScript Language section

### DIFF
--- a/packages/playground-examples/copy/es/TypeScript/Language/Soundness.ts
+++ b/packages/playground-examples/copy/es/TypeScript/Language/Soundness.ts
@@ -1,0 +1,114 @@
+//// {compiler: { strictFunctionTypes: false } }
+
+// Sin antecedentes en la teoría de tipos, es poco probable que esté
+// familiarizado con la idea de que un sistema de tipos sea "sólido".
+
+// La Solidez es la idea de que el compilador puede dar garantías sobre el tipo
+// de valor que tiene un valor en tiempo de ejecución, y no sólo durante la
+// compilación. Esto es normal para la mayoría de los lenguajes de programación
+// que se construyen con tipos desde el primer día.
+
+// Sin embargo, la construcción de un sistema de tipos que modela un lenguaje el
+// cual ha existido por algunas décadas se torna en la toma de decisiones para
+// compensar tres cualidades: Simplicidad, Usabilidad y Solidez.
+
+// Siendo el objetivo de TypeScript de ser capaz de soportar todo el código
+// JavaScript, el lenguaje tiende a la simplicidad y la usabilidad cuando se
+// presenta con formas de añadir tipos a JavaScript.
+
+// Veamos algunos casos en los cuales TypeScript probablemente no es sólido,
+// para entender cómo se verían esas compensaciones de otra manera.
+
+// Aserciones de Tipo
+
+const usersAge = ("23" as any) as number;
+
+// TypeScript le permitirá usar aserciones de tipo para anular la inferencia de
+// algo que está mal. El uso de aserciones de tipo es una manera de decirle a
+// TypeScript que usted sabe lo que hace, y TypeScript tratará de dejarle
+// continuar con ello.
+
+// Los lenguajes que son sólidos ocasionalmente usarían comprobaciones de tiempo
+// de ejecución para asegurarse de que los datos coinciden con lo que dicen sus
+// tipos - pero TypeScript tiene como objetivo no tener un impacto en tiempo de
+// ejecución de los tipos en su código transpilado.
+
+// Parámetro de función Bi-variante
+
+// Los parámetros de una función soportan la redefinición del parámetro para que
+// sea un subtipo de la declaración original.
+
+interface InputEvent {
+  timestamp: number;
+}
+interface MouseInputEvent extends InputEvent {
+  x: number;
+  y: number;
+}
+interface KeyboardInputEvent extends InputEvent {
+  keyCode: number;
+}
+
+function listenForEvent(eventType: "keyboard" | "mouse", handler: (event: InputEvent) => void) {}
+
+// Puede volver a declarar el tipo de parámetro para que sea un subtipo de la
+// declaración. En lo anterior, el parámetro `handler` esperaba un tipo
+// InputEvent pero en los siguientes ejemplos - TypeScript acepta un tipo que
+// tiene propiedades adicionales.
+
+listenForEvent("keyboard", (event: KeyboardInputEvent) => {});
+listenForEvent("mouse", (event: MouseInputEvent) => {});
+
+// Esto puede extenderse hasta el tipo común más pequeño:
+
+listenForEvent("mouse", (event: {}) => {});
+
+// Pero no más allá:
+
+listenForEvent("mouse", (event: string) => {});
+
+// Esto cubre el patrón del mundo real para escuchar eventos en JavaScript, a
+// expensas de tener un código más sólido.
+
+// TypeScript puede arrojar un error cuando esto sucede a través de la opción
+// `strictFunctionTypes`. O, podrías trabajar alrededor de este caso particular
+// con sobrecargas de funciones,
+// Véase: example:typing-functions
+
+// Caso especial para Void
+
+// Descarte de parámetros
+
+// Para conocer acerca de los casos especiales con parámetros de función
+// Véase example:structural-typing
+
+// Parámetros Rest
+
+// Los parámetros rest se asumen todos como opcionales, esto significa que
+// TypeScript no tiene manera de hacer cumplir el número de parámetros
+// disponibles para una llamada de retorno.
+
+function getRandomNumbers(count: number, callback: (...args: number[]) => void) {}
+
+getRandomNumbers(2, (first, second) => console.log([first, second]));
+getRandomNumbers(400, first => console.log(first));
+
+// Las funciones declaradas `void` pueden coincidir con una función con un valor de retorno
+
+// Una función que retorna una función declarada `void` puede aceptar una
+// función que acepta cualquier otro tipo.
+
+const getPI = () => 3.14;
+
+function runFunction(func: () => void) {
+  func();
+}
+
+runFunction(getPI);
+
+// Para más información sobre los lugares donde la solidez del sistema de tipos
+// se ve comprometida, véase:
+
+// https://github.com/Microsoft/TypeScript/wiki/FAQ#type-system-behavior
+// https://github.com/Microsoft/TypeScript/issues/9825
+// https://www.typescriptlang.org/docs/handbook/type-compatibility.html

--- a/packages/playground-examples/copy/es/TypeScript/Language/Structural Typing.ts
+++ b/packages/playground-examples/copy/es/TypeScript/Language/Structural Typing.ts
@@ -1,0 +1,89 @@
+// TypeScript es un sistema de tipo estructural. Un sistema
+// de tipo estructural significa que cuando se comparan los
+// tipos, TypeScript sólo tiene en cuenta los miembros en el
+// tipo.
+
+// Esto es en contraste con los sistemas de tipo nominal,
+// donde se pueden crear dos tipos pero no se pueden asignar
+// uno al otro. Véase example:nominal-typing
+
+// Por ejemplo, estas dos interfaces son completamente
+// transferibles en un sistema de tipo estructural:
+
+interface Ball {
+  diameter: number;
+}
+interface Sphere {
+  diameter: number;
+}
+
+let ball: Ball = { diameter: 10 };
+let sphere: Sphere = { diameter: 20 };
+
+sphere = ball;
+ball = sphere;
+
+// Si añadimos un tipo que estructuralmente contiene todos
+// los miembros de Ball (Bola) y Sphere (Esfera), entonces
+// también puede ser configurado para ser una bola o esfera.
+
+interface Tube {
+  diameter: number;
+  length: number;
+}
+
+let tube: Tube = { diameter: 12, length: 3 };
+
+tube = ball;
+ball = tube;
+
+// Debido a que una bola no tiene una longitud, no puede ser
+// asignada a la variable `tube`. Sin embargo, todos los
+// miembros de Ball están dentro de Tube, y por lo
+// tanto puede ser asignada.
+
+// TypeScript está comparando cada miembro del tipo con los
+// demás para verificar su igualdad.
+
+// Una función es un objeto en JavaScript y se compara de
+// manera similar. Con un útil truco extra alrededor de los
+// parámetros:
+
+let createBall = (diameter: number) => ({ diameter });
+let createSphere = (diameter: number, useInches: boolean) => {
+  return { diameter: useInches ? diameter * 0.39 : diameter };
+};
+
+createSphere = createBall;
+createBall = createSphere;
+
+// TypeScript permitirá que (number) sea igual a (number, boolean)
+// en los parámetros, pero no (number, boolean) -> (number)
+
+// TypeScript descartará el booleano en la primera
+// asignación porque es muy común que el código JavaScript
+// salte los parámetros de paso cuando no se necesitan.
+
+// Por ejemplo, el método forEach del arreglo tiene tres
+// parámetros, value, index y el arreglo entero - si
+// TypeScript no soportará el descarte de parámetros,
+// entonces tendrías que incluir todas las opciones para
+// hacer que las funciones coincidieran:
+
+[createBall(1), createBall(2)].forEach((ball, _index, _balls) => {
+  console.log(ball);
+});
+
+// Nadie necesita eso.
+
+// Los tipos de retorno se tratan como objetos, y cualquier
+// diferencia se compara con las mismas reglas de igualdad
+// de objetos de arriba.
+
+let createRedBall = (diameter: number) => ({ diameter, color: "red" });
+
+createBall = createRedBall;
+createRedBall = createBall;
+
+// Donde la primera asignación funciona (ambos tienen
+// diámetro) pero la segunda no (la bola no tiene color).

--- a/packages/playground-examples/copy/es/TypeScript/Language/Type Guards.ts
+++ b/packages/playground-examples/copy/es/TypeScript/Language/Type Guards.ts
@@ -1,0 +1,91 @@
+// Las guardias de tipo es el término en el que influyes en el análisis del
+// flujo de código a través del código. TypeScript utiliza el comportamiento
+// existente de JavaScript que valida sus objetos en tiempo de ejecución para
+// influir en el flujo de código. Este ejemplo asume que has leído
+// example:code-flow
+
+// Para repasar estos ejemplos, crearemos algunas clases, aquí hay un sistema
+// para manejar los pedidos por Internet o por teléfono.
+
+interface Order {
+  address: string;
+}
+interface TelephoneOrder extends Order {
+  callerNumber: string;
+}
+interface InternetOrder extends Order {
+  email: string;
+}
+
+// Entonces un tipo puede ser cualquiera de los dos subtipos de Order o undefined
+type PossibleOrders = TelephoneOrder | InternetOrder | undefined;
+
+// Y una función que retorna una posible orden `PossibleOrder`
+declare function getOrder(): PossibleOrders;
+const possibleOrder = getOrder();
+
+// Podemos usar el operador "in" para verificar si una llave en particular está
+// en el objeto a deducir de la unión. ("in" es un operador de JavaScript para
+// probar las claves de los objetos.)
+
+if ("email" in possibleOrder) {
+  const mustBeInternetOrder = possibleOrder;
+}
+
+// Puedes usar el operador "instanceof" de JavaScript si tienes una clase que se
+// ajusta a la interfaz:
+
+class TelephoneOrderClass {
+  address: string;
+  callerNumber: string;
+}
+
+if (possibleOrder instanceof TelephoneOrderClass) {
+  const mustBeTelephoneOrder = possibleOrder;
+}
+
+// Puedes usar el operador "typeof" para reducir la unión. Esto solo funciona
+// con las primitivas de JavaScript (como cadenas, objetos, números).
+
+if (typeof possibleOrder === "undefined") {
+  const definitelyNotAnOder = possibleOrder;
+}
+
+// Puede ver una lista completa de los posibles valores de typeof aquí:
+// https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/typeof
+
+// Usando los operadores de JavaScript sólo pueden llegar hasta aquí. Cuando
+// quieras comprobar tus propios tipos de objetos puedes usar las funciones de
+// predicado de tipos.
+
+// Una función de predicado de tipos es una función donde el tipo retornado
+// ofrece información al análisis del flujo de código cuando la función evaluada
+// es verdadera.
+
+// Usando el tipo PossibleOrders, podemos usar dos guardias de tipo para
+// declarar de que tipo es la orden:
+
+function isAnInternetOrder(order: PossibleOrders): order is InternetOrder {
+  return order && "email" in order;
+}
+
+function isATelephoneOrder(order: PossibleOrders): order is TelephoneOrder {
+  return order && "calledNumber" in order;
+}
+
+// Ahora podemos usar estas funciones en las declaraciones if para deducir el
+// tipo de la variable possibleOrder dentro del condicional if:
+
+if (isAnInternetOrder(possibleOrder)) {
+  console.log("Order received via email:", possibleOrder.email);
+}
+
+if (isATelephoneOrder(possibleOrder)) {
+  console.log("Order received via phone:", possibleOrder.callerNumber);
+}
+
+// Puedes leer más sobre el análisis del flujo de código aquí:
+//
+//  - example:code-flow
+//  - example:type-guards
+//  - example:discriminate-types

--- a/packages/playground-examples/copy/es/TypeScript/Language/Type Widening and Narrowing.ts
+++ b/packages/playground-examples/copy/es/TypeScript/Language/Type Widening and Narrowing.ts
@@ -1,0 +1,67 @@
+// Podría ser más fácil comenzar el debate sobre la ampliación y
+// la reducción con un ejemplo:
+
+const welcomeString = "Hello There";
+let replyString = "Hey";
+
+// Aparte de las diferencias de texto en las cadenas, welcomeString
+// es una const (lo que significa que el valor nunca cambiará)
+// y replyString es un let (lo que significa que puede cambiar).
+
+// Si pasas el cursor por encima de ambas variables, obtienes
+// información de tipo muy diferente de TypeScript:
+//
+//   const welcomeString: "Hello There"
+//
+//   let replyString: string
+
+// TypeScript ha inferido el tipo de welcomeString como la cadena
+// literal "Hello There", mientras que replyString es una cadena
+// general.
+
+// Esto se debe a que let necesita un tipo mas amplio, podrias
+// establecer replyString como cualquier otra cadena, lo que
+// significa que tiene un conjunto más amplio de posibilidades.
+
+replyString = "Hi :wave:";
+
+// Si replyString tiene como tipo la cadena literal "Hey" -
+// entonces nunca podrías cambiar el valor porque sólo podría
+// cambiar a "Hey" de nuevo.
+
+// La ampliación y reducción de tipos se basa en aumentar o
+// reducir las posibilidades que un tipo puede representar.
+
+// Un ejemplo de reducción de tipo es trabajar con uniones, el
+// ejemplo del análisis de flujo de código se basa casi
+// enteramente en la reducción: example:code-flow
+
+// La reducción de tipo es lo que impulsa el modo estricto de
+// TypeScript a través de las verificaciones de nulidad. Con el
+// modo estricto desactivado, los marcadores de nulidad como
+// indefinido y nulo son ignorados en una unión.
+
+declare const quantumString: string | undefined;
+// Esto fallará sólo en modo estricto
+quantumString.length;
+
+// En el modo estricto la responsabilidad es del autor del código
+// para asegurar que el tipo se ha reducido al tipo no nulo.
+// Normalmente esto es tan simple como una comprobación de tipo if:
+
+if (quantumString) {
+  quantumString.length;
+}
+
+// En el modo estricto, el tipo quantumString tiene dos representaciones.
+// Dentro del condicional if, el tipo fue reducido a solo una cadena.
+
+// Puede ver más ejemplos de reducción en:
+//
+// example:union-and-intersection-types
+// example:discriminate-types
+
+// Y aún más recursos en la web:
+//
+// https://mariusschulz.com/blog/literal-type-widening-in-typescript
+// https://sandersn.github.io/manual/Widening-and-Narrowing-in-Typescript.html

--- a/packages/typescriptlang-org/src/copy/es/community.ts
+++ b/packages/typescriptlang-org/src/copy/es/community.ts
@@ -20,8 +20,8 @@ export const comCopy = {
   com_online_typed_desc: "Archivos de definiciones de TypeScript.",
   com_online_typed_href: "Navegue por los miles de",
   com_online_typed_available_for:
-    "disponibles para las librerias y marcos de trabajo comunes.",
-  com_person: "Conectesé en persona",
+    "disponibles para las librerías y marcos de trabajo comunes.",
+  com_person: "Conéctate en persona",
   com_conferences: "Conferencias",
   com_conferences_alt_img: "logo de ",
   nav_: {

--- a/packages/typescriptlang-org/src/copy/es/documentation.ts
+++ b/packages/typescriptlang-org/src/copy/es/documentation.ts
@@ -14,7 +14,7 @@ export const docCopy = {
   doc_headline_examples_title: "Ejemplos",
   doc_headline_examples_blurb:
     "Completos tutoriales prácticos en el Playground",
-  doc_start_a_project: "¡Inicie un projecto!",
+  doc_start_a_project: "¡Inicie un proyecto!",
   doc_start_a_project_desc:
     "Debido a que TypeScript es un superconjunto de JavaScript, no tiene una plantilla por defecto - habría demasiadas. En su lugar, otros proyectos tienen sus propias plantillas de TypeScript con su propio contexto. Estos proyectos proporcionan plantillas que incluyen soporte para TypeScript.",
   doc_node_npm: "Node con npm",

--- a/packages/typescriptlang-org/src/copy/es/index.ts
+++ b/packages/typescriptlang-org/src/copy/es/index.ts
@@ -17,13 +17,13 @@ export const indexCopy = {
   <p>Denotar tipos es opcional en TypeScript, porque la inferencia de tipos le permite obtener mucha más potencia sin escribir código adicional.</p>`,
 
   index_trust: "Resultados Confiables",
-  index_trust_copy_a: `Todo código en JavaScript tambien es válido en TypeScript. Puedes tener validación de errores de tipo, pero eso no te detendrá de ejecutar el JavaScript resultante. Si bien puedes optar por un comportamiento más estricto, eso significa que aún tienes el control.`,
-  index_trust_copy_b: `TypeScript code is transformed into JavaScript code via the TypeScript compiler or <babel>Babel</babel>. This JavaScript is clean, simple code which runs anywhere JavaScript runs: In a browser, on Node.JS or in your apps.`,
-  index_standards: "Evolucionando Con Estandares.",
+  index_trust_copy_a: `Todo código en JavaScript también es válido en TypeScript. Puedes tener validación de errores de tipo, pero eso no te detendrá de ejecutar el JavaScript resultante. Si bien puedes optar por un comportamiento más estricto, eso significa que aún tienes el control.`,
+  index_trust_copy_b: `El código en TypeScript es transformado en código JavaScript a través del compilador de TypeScript o <babel>Babel</babel>. Este JavaScript es un código limpio y simple que se ejecuta en cualquier lugar donde se ejecuta JavaScript: En un navegador, en Node.JS o en tus aplicaciones.`,
+  index_standards: "Evolucionando Con Estándares.",
   index_standards_copy: `
     <p>El equipo detrás de TypeScript contribuye al comité TC39 que ayuda a guiar la evolución del lenguaje JavaScript.</p>
   
-    <p>Cuando nuevas caracteristicas han alcanzado la etapa 3, es cuando se encuentran listas para ser incluidas en TypeScript.</p>
+    <p>Cuando nuevas características han alcanzado la etapa 3, es cuando se encuentran listas para ser incluidas en TypeScript.</p>
     
     <p>Por ejemplo el equipo de TypeScript logró propuestas como encadenamiento opcional, operador de fusión nulo, expresiones de excepciones e índices de coincidencia RegExp.</p>`,
 
@@ -35,7 +35,7 @@ export const indexCopy = {
 
   index_dts: "Tipado en todas partes",
   index_dts_copy: `
-  <p>El código JavaScript en gran parte del mundo no tiene tipado y la inferencia solo puede llegar hasta donde puede. Para afrontar esto, el equipo de TypeScript ayuda a mantener <dt>Definitely Typed</dt> - un proyecto comunitario para proporcionar tipos y documentación en línea a JavaScript existente.</p>
+  <p>El código JavaScript en gran parte del mundo no tiene tipado y la inferencia solo puede llegar hasta donde puede. Para afrontar esto, el equipo de TypeScript ayuda a mantener <dt>Definitely Typed</dt> - un proyecto comunitario para proporcionar tipos y documentación en línea a JavaScript existente.
   
   <p>Este proyecto permite a la comunidad mantener definiciones de tipo para bibliotecas JavaScript sin ejercer presión adicional sobre sus mantenedores.</p>`,
 
@@ -51,15 +51,15 @@ export const indexCopy = {
   index_started_title: "Empezar",
   index_started_handbook: "Manual",
   index_started_handbook_blurb: "Aprende el lenguaje",
-  index_started_guides: "Referencias",
-  index_started_guides_blurb: "Reseñas de alto nivel",
+  index_started_docs: "Comienza un proyecto",
+  index_started_docs_blurb: "Encuentra una herramienta inicial",
   index_started_ref: "Referencia",
   index_started_ref_blurb: "Entendiendo la herramienta",
   index_started_community: "Comunidad",
   index_started_community_blurb: "Mantente al día",
   index_install: "Instalar TypeScript",
   index_install_ref: `
-    <p>Puedes instalar TypeScript a tráves de npm<pre>npm install -g typescript</pre>
+    <p>Puedes instalar TypeScript a través de npm<pre>npm install -g typescript</pre>
     <p>Y luego ejecutar el compilador con el comando <code>tsc</code><pre>npm install -g typescript</pre>
     `,
   index_releases: "Publicaciones trimestrales",

--- a/packages/typescriptlang-org/src/copy/inYourLanguage.ts
+++ b/packages/typescriptlang-org/src/copy/inYourLanguage.ts
@@ -12,7 +12,7 @@ export const inYourLanguage: Record<
     shorthand: "En Es",
     body: "Esta página está disponible en Español",
     open: "Adelante",
-    cancel: "No preguntes de nuevo",
+    cancel: "No preguntar de nuevo",
   },
   pt: {
     shorthand: "Em Pt",


### PR DESCRIPTION
References #232

- **TypeScript -> Language Section**
  - [x] [Soundness.ts](https://github.com/microsoft/TypeScript-Website/blob/v2/packages//playground-examples/copy/en/TypeScript/Language/Soundness.ts)
  - [x] [Structural Typing.ts](https://github.com/microsoft/TypeScript-Website/blob/v2/packages//playground-examples/copy/en/TypeScript/Language/Structural%20Typing.ts)
  - [x] [Type Guards.ts](https://github.com/microsoft/TypeScript-Website/blob/v2/packages//playground-examples/copy/en/TypeScript/Language/Type%20Guards.ts)
  - [x] [Type Widening and Narrowing.ts](https://github.com/microsoft/TypeScript-Website/blob/v2/packages//playground-examples/copy/en/TypeScript/Language/Type%20Widening%20and%20Narrowing.ts)

Also provides minor typo fixes to the index and community files 🚀 