### PR TITLE
Add import helpers to the playground config

### DIFF
--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -386,8 +386,8 @@ export const setupPlayground = (
       } else {
         sidebarTabs.style.display = "none"
         sidebarContent.style.display = "none"
-        settingsContent.style.display = "block";
-        (document.querySelector(".playground-sidebar label") as any).focus()
+        settingsContent.style.display = "block"
+        ;(document.querySelector(".playground-sidebar label") as any).focus()
       }
       settingsToggle.parentElement!.classList.toggle("open")
     }
@@ -462,8 +462,8 @@ export const setupPlayground = (
   }
 
   // Ensure that the editor is full-width when the screen resizes
-  window.addEventListener('resize', () => {
-    sandbox.editor.layout();
+  window.addEventListener("resize", () => {
+    sandbox.editor.layout()
   })
 
   const ui = createUI()

--- a/packages/sandbox/src/compilerOptions.ts
+++ b/packages/sandbox/src/compilerOptions.ts
@@ -40,6 +40,8 @@ export function getDefaultSandboxCompilerOptions(config: PlaygroundConfig, monac
     allowJs: config.useJavaScript,
     declaration: true,
 
+    importHelpers: false,
+
     experimentalDecorators: true,
     emitDecoratorMetadata: true,
     moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -150,7 +150,12 @@ export const createTypeScriptSandbox = (
     ? monaco.languages.typescript.javascriptDefaults
     : monaco.languages.typescript.typescriptDefaults
 
-  defaults.setDiagnosticsOptions({ ...defaults.getDiagnosticsOptions(), noSemanticValidation: false })
+  defaults.setDiagnosticsOptions({
+    ...defaults.getDiagnosticsOptions(),
+    noSemanticValidation: false,
+    // This is when tslib is not found
+    diagnosticCodesToIgnore: [2354],
+  })
 
   // In the future it'd be good to add support for an 'add many files'
   const addLibraryToRuntime = (code: string, path: string) => {

--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -117,7 +117,6 @@ export const defaultsForOptions = {
   inlineSourceMap: "false",
   inlineSources: "false",
   isolatedModules: "false",
-  jsx: '`"react"`',
   jsxFactory: "`React.createElement`",
   keyofStringsOnly: "false",
   listEmittedFiles: "false",

--- a/packages/typescriptlang-org/tsconfig.json
+++ b/packages/typescriptlang-org/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "esModuleInterop": true,
     "noEmit": true,
+    "jsx": "react",
     "skipLibCheck": true,
     "noImplicitAny": false,
     "resolveJsonModule": true


### PR DESCRIPTION
Adds support for setting `importHelpers` in the UI, also surpasses ts diagnostics when the tslib can't be found at runtime. 

![Screen Shot 2020-08-06 at 12 10 43 PM](https://user-images.githubusercontent.com/49038/89555240-cae57100-d7dd-11ea-82fd-4479f503a960.png)
