### PR TITLE
fix wrong command in zh and es page

### DIFF
--- a/packages/typescriptlang-org/src/copy/es/index.ts
+++ b/packages/typescriptlang-org/src/copy/es/index.ts
@@ -60,7 +60,7 @@ export const indexCopy = {
   index_install: "Instalar TypeScript",
   index_install_ref: `
     <p>Puedes instalar TypeScript a través de npm<pre>npm install -g typescript</pre>
-    <p>Y luego ejecutar el compilador con el comando <code>tsc</code><pre>npm install -g typescript</pre>
+    <p>Y luego ejecutar el compilador con el comando <code>tsc</code><pre>npx tsc</pre>
     `,
   index_releases: "Publicaciones trimestrales",
   index_releases_pt1: "Nuestro siguiente lanzamiento es ",

--- a/packages/typescriptlang-org/src/copy/zh/index.ts
+++ b/packages/typescriptlang-org/src/copy/zh/index.ts
@@ -57,7 +57,7 @@ export const indexCopy = {
   index_install: "安装 TypeScript",
   index_install_ref: `
   <p>你可以使用 npm 安装 TypeScript<pre>npm install -g typescript</pre>
-  <p>之后执行 <code>tsc</code> 来运行 TypeScript 编译器 <pre>npm install -g typescript</pre>
+  <p>之后执行 <code>tsc</code> 来运行 TypeScript 编译器 <pre>npx tsc</pre>
   `,
   index_releases: "季度发布",
   index_releases_pt1: "我们的下一个版本发布是 ",


### PR DESCRIPTION
It should be `npx tsc` to execute tsc command.

Correct wrong command line description in `zh` and `es` page.