### PR TITLE
[pt-br] Translation files from tsconfig-reference

### DIFF
--- a/packages/tsconfig-reference/copy/pt/options/strict.md
+++ b/packages/tsconfig-reference/copy/pt/options/strict.md
@@ -1,0 +1,11 @@
+---
+display: "Strict"
+oneline: "Ativa as regras de verificação de tipo mais detalhadas do TypeScript"
+---
+
+A opção `strict` permite uma ampla gama de comportamento de verificação de tipo que resulta em melhores garantias de correção do programa.
+Ativar isso equivale a ativar todas as opções da _família do modo restrito_, que são descritas abaixo.
+Você pode desativar as verificações de família de modo restrito individualmente conforme necessário.
+
+Versões futuras do TypeScript podem introduzir verificação rigorosas adicionais dentro desta opção, portanto, as atualizações do TypeScript podem resultar em novos erros de tipo em seu programa.
+Quando apropriado e possível, uma opção correspondente será adicionado para desativar esse comportamento.

--- a/packages/tsconfig-reference/copy/pt/options/strict.md
+++ b/packages/tsconfig-reference/copy/pt/options/strict.md
@@ -1,5 +1,5 @@
 ---
-display: "Strict"
+display: "Modo estrito"
 oneline: "Ativa as regras de verificação de tipo mais detalhadas do TypeScript"
 ---
 

--- a/packages/tsconfig-reference/copy/pt/options/strictBindCallApply.md
+++ b/packages/tsconfig-reference/copy/pt/options/strictBindCallApply.md
@@ -1,0 +1,34 @@
+---
+display: "Bind Call Apply Restritos"
+oneline: "Garante que 'call', 'bind' e 'apply' tenham os argumentos corretos"
+---
+
+Quando definido, o TypeScript verificará se os métodos integrados das funções `call`, `bind` e `apply` são invocados com os argumentos corretos para a função subjacente:
+
+```ts twoslash
+// @strictBindCallApply: true
+// @errors: 2345
+
+// Com strictBindCallApply ativado
+function fn(x: string) {
+  return parseInt(x);
+}
+
+const n1 = fn.call(undefined, "10");
+
+const n2 = fn.call(undefined, false);
+```
+
+Caso contrário, essas funções aceitarão qualquer argumento e retornarão `any`:
+
+```ts twoslash
+// @strictBindCallApply: false
+
+// Com strictBindCallApply desativado
+function fn(x: string) {
+  return parseInt(x);
+}
+
+// Nota: Sem erro; tipo do retorno é 'any'
+const n = fn.call(undefined, false);
+```

--- a/packages/tsconfig-reference/copy/pt/options/strictFunctionTypes.md
+++ b/packages/tsconfig-reference/copy/pt/options/strictFunctionTypes.md
@@ -32,7 +32,7 @@ function fn(x: string) {
 type StringOuNumeroFn = (ns: string | number) => void;
 
 // Atribuição não segura é prevenida
-let func: StringOrNumberFunc = fn;
+let func: StringOuNumeroFn = fn;
 ```
 
 Durante o desenvolvimento desse recurso, descobrimos um grande número de hierarquias de classes profundamente não seguras, incluindo algumas no DOM.

--- a/packages/tsconfig-reference/copy/pt/options/strictFunctionTypes.md
+++ b/packages/tsconfig-reference/copy/pt/options/strictFunctionTypes.md
@@ -26,7 +26,7 @@ Com `strictFunctionTypes` ativado, o erro é detectado corretamente:
 ```ts twoslash
 // @errors: 2322
 function fn(x: string) {
-  console.log("Hello, " + x.toLowerCase());
+  console.log("Olá, " + x.toLowerCase());
 }
 
 type StringOrNumberFunc = (ns: string | number) => void;

--- a/packages/tsconfig-reference/copy/pt/options/strictFunctionTypes.md
+++ b/packages/tsconfig-reference/copy/pt/options/strictFunctionTypes.md
@@ -1,0 +1,55 @@
+---
+display: "Tipo de Funções Restritos"
+oneline: "Garante que os parâmetros da função são consistentes"
+---
+
+Quando ativado, esta opção faz com que os parâmetros das funções sejam verificados mais corretamente.
+
+Aqui está um exemplo básico com `strictFunctionTypes` desativado:
+
+```ts twoslash
+// @strictFunctionTypes: false
+function fn(x: string) {
+  console.log("Hello, " + x.toLowerCase());
+}
+
+type StringOrNumberFunc = (ns: string | number) => void;
+
+// Atribuição não segura
+let func: StringOrNumberFunc = fn;
+// Chamada não segura - vai quebrar
+func(10);
+```
+
+Com `strictFunctionTypes` _on_, o erro é detectado corretamente:
+
+```ts twoslash
+// @errors: 2322
+function fn(x: string) {
+  console.log("Hello, " + x.toLowerCase());
+}
+
+type StringOrNumberFunc = (ns: string | number) => void;
+
+// Atribuição não segura é prevenida
+let func: StringOrNumberFunc = fn;
+```
+
+Durante o desenvolvimento desse recurso, descobrimos um grande número de hierarquias de classes profundamente não seguras, incluindo algumas no DOM.
+Por causa disso, a configuração apenas se aplica a funções escritas na sintaxe _function_, não àquelas na sintaxe _method_:
+
+```ts twoslash
+type Methodish = {
+  func(x: string | number): void;
+};
+
+function fn(x: string) {
+  console.log("Hello, " + x.toLowerCase());
+}
+
+// Por fim, uma atribuição insegura, porém não detectada.
+const m: Methodish = {
+  func: fn,
+};
+m.func(10);
+```

--- a/packages/tsconfig-reference/copy/pt/options/strictFunctionTypes.md
+++ b/packages/tsconfig-reference/copy/pt/options/strictFunctionTypes.md
@@ -44,7 +44,7 @@ type PareceUmMetodo = {
 };
 
 function fn(x: string) {
-  console.log("Hello, " + x.toLowerCase());
+  console.log("Olá, " + x.toLowerCase());
 }
 
 // Por fim, uma atribuição insegura, porém não detectada.

--- a/packages/tsconfig-reference/copy/pt/options/strictFunctionTypes.md
+++ b/packages/tsconfig-reference/copy/pt/options/strictFunctionTypes.md
@@ -21,7 +21,7 @@ let func: StringOrNumberFunc = fn;
 func(10);
 ```
 
-Com `strictFunctionTypes` _on_, o erro é detectado corretamente:
+Com `strictFunctionTypes` ativado, o erro é detectado corretamente:
 
 ```ts twoslash
 // @errors: 2322

--- a/packages/tsconfig-reference/copy/pt/options/strictFunctionTypes.md
+++ b/packages/tsconfig-reference/copy/pt/options/strictFunctionTypes.md
@@ -39,7 +39,7 @@ Durante o desenvolvimento desse recurso, descobrimos um grande número de hierar
 Por causa disso, a configuração apenas se aplica a funções escritas na sintaxe _function_, não àquelas na sintaxe _method_:
 
 ```ts twoslash
-type Methodish = {
+type PareceUmMetodo = {
   func(x: string | number): void;
 };
 

--- a/packages/tsconfig-reference/copy/pt/options/strictFunctionTypes.md
+++ b/packages/tsconfig-reference/copy/pt/options/strictFunctionTypes.md
@@ -48,7 +48,7 @@ function fn(x: string) {
 }
 
 // Por fim, uma atribuição insegura, porém não detectada.
-const m: Methodish = {
+const m: PareceUmMetodo = {
   func: fn,
 };
 m.func(10);

--- a/packages/tsconfig-reference/copy/pt/options/strictFunctionTypes.md
+++ b/packages/tsconfig-reference/copy/pt/options/strictFunctionTypes.md
@@ -29,7 +29,7 @@ function fn(x: string) {
   console.log("Olá, " + x.toLowerCase());
 }
 
-type StringOrNumberFunc = (ns: string | number) => void;
+type StringOuNumeroFn = (ns: string | number) => void;
 
 // Atribuição não segura é prevenida
 let func: StringOrNumberFunc = fn;

--- a/packages/tsconfig-reference/copy/pt/options/strictPropertyInitialization.md
+++ b/packages/tsconfig-reference/copy/pt/options/strictPropertyInitialization.md
@@ -1,5 +1,5 @@
 ---
-display: "Inicialização de Propriedade Restrita"
+display: "Inicialização restrita de propriedade"
 oneline: "Garante que todas as propriedades da classe correspondam aos seus tipos depois que o construtor finalizar"
 ---
 

--- a/packages/tsconfig-reference/copy/pt/options/strictPropertyInitialization.md
+++ b/packages/tsconfig-reference/copy/pt/options/strictPropertyInitialization.md
@@ -3,7 +3,7 @@ display: "Inicialização restrita de propriedade"
 oneline: "Garante que todas as propriedades da classe correspondam aos seus tipos depois que o construtor finalizar"
 ---
 
-Quando definido como verdadeiro, o TypeScript gerará um erro quando uma propriedade de classe for declarada, mas não definida no construtor.
+Quando definido como `true`, o TypeScript gerará um erro quando uma propriedade de classe for declarada, mas não definida no construtor.
 
 ```ts twoslash
 // @errors: 2564

--- a/packages/tsconfig-reference/copy/pt/options/strictPropertyInitialization.md
+++ b/packages/tsconfig-reference/copy/pt/options/strictPropertyInitialization.md
@@ -7,16 +7,16 @@ Quando definido como `true`, o TypeScript gerará um erro quando uma propriedade
 
 ```ts twoslash
 // @errors: 2564
-class UserAccount {
-  name: string;
-  accountType = "user";
+class Conta {
+  nome: string;
+  tipo = "usuario";
 
   email: string;
-  address: string | undefined;
+  endereco: string | undefined;
 
-  constructor(name: string) {
-    this.name = name;
-    // Note quer this.email não foi atribuído
+  constructor(nome: string) {
+    this.nome = nome;
+    // Note que this.email não foi atribuído
   }
 }
 ```

--- a/packages/tsconfig-reference/copy/pt/options/strictPropertyInitialization.md
+++ b/packages/tsconfig-reference/copy/pt/options/strictPropertyInitialization.md
@@ -23,7 +23,7 @@ class Conta {
 
 No caso acima:
 
-- `this.name` é atribuído especificamente.
-- `this.accountType` é atribuído por padrão.
+- `this.nome` é atribuído especificamente.
+- `this.tipo` é atribuído por padrão.
 - `this.email` não é atribuído e gera um erro.
-- `this.address` é declarado como possível `undefined`, o que significa que não precisa ser atribuído.
+- `this.endereco` é declarado como possível `undefined`, o que significa que não precisa ser atribuído.

--- a/packages/tsconfig-reference/copy/pt/options/strictPropertyInitialization.md
+++ b/packages/tsconfig-reference/copy/pt/options/strictPropertyInitialization.md
@@ -1,0 +1,29 @@
+---
+display: "Inicialização de Propriedade Restrita"
+oneline: "Garante que todas as propriedades da classe correspondam aos seus tipos depois que o construtor finalizar"
+---
+
+Quando definido como verdadeiro, o TypeScript gerará um erro quando uma propriedade de classe for declarada, mas não definida no construtor.
+
+```ts twoslash
+// @errors: 2564
+class UserAccount {
+  name: string;
+  accountType = "user";
+
+  email: string;
+  address: string | undefined;
+
+  constructor(name: string) {
+    this.name = name;
+    // Note quer this.email não foi atribuído
+  }
+}
+```
+
+No caso acima:
+
+- `this.name` é atribuído especificamente.
+- `this.accountType` é atribuído por padrão.
+- `this.email` não é atribuído e gera um erro.
+- `this.address` é declarado como possível `undefined`, o que significa que não precisa ser atribuído.

--- a/packages/tsconfig-reference/copy/pt/options/stripInternal.md
+++ b/packages/tsconfig-reference/copy/pt/options/stripInternal.md
@@ -49,11 +49,11 @@ Com `stripInternal` definido como `true` o `d.ts` emitido será editado.
  * Dias disponíveis na semana
  * @internal
  */
-export const daysInAWeek = 7;
+export const diasNaSemana = 7;
 
 /** Calcule quanto alguém ganha em uma semana */
-export function weeklySalary(dayRate: number) {
-  return daysInAWeek * dayRate;
+export function selarioSemanal(porDia: number) {
+  return diasNaSemana * porDia;
 }
 ```
 

--- a/packages/tsconfig-reference/copy/pt/options/stripInternal.md
+++ b/packages/tsconfig-reference/copy/pt/options/stripInternal.md
@@ -1,0 +1,60 @@
+---
+display: "Remover Internal"
+oneline: "Remove as declarações que têm '@internal' em seus comentários JSDoc"
+---
+
+Não emite declarações para códigos que tenham uma anotação `@internal` em seu comentário JSDoc.
+Esta é uma opção interna do compilador; use por sua conta em risco, porque o compilador não verifica se o resultado é válido.
+Se você estiver procurando por uma ferramenta para lidar com níveis adicionais de visibilidade dentro de seus arquivos `d.ts`, veja o [api-extractor](https://api-extractor.com).
+
+```ts twoslash
+/**
+ * Dias disponíveis na semana
+ * @internal
+ */
+export const daysInAWeek = 7;
+
+/** Calcule quanto alguém ganha em uma semana */
+export function weeklySalary(dayRate: number) {
+  return daysInAWeek * dayRate;
+}
+```
+
+Com a opção definida como `false` (padrão):
+
+```ts twoslash
+// @showEmittedFile: index.d.ts
+// @showEmit
+// @declaration
+/**
+ * Dias disponíveis na semana
+ * @internal
+ */
+export const daysInAWeek = 7;
+
+/** Calcule quanto alguém ganha em uma semana */
+export function weeklySalary(dayRate: number) {
+  return daysInAWeek * dayRate;
+}
+```
+
+Com `stripInternal` definido como `true` o `d.ts` emitido será editado.
+
+```ts twoslash
+// @stripinternal
+// @showEmittedFile: index.d.ts
+// @showEmit
+// @declaration
+/**
+ * Dias disponíveis na semana
+ * @internal
+ */
+export const daysInAWeek = 7;
+
+/** Calcule quanto alguém ganha em uma semana */
+export function weeklySalary(dayRate: number) {
+  return daysInAWeek * dayRate;
+}
+```
+
+A JavaScript emitido ainda é o mesmo.

--- a/packages/tsconfig-reference/copy/pt/options/stripInternal.md
+++ b/packages/tsconfig-reference/copy/pt/options/stripInternal.md
@@ -12,7 +12,7 @@ Se você estiver procurando por uma ferramenta para lidar com níveis adicionais
  * Dias disponíveis na semana
  * @internal
  */
-export const daysInAWeek = 7;
+export const diasNaSemana = 7;
 
 /** Calcule quanto alguém ganha em uma semana */
 export function weeklySalary(dayRate: number) {

--- a/packages/tsconfig-reference/copy/pt/options/stripInternal.md
+++ b/packages/tsconfig-reference/copy/pt/options/stripInternal.md
@@ -1,5 +1,5 @@
 ---
-display: "Remover Internal"
+display: "Remover internal"
 oneline: "Remove as declarações que têm '@internal' em seus comentários JSDoc"
 ---
 

--- a/packages/tsconfig-reference/copy/pt/options/stripInternal.md
+++ b/packages/tsconfig-reference/copy/pt/options/stripInternal.md
@@ -30,11 +30,11 @@ Com a opção definida como `false` (padrão):
  * Dias disponíveis na semana
  * @internal
  */
-export const daysInAWeek = 7;
+export const diasNaSemana = 7;
 
 /** Calcule quanto alguém ganha em uma semana */
-export function weeklySalary(dayRate: number) {
-  return daysInAWeek * dayRate;
+export function salarioSemanal(porDia: number) {
+  return diasNaSemana * porDia;
 }
 ```
 

--- a/packages/tsconfig-reference/copy/pt/options/stripInternal.md
+++ b/packages/tsconfig-reference/copy/pt/options/stripInternal.md
@@ -15,8 +15,8 @@ Se você estiver procurando por uma ferramenta para lidar com níveis adicionais
 export const diasNaSemana = 7;
 
 /** Calcule quanto alguém ganha em uma semana */
-export function weeklySalary(dayRate: number) {
-  return daysInAWeek * dayRate;
+export function salarioSemanal(porDia: number) {
+  return diasNaSemana * porDia;
 }
 ```
 

--- a/packages/tsconfig-reference/copy/pt/options/suppressExcessPropertyErrors.md
+++ b/packages/tsconfig-reference/copy/pt/options/suppressExcessPropertyErrors.md
@@ -1,0 +1,16 @@
+---
+display: "Prevenir Erros de Propriedades em Excesso"
+oneline: "Permitir que propriedades adicionais sejam definidas durante a criação de tipos"
+---
+
+Desativa o relatório de erros de propriedades em excesso, como o mostrado no exemplo a seguir:
+
+```ts twoslash
+// @errors: 2322
+type Point = { x: number; y: number };
+const p: Point = { x: 1, y: 3, m: 10 };
+```
+
+Esta opção foi adicionada para ajudar as pessoas a migrar para a verificação mais rigorosa de novos objetos literais no [TypeScript 1.6](/docs/handbook/release-notes/typescript-1-6.html#stricter-object-literal-assignment-checks).
+
+Não recomendamos o uso dessa sinalização em uma base de código moderna, você pode prevenir casos únicos em que precise dela usando `// @ts-ignore`.

--- a/packages/tsconfig-reference/copy/pt/options/suppressExcessPropertyErrors.md
+++ b/packages/tsconfig-reference/copy/pt/options/suppressExcessPropertyErrors.md
@@ -1,5 +1,5 @@
 ---
-display: "Prevenir Erros de Propriedades em Excesso"
+display: "Prevenir erros de propriedades em excesso"
 oneline: "Permitir que propriedades adicionais sejam definidas durante a criação de tipos"
 ---
 

--- a/packages/tsconfig-reference/copy/pt/options/suppressImplicitAnyIndexErrors.md
+++ b/packages/tsconfig-reference/copy/pt/options/suppressImplicitAnyIndexErrors.md
@@ -1,5 +1,5 @@
 ---
-display: "Prevenir Erros de Implicit Any Index"
+display: "Prevenir erros de implicit any index"
 oneline: "Remove o aviso ao usar índices de string para acessar propriedades desconhecidas"
 ---
 

--- a/packages/tsconfig-reference/copy/pt/options/suppressImplicitAnyIndexErrors.md
+++ b/packages/tsconfig-reference/copy/pt/options/suppressImplicitAnyIndexErrors.md
@@ -1,0 +1,25 @@
+---
+display: "Prevenir Erros de Implicit Any Index"
+oneline: "Remove o aviso ao usar índices de string para acessar propriedades desconhecidas"
+---
+
+Ativando `suppressImplicitAnyIndexErrors` previne o relato do erros sobre qualquer implícito ao indexar objetos, conforme mostrado no exemplo a seguir:
+
+```ts twoslash
+// @noImplicitAny: true
+// @suppressImplicitAnyIndexErrors: false
+// @strict: true
+// @errors: 7053
+const obj = { x: 10 };
+console.log(obj["foo"]);
+```
+
+Usar `suppressImplicitAnyIndexErrors` é uma abordagem bastante extrema. É recomendado usar um comentário `@ts-ignore` ao invés:
+
+```ts twoslash
+// @noImplicitAny: true
+// @strict: true
+const obj = { x: 10 };
+// @ts-ignore
+console.log(obj["foo"]);
+```

--- a/packages/tsconfig-reference/copy/pt/options/target.md
+++ b/packages/tsconfig-reference/copy/pt/options/target.md
@@ -1,0 +1,26 @@
+---
+display: "Target"
+oneline: "Defina o runtime suportado da linguagem JavaScript para ser transpilado"
+---
+
+Navegadores modernos suportam todas as funcionalidades ES6, então `ES6` é uma boa escolha.
+Você pode definir um alvo (target) mais baixo se o deploy do seu código for feito em ambientes antigos, ou um alvo mais alto se o seu código é garantido de rodar em ambientes mais novos.
+
+A configuração `target` altera quais funcionalidades JS serão niveladas para baixo e quais ficarão inalteradas.
+Por exemplo, a arrow function `() => this` será transformada na expressão `function` equivalente se o `target` for ES5 ou mais baixo.
+
+Alterando o `target` também alterará o valor da [`lib`](#lib).
+Você pode "misturar e combinar" as configurações `target` e `lib` da forma que quiser, mas você pode definir apenas o `target`, por conveniência.
+
+Se você está trabalhando apenas com Node.js, esses são os `target`s recomendados para essas versões do Node:
+
+| Name    | Supported Target |
+| ------- | ---------------- |
+| Node 8  | `ES2017`         |
+| Node 10 | `ES2018`         |
+| Node 12 | `ES2019`         |
+
+Eles são baseados no banco de dados de suporte do [node.green](https://node.green).
+
+O valor especial `ESNext` se refere a versão mais alta que a sua versão do TypeScript suporta.
+Essa configuração deve ser utilizada com precaução, pois não significa a mesma coisa entre diferentes versões do TypeScript e pode tornar atualizações menos previsíveis.

--- a/packages/tsconfig-reference/copy/pt/options/target.md
+++ b/packages/tsconfig-reference/copy/pt/options/target.md
@@ -1,5 +1,5 @@
 ---
-display: "Target"
+display: "Runtime alvo"
 oneline: "Defina o runtime suportado da linguagem JavaScript para ser transpilado"
 ---
 

--- a/packages/tsconfig-reference/copy/pt/options/traceResolution.md
+++ b/packages/tsconfig-reference/copy/pt/options/traceResolution.md
@@ -1,5 +1,5 @@
 ---
-display: "Resolução de Rastreamento"
+display: "Resolução de rastreamento"
 oneline: "Fazer log de caminhos ao resolver todos os módulos"
 ---
 

--- a/packages/tsconfig-reference/copy/pt/options/traceResolution.md
+++ b/packages/tsconfig-reference/copy/pt/options/traceResolution.md
@@ -1,0 +1,9 @@
+---
+display: "Resolução de Rastreamento"
+oneline: "Fazer log de caminhos ao resolver todos os módulos"
+---
+
+Quando você estiver tentando depurar o motivo de um módulo não ter sido incluso,
+você pode definir o `traceResolutions` para `true` para que o TypeScript imprima informações sobre o seu processo de resolução de cada arquivo processado.
+
+Você pode ler mais sobre projetos compostos [nesse guia](/docs/handbook/module-resolution.html#tracing-module-resolution).

--- a/packages/tsconfig-reference/copy/pt/options/tsBuildInfoFile.md
+++ b/packages/tsconfig-reference/copy/pt/options/tsBuildInfoFile.md
@@ -1,5 +1,5 @@
 ---
-display: "Arquivo de Informações da Build do TS"
+display: "Arquivo de informações da build do TS"
 oneline: "Conjunto de pastas para os arquivos .tsbuildinfo"
 ---
 

--- a/packages/tsconfig-reference/copy/pt/options/tsBuildInfoFile.md
+++ b/packages/tsconfig-reference/copy/pt/options/tsBuildInfoFile.md
@@ -1,0 +1,10 @@
+---
+display: "Arquivo de Informações da Build do TS"
+oneline: "Conjunto de pastas para os arquivos .tsbuildinfo"
+---
+
+Essa configuração possibilita a você especificar um arquivo para armazenar informações incrementais de compilação como parte de projetos compostos que habilitam
+builds rápidas de grandes bases de código TypeScript. Você pode ler mais sobre projetos compostos [nesse guia](/docs/handbook/project-references.html).
+
+Essa opção oferece uma forma de configurar o local onde o TypeScript se mantém informado sobre os arquivos que armazena no disco para
+indicar o estado de build de um projeto &mdash; por padrão, eles estão na mesma pasta dos seus JavaScripts emitidos.

--- a/packages/tsconfig-reference/copy/pt/options/typeAcquisition.md
+++ b/packages/tsconfig-reference/copy/pt/options/typeAcquisition.md
@@ -1,6 +1,6 @@
 ---
 display: "Aquisição de tipo"
-oneline: "Conjunto de opções para Aquisição de Tipo Automática no JavaScript"
+oneline: "Conjunto de opções para aquisição de tipo automática no JavaScript"
 ---
 
 Quando você tem um projeto JavaScript no seu editor, TypeScript providenciará tipos para o seu `node_modules` automaticamente utilizando o conjunto de definições de `@types`, DefinitelyTyped.

--- a/packages/tsconfig-reference/copy/pt/options/typeAcquisition.md
+++ b/packages/tsconfig-reference/copy/pt/options/typeAcquisition.md
@@ -1,5 +1,5 @@
 ---
-display: "Aquisição de Tipo"
+display: "Aquisição de tipo"
 oneline: "Conjunto de opções para Aquisição de Tipo Automática no JavaScript"
 ---
 

--- a/packages/tsconfig-reference/copy/pt/options/typeAcquisition.md
+++ b/packages/tsconfig-reference/copy/pt/options/typeAcquisition.md
@@ -1,0 +1,37 @@
+---
+display: "Aquisição de Tipo"
+oneline: "Conjunto de opções para Aquisição de Tipo Automática no JavaScript"
+---
+
+Quando você tem um projeto JavaScript no seu editor, TypeScript providenciará tipos para o seu `node_modules` automaticamente utilizando o conjunto de definições de `@types`, DefinitelyTyped.
+Isso é conhecido como aquisição de tipo automática e você pode modificá-la utilizando o objecto `typeAcquisition` no seu arquivo de configuração.
+
+Se você quiser desabilitar ou modificar essa funcionalidade, crie o `jsconfig.json` na raíz do seu projeto:
+
+```json
+{
+  "typeAcquisition": {
+    "enable": false
+  }
+}
+```
+
+Se você quer incluir um módulo específico (mas ele não está em `node_modules`):
+
+```json
+{
+  "typeAcquisition": {
+    "include": ["jest"]
+  }
+}
+```
+
+Se um módulo não deve ser automaticamente adquirido, por exemplo, se uma biblioteca está disponível no seu `node_modules`, mas a sua equipe concordou em não utilizá-lo:
+
+```json
+{
+  "typeAcquisition": {
+    "exclude": ["jquery"]
+  }
+}
+```


### PR DESCRIPTION
First contribution. I've translated the following files from tsconfig section:

- [x] typeAcquisition.md

- [x] tsBuildInfoFile.md

- [x] traceResolution.md

- [x] target.md

- [x] suppressExcessPropertyErrors.md

- [x] suppressImplicitAnyIndexErrors.md

- [x] strict.md

- [x] strictBindCallApply.md

- [x] strictFunctionTypes.md

- [x] strictPropertyInitialization.md

- [x] stripInternal.md

@khaosdoctor, @alvarocamillont, @danilofuchs e @orta 