### PR TITLE
Fix typo in module template name

### DIFF
--- a/packages/documentation/copy/en/declaration-files/Library Structures.md
+++ b/packages/documentation/copy/en/declaration-files/Library Structures.md
@@ -86,7 +86,7 @@ They will rarely have:
 ### Templates For Modules
 
 There are four templates available for modules,
-[`module.d.ts`](/docs/handbook/declaration-files/templates/module-d-ts.html), [`module-class.d.ts`](/docs/handbook/declaration-files/templates/module-class-d-ts.html), [`module-function.d.ts`](/docs/handbook/declaration-files/templates/module-function-d-ts.html) and [`module-plugins.d.ts`](/docs/handbook/declaration-files/templates/module-plugins-d-ts.html).
+[`module.d.ts`](/docs/handbook/declaration-files/templates/module-d-ts.html), [`module-class.d.ts`](/docs/handbook/declaration-files/templates/module-class-d-ts.html), [`module-function.d.ts`](/docs/handbook/declaration-files/templates/module-function-d-ts.html) and [`module-plugin.d.ts`](/docs/handbook/declaration-files/templates/module-plugin.d.ts).
 
 You should first read [`module.d.ts`](/docs/handbook/declaration-files/templates/module-d-ts.html) for an overview on the way they all work.
 


### PR DESCRIPTION
Templates directory seems to only have a module-plugin file which I'm assuming is the one this is meant to reference

https://github.com/microsoft/TypeScript-Website/tree/v2/packages/documentation/copy/en/declaration-files/templates