### PR TITLE
Fix link to `object` type information in "Do's and Don'ts"

### DIFF
--- a/packages/documentation/copy/en/declaration-files/Do's and Don'ts.md
+++ b/packages/documentation/copy/en/declaration-files/Do's and Don'ts.md
@@ -24,7 +24,7 @@ _Do_ use the types `number`, `string`, `boolean`, and `symbol`.
 function reverse(s: string): string;
 ```
 
-Instead of `Object`, use the non-primitive `object` type ([added in TypeScript 2.2](../release%20notes/TypeScript%202.2.md#object-type)).
+Instead of `Object`, use the non-primitive `object` type ([added in TypeScript 2.2](../release-notes/typescript-2-2.html#object-type)).
 
 ## Generics
 


### PR DESCRIPTION
Fix link to `object` type information in the declaration files "Do's and Don'ts".