### PR TITLE
Chore: Format var keyword as code

### DIFF
--- a/packages/documentation/copy/en/handbook-v1/Basic Types.md
+++ b/packages/documentation/copy/en/handbook-v1/Basic Types.md
@@ -381,7 +381,7 @@ Using one over the other is mostly a choice of preference; however, when using T
 
 You may have noticed that so far, we've been using the `let` keyword instead of JavaScript's `var` keyword which you might be more familiar with.
 The `let` keyword is actually a newer JavaScript construct that TypeScript makes available.
-You can read in the Handbook Reference on [Variable Declarations](/docs/handbook/variable-declarations.html) more about how `let` and `const` fix a lot of the problems with var.
+You can read in the Handbook Reference on [Variable Declarations](/docs/handbook/variable-declarations.html) more about how `let` and `const` fix a lot of the problems with `var`.
 
 ## About `Number`, `String`, `Boolean`, `Symbol` and `Object`
 


### PR DESCRIPTION
The `var` keyword is also formatted as code earlier in the same paragraph.