### PR TITLE
Mention "UMD" in moduleResolution rule.

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -124,7 +124,7 @@ export const defaultsForOptions = {
   listFiles: "false",
   locale: "Platform specific",
   maxNodeModuleJsDepth: "0",
-  moduleResolution: "module === `AMD`, `System` or `ES6` then `Classic`<br/><br/>Otherwise `Node`",
+  moduleResolution: "module === `AMD`, `UMD`, `System` or `ES6` then `Classic`<br/><br/>Otherwise `Node`",
   newLine: "Platform specific",
   noEmit: "false",
   noEmitHelpers: "false",


### PR DESCRIPTION
I noticed UMD also sets default moduleResolution as 'classic'.

My config was:

```json
{
  "compilerOptions": {
    "allowSyntheticDefaultImports": true,
    "alwaysStrict": true,
    "downlevelIteration": true,
    "emitDecoratorMetadata": true,
    "esModuleInterop": true,
    "experimentalDecorators": true,
    "forceConsistentCasingInFileNames": true,
    "lib": [
      "ES2015",
      "DOM"
    ],
    "module": "UMD",
    "target": "ES2015",
    "removeComments": true
  },
  "include": [
    "./src"
  ]
}
```

It emitted errors like:

```
node_modules/@types/inquirer/index.d.ts:17:28 - error TS2307: Cannot find module 'rxjs'.
17 import { Observable } from "rxjs";
```

There is ES6 import `import { Observable } from "rxjs";` used in `node_modules/@types/inquirer/index.d.ts`

Adding next line to my config fixed the issue:

```json
"moduleResolution": "Node"
```
