### PR TITLE
(PT-BR) Translating 3  files from "tsconfig"

### DIFF
--- a/packages/tsconfig-reference/copy/pt/options/forceConsistentCasingInFileNames.md
+++ b/packages/tsconfig-reference/copy/pt/options/forceConsistentCasingInFileNames.md
@@ -1,0 +1,9 @@
+---
+display: "Mantenha A Consistência Nos Nomes Do Arquivo"
+oneline: "Certifique-se de verificar se as letras maiúsculas e minúsculas estão corretas nas importações"
+---
+
+TypeScript diferencia letras maiúsculas e minúsculas no arquivo que está sendo executado.
+Isso pode se tornar um problema se alguns desenvolvedores trabalharem com diferenciação de letras maiúsculas e minúsculas no arquivo, e outros não. Se um arquivo tentar importar `fileManager.ts` especificando `./FileManager.ts` em sistemas que não fazem a diferenciação de maiúsculas e minúsculas, vai encontrar o arquivo, porém, em sistemas que fazem essa diferenciação, o arquivo não será encontrado.
+
+Quando essa opção está definida, o TypeScript vai gerar um erro caso o programa tente incluir um arquivo com padrão diferente - de diferenciação maiúsculas e minúsculas - no sistema.

--- a/packages/tsconfig-reference/copy/pt/options/forceConsistentCasingInFileNames.md
+++ b/packages/tsconfig-reference/copy/pt/options/forceConsistentCasingInFileNames.md
@@ -1,6 +1,6 @@
 ---
-display: "Mantenha A Consistência Nos Nomes Do Arquivo"
-oneline: "Certifique-se de verificar se as letras maiúsculas e minúsculas estão corretas nas importações"
+display: "Manter a consistência nos nomes do arquivo"
+oneline: "Verifica se as letras maiúsculas e minúsculas estão corretas nas importações"
 ---
 
 TypeScript diferencia letras maiúsculas e minúsculas no arquivo que está sendo executado.

--- a/packages/tsconfig-reference/copy/pt/options/generateCpuProfile.md
+++ b/packages/tsconfig-reference/copy/pt/options/generateCpuProfile.md
@@ -1,0 +1,14 @@
+---
+display: "Gerar Perfil de CPU"
+oneline: "Emita um perfil de CPU v8 do compilador executado para depuração"
+
+---
+Essa opção dá a oportunidade para que o TypeScript emita um perfil de CPU v8 durante a depuração. O perfil de CPU pode oferecer informações sobre o porquê das suas compilações estarem lentas.
+
+Essa opção só pode ser utilizada no CLI pelo comando: `--generateCpuProfile tsc-output.cpuprofile`.
+
+```sh
+npm run tsc --generateCpuProfile tsc-output.cpuprofile
+```
+
+Esse arquivo pode ser aberto em um navegador com base chromium, como o Chrome ou Microsoft Edge na seção [de perfil de CPU](https://developers.google.com/web/tools/chrome-devtools/rendering-tools/js-execution). Para saber mais sobre o desempenho dos compiladores, pode visitar a [wiki do TypeScript sobre performance](https://github.com/microsoft/TypeScript/wiki/Performance).

--- a/packages/tsconfig-reference/copy/pt/options/generateCpuProfile.md
+++ b/packages/tsconfig-reference/copy/pt/options/generateCpuProfile.md
@@ -1,9 +1,10 @@
 ---
 display: "Gerar Perfil de CPU"
-oneline: "Emita um perfil de CPU v8 do compilador executado para depuração"
+oneline: "Emite um perfil de CPU do compilador para depuração"
 
 ---
-Essa opção dá a oportunidade para que o TypeScript emita um perfil de CPU v8 durante a depuração. O perfil de CPU pode oferecer informações sobre o porquê das suas compilações estarem lentas.
+
+Essa opção permite que o TypeScript emita um perfil de CPU durante a depuração. O perfil de CPU pode oferecer informações sobre o porquê das suas compilações estarem lentas.
 
 Essa opção só pode ser utilizada no CLI pelo comando: `--generateCpuProfile tsc-output.cpuprofile`.
 
@@ -11,4 +12,4 @@ Essa opção só pode ser utilizada no CLI pelo comando: `--generateCpuProfile t
 npm run tsc --generateCpuProfile tsc-output.cpuprofile
 ```
 
-Esse arquivo pode ser aberto em um navegador com base chromium, como o Chrome ou Microsoft Edge na seção [de perfil de CPU](https://developers.google.com/web/tools/chrome-devtools/rendering-tools/js-execution). Para saber mais sobre o desempenho dos compiladores, pode visitar a [wiki do TypeScript sobre performance](https://github.com/microsoft/TypeScript/wiki/Performance).
+Esse arquivo pode ser aberto em um navegador baseado no Chromium, como o Chrome ou Microsoft Edge na seção [de perfil de CPU](https://developers.google.com/web/tools/chrome-devtools/rendering-tools/js-execution). Para saber mais sobre o desempenho dos compiladores, pode visitar a [wiki do TypeScript sobre performance](https://github.com/microsoft/TypeScript/wiki/Performance).

--- a/packages/tsconfig-reference/copy/pt/options/importHelpers.md
+++ b/packages/tsconfig-reference/copy/pt/options/importHelpers.md
@@ -1,0 +1,43 @@
+---
+display: "Importação de Auxiliares"
+oneline: "Permite importar funções auxiliares por projeto, ao invés de incluir em arquivos individuais."
+
+---
+Para algumas operações de nível mais baixo, o TypeScript pode usar alguns códigos auxiliares para operações como extensão de classes, espalhar arrays ou objetos e para operações async. Por padrão esses auxiliares são inseridos em cada arquivo utilizado. Isso pode provocar duplicação de códigos se o mesmo auxiliar for usado em diferentes módulos.
+
+Se o `importHelpers` estiver ligado, as funções auxiliares serão importadas do módulo [tslib](https://www.npmjs.com/package/tslib).Você precisa ter certeza que o módulo `tslib` pode ser importado no runtime. Isso afeta apenas módulos; Os arquivos de scripts globais não tentarão importar módulos.
+
+Exemplo com esse TypeScript:
+
+
+```ts
+export function fn(arr: number[]) {
+  const arr2 = [1, ...arr];
+}
+```
+
+Ligando [`downlevelIteration`](#downlevelIteration) e mantendo o `importHelpers` como falso:
+
+```ts twoslash
+// @showEmit
+// @target: ES5
+// @downleveliteration
+export function fn(arr: number[]) {
+  const arr2 = [1, ...arr];
+}
+```
+
+Em seguida, ativando [`downlevelIteration`](#downlevelIteration) e `importHelpers`:
+
+```ts twoslash
+// @showEmit
+// @target: ES5
+// @downleveliteration
+// @importhelpers
+// @noErrors
+export function fn(arr: number[]) {
+  const arr2 = [1, ...arr];
+}
+```
+
+Você pode utilizar [`noEmitHelpers`](#noEmitHelpers) quando fornecer suas próprias implementações dessas funções.

--- a/packages/tsconfig-reference/copy/pt/options/importHelpers.md
+++ b/packages/tsconfig-reference/copy/pt/options/importHelpers.md
@@ -1,11 +1,12 @@
 ---
-display: "Importação de Auxiliares"
+display: "Importar Auxiliares"
 oneline: "Permite importar funções auxiliares por projeto, ao invés de incluir em arquivos individuais."
 
 ---
-Para algumas operações de nível mais baixo, o TypeScript pode usar alguns códigos auxiliares para operações como extensão de classes, espalhar arrays ou objetos e para operações async. Por padrão esses auxiliares são inseridos em cada arquivo utilizado. Isso pode provocar duplicação de códigos se o mesmo auxiliar for usado em diferentes módulos.
 
-Se o `importHelpers` estiver ligado, as funções auxiliares serão importadas do módulo [tslib](https://www.npmjs.com/package/tslib).Você precisa ter certeza que o módulo `tslib` pode ser importado no runtime. Isso afeta apenas módulos; Os arquivos de scripts globais não tentarão importar módulos.
+Para algumas operações de mais baixo nível, o TypeScript pode usar alguns códigos auxiliares para operações como extensão de classes, fazer spread de arrays ou objetos e para operações async. Por padrão esses auxiliares são inseridos em cada arquivo utilizado. Isso pode provocar duplicação de códigos se o mesmo auxiliar for usado em diferentes módulos.
+
+Se `importHelpers` estiver ligado, as funções auxiliares serão importadas do módulo [tslib](https://www.npmjs.com/package/tslib). Você precisa ter certeza que o módulo `tslib` pode ser importado no runtime. Isso afeta apenas módulos; Os arquivos de scripts globais não tentarão importar módulos.
 
 Exemplo com esse TypeScript:
 


### PR DESCRIPTION
Hello @khaosdoctor, @alvarocamillont, @danilofuchs e @orta

This commit is about the translation of these files:  

- forceConsistentCasingInFileNames.md
- generateCpuProfile.md
- importHelpers.md

Some notes about:  


- In the file: `forceConsistentCasingInFileNames.mds`, 
    - I used "Mantenha" (keep) instead of "Force". I did this to sound less aggressive in Portuguese but can change without problems.

- In the file: `importHelpers.md`
    - Kept in English the terms: array, async, and runtime.


And that's it. Anything, just let me know them I fix it.
Thank you guys!