### PR TITLE
Adds translatable docs to the localization summary issues + Korean

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,4 +27,9 @@ packages/tsconfig-reference/copy/zh/**/*.md @Kingwl
 packages/typescriptlang-org/src/copy/zh/**/*.md @Kingwl
 packages/documentation/copy/zh/**/*.ts @Kingwl
 
-
+# Collaborators for Korean Translation of the Website
+packages/playground-examples/copy/ko/**/*.md @Bumkeyy
+packages/playground-examples/copy/ko/**/*.ts @Bumkeyy
+packages/tsconfig-reference/copy/ko/**/*.md @Bumkeyy
+packages/typescriptlang-org/src/copy/ko/**/*.md @Bumkeyy
+packages/documentation/copy/ko/**/*.ts @Bumkeyy

--- a/packages/documentation/copy/en/Nightly Builds.md
+++ b/packages/documentation/copy/en/Nightly Builds.md
@@ -3,9 +3,10 @@ title: Nightly Builds
 layout: docs
 permalink: /docs/handbook/nightly-builds.html
 oneline: How to use a nightly build of TypeScript
+translatable: true
 ---
 
-A nightly build from the [TypeScript's `master`](https://github.com/Microsoft/TypeScript/tree/master) branch is published by midnight PST to npm and NuGet.
+A nightly build from the [TypeScript's `master`](https://github.com/Microsoft/TypeScript/tree/master) branch is published by midnight PST to npm.
 Here is how you can get it and use it with your tools.
 
 ## Using npm
@@ -13,18 +14,6 @@ Here is how you can get it and use it with your tools.
 ```shell
 npm install -g typescript@next
 ```
-
-## Using NuGet with MSBuild
-
-> Note: You'll need to configure your project to use the NuGet packages.
-> Please see [Configuring MSBuild projects to use NuGet](https://github.com/Microsoft/TypeScript/wiki/Configuring-MSBuild-projects-to-use-NuGet) for more information.
-
-The nightlies are available on [www.myget.org](https://www.myget.org/gallery/typescript-preview).
-
-There are two packages:
-
-- `Microsoft.TypeScript.Compiler`: Tools only (`tsc.exe`, `lib.d.ts`, etc.) .
-- `Microsoft.TypeScript.MSBuild`: Tools as above, as well as MSBuild tasks and targets (`Microsoft.TypeScript.targets`, `Microsoft.TypeScript.Default.props`, etc.)
 
 ## Updating your IDE to use the nightly builds
 

--- a/packages/documentation/copy/en/javascript/Creating DTS files From JS.md
+++ b/packages/documentation/copy/en/javascript/Creating DTS files From JS.md
@@ -3,6 +3,7 @@ title: Creating .d.ts Files from .js files
 layout: docs
 permalink: /docs/handbook/declaration-files/dts-from-js.html
 oneline: "How to add d.ts generation to JavaScript projects"
+translatable: true
 ---
 
 [With TypeScript 3.7](/docs/handbook/release-notes/typescript-3-7.html#--declaration-and---allowjs),

--- a/packages/documentation/copy/en/javascript/Intro to JS with TS.md
+++ b/packages/documentation/copy/en/javascript/Intro to JS with TS.md
@@ -3,6 +3,7 @@ title: JS Projects Utilizing TypeScript
 layout: docs
 permalink: /docs/handbook/intro-to-js-ts.html
 oneline: How to add type checking to JavaScript files using TypeScript
+translatable: true
 ---
 
 The type system in TypeScript has different levels of strictness when working with a codebase:

--- a/packages/documentation/copy/en/javascript/JSDoc Reference.md
+++ b/packages/documentation/copy/en/javascript/JSDoc Reference.md
@@ -3,6 +3,7 @@ title: JSDoc Reference
 layout: docs
 permalink: /docs/handbook/jsdoc-supported-types.html
 oneline: What JSDoc does TypeScript-powered JavaScript support?
+translatable: true
 ---
 
 The list below outlines which constructs are currently supported

--- a/packages/documentation/copy/en/project-config/Configuring Watch.md
+++ b/packages/documentation/copy/en/project-config/Configuring Watch.md
@@ -3,6 +3,7 @@ title: Configuring Watch
 layout: docs
 permalink: /docs/handbook/configuring-watch.html
 oneline: How to configure the watch mode of TypeScript
+translatable: true
 ---
 
 Compiler supports configuring how to watch files and directories using compiler flags in TypeScript 3.8+, and environment variables before that.

--- a/packages/documentation/copy/en/project-config/Integrating with Build Tools.md
+++ b/packages/documentation/copy/en/project-config/Integrating with Build Tools.md
@@ -99,7 +99,7 @@ var out = path.join(__dirname, "output.js");
 Duo(__dirname)
   .entry("entry.ts")
   .use(typescript())
-  .run(function(err, results) {
+  .run(function (err, results) {
     if (err) throw err;
     // Write compiled result to output file
     fs.writeFileSync(out, results.code);
@@ -119,13 +119,13 @@ npm install grunt-ts
 ### Basic Gruntfile.js
 
 ```js
-module.exports = function(grunt) {
+module.exports = function (grunt) {
   grunt.initConfig({
     ts: {
       default: {
-        src: ["**/*.ts", "!node_modules/**/*.ts"]
-      }
-    }
+        src: ["**/*.ts", "!node_modules/**/*.ts"],
+      },
+    },
   });
   grunt.loadNpmTasks("grunt-ts");
   grunt.registerTask("default", ["ts"]);
@@ -148,11 +148,11 @@ npm install gulp-typescript
 var gulp = require("gulp");
 var ts = require("gulp-typescript");
 
-gulp.task("default", function() {
+gulp.task("default", function () {
   var tsResult = gulp.src("src/*.ts").pipe(
     ts({
       noImplicitAny: true,
-      out: "output.js"
+      out: "output.js",
     })
   );
   return tsResult.js.pipe(gulp.dest("built/local"));
@@ -188,17 +188,17 @@ module.exports = {
   entry: "./src/index.tsx",
   output: {
     path: "/",
-    filename: "bundle.js"
+    filename: "bundle.js",
   },
   resolve: {
-    extensions: [".tsx", ".ts", ".js", ".json"]
+    extensions: [".tsx", ".ts", ".js", ".json"],
   },
   module: {
     rules: [
       // all files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'
-      { test: /\.tsx?$/, use: ["ts-loader"], exclude: /node_modules/ }
-    ]
-  }
+      { test: /\.tsx?$/, use: ["ts-loader"], exclude: /node_modules/ },
+    ],
+  },
 };
 ```
 
@@ -208,18 +208,18 @@ module.exports = {
 module.exports = {
   entry: "./src/index.tsx",
   output: {
-    filename: "bundle.js"
+    filename: "bundle.js",
   },
   resolve: {
     // Add '.ts' and '.tsx' as a resolvable extension.
-    extensions: ["", ".webpack.js", ".web.js", ".ts", ".tsx", ".js"]
+    extensions: ["", ".webpack.js", ".web.js", ".ts", ".tsx", ".js"],
   },
   module: {
     rules: [
       // all files with a '.ts' or '.tsx' extension will be handled by 'ts-loader'
-      { test: /\.tsx?$/, loader: "ts-loader" }
-    ]
-  }
+      { test: /\.tsx?$/, loader: "ts-loader" },
+    ],
+  },
 };
 ```
 

--- a/packages/documentation/copy/en/project-config/Project References.md
+++ b/packages/documentation/copy/en/project-config/Project References.md
@@ -3,6 +3,7 @@ title: Project References
 layout: docs
 permalink: /docs/handbook/project-references.html
 oneline: How to split up a large TypeScript project
+translatable: true
 ---
 
 Project references are a new feature in TypeScript 3.0 that allow you to structure your TypeScript programs into smaller pieces.

--- a/packages/documentation/copy/en/project-config/tsconfig.json.md
+++ b/packages/documentation/copy/en/project-config/tsconfig.json.md
@@ -3,6 +3,7 @@ title: tsconfig.json
 layout: docs
 permalink: /docs/handbook/tsconfig-json.html
 oneline: Learn about how a TSConfig works
+translatable: true
 ---
 
 ## Overview

--- a/packages/documentation/copy/en/reference/Declaration Merging.md
+++ b/packages/documentation/copy/en/reference/Declaration Merging.md
@@ -3,6 +3,7 @@ title: Declaration Merging
 layout: docs
 permalink: /docs/handbook/declaration-merging.html
 oneline: How merging namespaces and interfaces works
+translatable: true
 ---
 
 ## Introduction
@@ -227,7 +228,7 @@ Similarly, namespaces can be used to extend enums with static members:
 enum Color {
   red = 1,
   green = 2,
-  blue = 4
+  blue = 4,
 }
 
 namespace Color {
@@ -264,7 +265,7 @@ export class Observable<T> {
 
 // map.ts
 import { Observable } from "./observable";
-Observable.prototype.map = function(f) {
+Observable.prototype.map = function (f) {
   // ... another exercise for the reader
 };
 ```
@@ -285,7 +286,7 @@ declare module "./observable" {
     map<U>(f: (x: T) => U): Observable<U>;
   }
 }
-Observable.prototype.map = function(f) {
+Observable.prototype.map = function (f) {
   // ... another exercise for the reader
 };
 
@@ -293,7 +294,7 @@ Observable.prototype.map = function(f) {
 import { Observable } from "./observable";
 import "./map";
 let o: Observable<number>;
-o.map(x => x.toFixed());
+o.map((x) => x.toFixed());
 ```
 
 The module name is resolved the same way as module specifiers in `import`/`export`.
@@ -321,7 +322,7 @@ declare global {
   }
 }
 
-Array.prototype.toObservable = function() {
+Array.prototype.toObservable = function () {
   // ...
 };
 ```

--- a/packages/documentation/copy/en/reference/Decorators.md
+++ b/packages/documentation/copy/en/reference/Decorators.md
@@ -3,6 +3,7 @@ title: Decorators
 layout: docs
 permalink: /docs/handbook/decorators.html
 oneline: TypeScript Decorators overview
+translatable: true
 ---
 
 ## Introduction
@@ -57,7 +58,7 @@ We can write a decorator factory in the following fashion:
 ```ts
 function color(value: string) {
   // this is the decorator factory
-  return function(target) {
+  return function (target) {
     // this is the decorator
     // do something with 'target' and 'value'...
   };
@@ -96,14 +97,22 @@ If we were to use [decorator factories](#decorator-factories), we can observe th
 ```ts
 function f() {
   console.log("f(): evaluated");
-  return function(target, propertyKey: string, descriptor: PropertyDescriptor) {
+  return function (
+    target,
+    propertyKey: string,
+    descriptor: PropertyDescriptor
+  ) {
     console.log("f(): called");
   };
 }
 
 function g() {
   console.log("g(): evaluated");
-  return function(target, propertyKey: string, descriptor: PropertyDescriptor) {
+  return function (
+    target,
+    propertyKey: string,
+    descriptor: PropertyDescriptor
+  ) {
     console.log("g(): called");
   };
 }
@@ -234,7 +243,7 @@ We can define the `@enumerable` decorator using the following function declarati
 
 ```ts
 function enumerable(value: boolean) {
-  return function(
+  return function (
     target: any,
     propertyKey: string,
     descriptor: PropertyDescriptor
@@ -296,7 +305,7 @@ We can define the `@configurable` decorator using the following function declara
 
 ```ts
 function configurable(value: boolean) {
-  return function(
+  return function (
     target: any,
     propertyKey: string,
     descriptor: PropertyDescriptor
@@ -422,7 +431,7 @@ function validate(
   descriptor: TypedPropertyDescriptor<Function>
 ) {
   let method = descriptor.value;
-  descriptor.value = function() {
+  descriptor.value = function () {
     let requiredParameters: number[] = Reflect.getOwnMetadata(
       requiredMetadataKey,
       target,
@@ -522,7 +531,7 @@ function validate<T>(
   descriptor: TypedPropertyDescriptor<T>
 ) {
   let set = descriptor.set;
-  descriptor.set = function(value: T) {
+  descriptor.set = function (value: T) {
     let type = Reflect.getMetadata("design:type", target, propertyKey);
     if (!(value instanceof type)) {
       throw new TypeError("Invalid type.");

--- a/packages/documentation/copy/en/reference/Iterators and Generators.md
+++ b/packages/documentation/copy/en/reference/Iterators and Generators.md
@@ -3,6 +3,7 @@ title: Iterators and Generators
 layout: docs
 permalink: /docs/handbook/iterators-and-generators.html
 oneline: How Iterators and Generators work in TypeScript
+translatable: true
 ---
 
 ## Iterables

--- a/packages/documentation/copy/en/reference/JSX.md
+++ b/packages/documentation/copy/en/reference/JSX.md
@@ -3,6 +3,7 @@ title: JSX
 layout: docs
 permalink: /docs/handbook/jsx.html
 oneline: Using JSX with TypeScript
+translatable: true
 ---
 
 [JSX](https://facebook.github.io/jsx/) is an embeddable XML-like syntax.

--- a/packages/documentation/copy/en/reference/Mixins.md
+++ b/packages/documentation/copy/en/reference/Mixins.md
@@ -3,6 +3,7 @@ title: Mixins
 layout: docs
 permalink: /docs/handbook/mixins.html
 oneline: Using the mixin pattern with TypeScript
+translatable: true
 ---
 
 Along with traditional OO hierarchies, another popular way of building up classes from reusable components is to build them by combining simpler partial classes.

--- a/packages/documentation/copy/en/reference/Module Resolution.md
+++ b/packages/documentation/copy/en/reference/Module Resolution.md
@@ -3,6 +3,7 @@ title: Module Resolution
 layout: docs
 permalink: /docs/handbook/module-resolution.html
 oneline: How TypeScript resolves modules in JavaScript
+translatable: true
 ---
 
 > This section assumes some basic knowledge about modules.

--- a/packages/documentation/copy/en/reference/Modules.md
+++ b/packages/documentation/copy/en/reference/Modules.md
@@ -3,6 +3,7 @@ title: Modules
 layout: docs
 permalink: /docs/handbook/modules.html
 oneline: How modules work in TypeScript
+translatable: true
 ---
 
 Starting with ECMAScript 2015, JavaScript has a concept of modules. TypeScript shares this concept.
@@ -136,10 +137,10 @@ With TypeScript 3.8, you can import a type using the `import` statement, or usin
 
 ```ts
 // Re-using the same import
-import {APIResponseType} from "./api";
+import { APIResponseType } from "./api";
 
 // Explicitly use import type
-import type {APIResponseType} from "./api";
+import type { APIResponseType } from "./api";
 ```
 
 `import type` is always guaranteed to be removed from your JavaScript, and tools like Babel can make better assumptions about your code via the `isolatedModules` compiler flag.
@@ -198,7 +199,7 @@ or
 ```ts
 const numberRegexp = /^[0-9]+$/;
 
-export default function(s: string) {
+export default function (s: string) {
   return s.length === 5 && numberRegexp.test(s);
 }
 ```
@@ -211,7 +212,7 @@ import validate from "./StaticZipCodeValidator";
 let strings = ["Hello", "98052", "101"];
 
 // Use function validate
-strings.forEach(s => {
+strings.forEach((s) => {
   console.log(`"${s}" ${validate(s) ? "matches" : "does not match"}`);
 });
 ```
@@ -283,7 +284,7 @@ let strings = ["Hello", "98052", "101"];
 let validator = new zip();
 
 // Show whether each string passed each validator
-strings.forEach(s => {
+strings.forEach((s) => {
   console.log(
     `"${s}" - ${validator.isAcceptable(s) ? "matches" : "does not match"}`
   );
@@ -307,7 +308,7 @@ export let t = m.something + 1;
 ##### AMD / RequireJS SimpleModule.js
 
 ```js
-define(["require", "exports", "./mod"], function(require, exports, mod_1) {
+define(["require", "exports", "./mod"], function (require, exports, mod_1) {
   exports.t = mod_1.something + 1;
 });
 ```
@@ -322,14 +323,14 @@ exports.t = mod_1.something + 1;
 ##### UMD SimpleModule.js
 
 ```js
-(function(factory) {
+(function (factory) {
   if (typeof module === "object" && typeof module.exports === "object") {
     var v = factory(require, exports);
     if (v !== undefined) module.exports = v;
   } else if (typeof define === "function" && define.amd) {
     define(["require", "exports", "./mod"], factory);
   }
-})(function(require, exports) {
+})(function (require, exports) {
   var mod_1 = require("./mod");
   exports.t = mod_1.something + 1;
 });
@@ -338,18 +339,18 @@ exports.t = mod_1.something + 1;
 ##### System SimpleModule.js
 
 ```js
-System.register(["./mod"], function(exports_1) {
+System.register(["./mod"], function (exports_1) {
   var mod_1;
   var t;
   return {
     setters: [
-      function(mod_1_1) {
+      function (mod_1_1) {
         mod_1 = mod_1_1;
-      }
+      },
     ],
-    execute: function() {
+    execute: function () {
       exports_1("t", (t = mod_1.something + 1));
-    }
+    },
   };
 });
 ```
@@ -427,7 +428,7 @@ validators["ZIP code"] = new ZipCodeValidator();
 validators["Letters only"] = new LettersOnlyValidator();
 
 // Show whether each string passed each validator
-strings.forEach(s => {
+strings.forEach((s) => {
   for (let name in validators) {
     console.log(
       `"${s}" - ${
@@ -850,7 +851,7 @@ class ProgrammerCalculator extends Calculator {
     "C",
     "D",
     "E",
-    "F"
+    "F",
   ];
 
   constructor(public base: number) {

--- a/packages/documentation/copy/en/reference/Namespaces and Modules.md
+++ b/packages/documentation/copy/en/reference/Namespaces and Modules.md
@@ -3,6 +3,7 @@ title: Namespaces and Modules
 layout: docs
 permalink: /docs/handbook/namespaces-and-modules.html
 oneline: How to organize code in TypeScript via modules or namespaces
+translatable: true
 ---
 
 This post outlines the various ways to organize your code using modules and namespaces in TypeScript.

--- a/packages/documentation/copy/en/reference/Namespaces.md
+++ b/packages/documentation/copy/en/reference/Namespaces.md
@@ -3,6 +3,7 @@ title: Namespaces
 layout: docs
 permalink: /docs/handbook/namespaces.html
 oneline: How TypeScript namespaces work
+translatable: true
 ---
 
 > **A note about terminology:**

--- a/packages/documentation/copy/en/reference/Symbols.md
+++ b/packages/documentation/copy/en/reference/Symbols.md
@@ -3,6 +3,7 @@ title: Symbols
 layout: docs
 permalink: /docs/handbook/symbols.html
 oneline: Using the JavaScript Symbol primitive in TypeScript
+translatable: true
 ---
 
 Starting with ECMAScript 2015, `symbol` is a primitive data type, just like `number` and `string`.
@@ -30,7 +31,7 @@ Just like strings, symbols can be used as keys for object properties.
 const sym = Symbol();
 
 let obj = {
-  [sym]: "value"
+  [sym]: "value",
 };
 
 console.log(obj[sym]); // "value"

--- a/packages/documentation/copy/en/reference/Triple-Slash Directives.md
+++ b/packages/documentation/copy/en/reference/Triple-Slash Directives.md
@@ -2,7 +2,8 @@
 title: Triple-Slash Directives
 layout: docs
 permalink: /docs/handbook/triple-slash-directives.html
-oneline: How to use triple slash directives in TypeScripit
+oneline: How to use triple slash directives in TypeScript
+translatable: true
 ---
 
 Triple-slash directives are single-line comments containing a single XML tag.
@@ -107,8 +108,8 @@ Will result in assigning the name `NamedModule` to the module as part of calling
 ##### amdModule.js
 
 ```js
-define("NamedModule", ["require", "exports"], function(require, exports) {
-  var C = (function() {
+define("NamedModule", ["require", "exports"], function (require, exports) {
+  var C = (function () {
     function C() {}
     return C;
   })();
@@ -133,7 +134,7 @@ moduleA.callStuff();
 Generated JS code:
 
 ```js
-define(["require", "exports", "legacy/moduleA"], function(
+define(["require", "exports", "legacy/moduleA"], function (
   require,
   exports,
   moduleA

--- a/packages/documentation/copy/en/reference/Type Compatibility.md
+++ b/packages/documentation/copy/en/reference/Type Compatibility.md
@@ -3,6 +3,7 @@ title: Type Compatibility
 layout: docs
 permalink: /docs/handbook/type-compatibility.html
 oneline: How type-checking works in TypeScript
+translatable: true
 ---
 
 Type compatibility in TypeScript is based on structural subtyping.
@@ -97,7 +98,7 @@ let items = [1, 2, 3];
 items.forEach((item, index, array) => console.log(item));
 
 // Should be OK!
-items.forEach(item => console.log(item));
+items.forEach((item) => console.log(item));
 ```
 
 Now let's look at how return types are treated, using two functions that differ only by their return type:
@@ -121,7 +122,7 @@ In practice, this sort of error is rare, and allowing this enables many common J
 ```ts
 enum EventType {
   Mouse,
-  Keyboard
+  Keyboard,
 }
 
 interface Event {
@@ -190,12 +191,12 @@ Enums are compatible with numbers, and numbers are compatible with enums. Enum v
 ```ts
 enum Status {
   Ready,
-  Waiting
+  Waiting,
 }
 enum Color {
   Red,
   Blue,
-  Green
+  Green,
 }
 
 let status = Status.Ready;
@@ -266,11 +267,11 @@ The resulting types are then checked for compatibility, just as in the non-gener
 For example,
 
 ```ts
-let identity = function<T>(x: T): T {
+let identity = function <T>(x: T): T {
   // ...
 };
 
-let reverse = function<U>(y: U): U {
+let reverse = function <U>(y: U): U {
   // ...
 };
 

--- a/packages/documentation/copy/en/reference/Type Inference.md
+++ b/packages/documentation/copy/en/reference/Type Inference.md
@@ -3,6 +3,7 @@ title: Type Inference
 layout: docs
 permalink: /docs/handbook/type-inference.html
 oneline: How code flow analysis works in TypeScript
+translatable: true
 ---
 
 In TypeScript, there are several places where type inference is used to provide type information when there is no explicit type annotation. For example, in this code
@@ -37,13 +38,13 @@ Because the best common type has to be chosen from the provided candidate types,
 // @strict: false
 class Animal {}
 class Rhino extends Animal {
-  hasHorn: true
+  hasHorn: true;
 }
 class Elephant extends Animal {
-  hasTrunk: true
+  hasTrunk: true;
 }
 class Snake extends Animal {
-  hasLegs: false
+  hasLegs: false;
 }
 // ---cut---
 let zoo = [new Rhino(), new Elephant(), new Snake()];
@@ -57,13 +58,13 @@ To correct this, instead explicitly provide the type when no one type is a super
 // @strict: false
 class Animal {}
 class Rhino extends Animal {
-  hasHorn: true
+  hasHorn: true;
 }
 class Elephant extends Animal {
-  hasTrunk: true
+  hasTrunk: true;
 }
 class Snake extends Animal {
-  hasLegs: false
+  hasLegs: false;
 }
 // ---cut---
 let zoo: Animal[] = [new Rhino(), new Elephant(), new Snake()];

--- a/packages/documentation/copy/en/reference/Utility Types.md
+++ b/packages/documentation/copy/en/reference/Utility Types.md
@@ -3,6 +3,7 @@ title: Utility Types
 layout: docs
 permalink: /docs/handbook/utility-types.html
 oneline: Types which are globally included in TypeScript
+translatable: true
 ---
 
 TypeScript provides several utility types to facilitate common type transformations. These utilities are available globally.
@@ -25,11 +26,11 @@ function updateTodo(todo: Todo, fieldsToUpdate: Partial<Todo>) {
 
 const todo1 = {
   title: "organize desk",
-  description: "clear clutter"
+  description: "clear clutter",
 };
 
 const todo2 = updateTodo(todo1, {
-  description: "throw out trash"
+  description: "throw out trash",
 });
 ```
 
@@ -46,7 +47,7 @@ interface Todo {
 }
 
 const todo: Readonly<Todo> = {
-  title: "Delete inactive users"
+  title: "Delete inactive users",
 };
 
 todo.title = "Hello";
@@ -76,10 +77,10 @@ type Page = "home" | "about" | "contact";
 const nav: Record<Page, PageInfo> = {
   about: { title: "about" },
   contact: { title: "contact" },
-  home: { title: "home" }
+  home: { title: "home" },
 };
 
-nav.about
+nav.about;
 //      ^?
 ```
 
@@ -100,10 +101,10 @@ type TodoPreview = Pick<Todo, "title" | "completed">;
 
 const todo: TodoPreview = {
   title: "Clean room",
-  completed: false
+  completed: false,
 };
 
-todo
+todo;
 // ^?
 ```
 
@@ -124,10 +125,10 @@ type TodoPreview = Omit<Todo, "description">;
 
 const todo: TodoPreview = {
   title: "Clean room",
-  completed: false
+  completed: false,
 };
 
-todo
+todo;
 // ^?
 ```
 
@@ -215,10 +216,10 @@ type T1 = ConstructorParameters<FunctionConstructor>;
 //    ^?
 type T2 = ConstructorParameters<RegExpConstructor>;
 //    ^?
-type T3 = ConstructorParameters<any>
+type T3 = ConstructorParameters<any>;
 //    ^?
 
-type T4 = ConstructorParameters<Function>
+type T4 = ConstructorParameters<Function>;
 //    ^?
 ```
 
@@ -353,8 +354,8 @@ let obj = makeObject({
     moveBy(dx: number, dy: number) {
       this.x += dx; // Strongly typed this
       this.y += dy; // Strongly typed this
-    }
-  }
+    },
+  },
 });
 
 obj.x = 10;

--- a/packages/documentation/copy/en/reference/Variable Declarations.md
+++ b/packages/documentation/copy/en/reference/Variable Declarations.md
@@ -3,6 +3,7 @@ title: Variable Declaration
 layout: docs
 permalink: /docs/handbook/variable-declarations.html
 oneline: How TypeScript handles variable declaration
+translatable: true
 ---
 
 `let` and `const` are two relatively new concepts for variable declarations in JavaScript.
@@ -123,7 +124,7 @@ Take a quick second to guess what the output of the following snippet is:
 
 ```ts
 for (var i = 0; i < 10; i++) {
-  setTimeout(function() {
+  setTimeout(function () {
     console.log(i);
   }, 100 * i);
 }
@@ -176,8 +177,8 @@ A common work around is to use an IIFE - an Immediately Invoked Function Express
 for (var i = 0; i < 10; i++) {
   // capture the current state of 'i'
   // by invoking a function with its current value
-  (function(i) {
-    setTimeout(function() {
+  (function (i) {
+    setTimeout(function () {
       console.log(i);
     }, 100 * i);
   })(i);
@@ -351,7 +352,7 @@ function theCityThatAlwaysSleeps() {
 
   if (true) {
     let city = "Seattle";
-    getCity = function() {
+    getCity = function () {
       return city;
     };
   }
@@ -372,7 +373,7 @@ Since this is what we were doing anyway with our IIFE, we can change our old `se
 
 ```ts
 for (let i = 0; i < 10; i++) {
-  setTimeout(function() {
+  setTimeout(function () {
     console.log(i);
   }, 100 * i);
 }
@@ -410,13 +411,13 @@ This should not be confused with the idea that the values they refer to are _imm
 const numLivesForCat = 9;
 const kitty = {
   name: "Aurora",
-  numLives: numLivesForCat
+  numLives: numLivesForCat,
 };
 
 // Error
 kitty = {
   name: "Danielle",
-  numLives: numLivesForCat
+  numLives: numLivesForCat,
 };
 
 // all "okay"
@@ -546,7 +547,7 @@ You can also destructure objects:
 let o = {
   a: "foo",
   b: 12,
-  c: "bar"
+  c: "bar",
 };
 let { a, b } = o;
 ```

--- a/packages/documentation/copy/en/tutorials/Babel with TypeScript.md
+++ b/packages/documentation/copy/en/tutorials/Babel with TypeScript.md
@@ -3,6 +3,7 @@ title: Using Babel with TypeScript
 layout: docs
 permalink: /docs/handbook/babel-with-typescript.html
 oneline: How to create a hybrid Babel + TypeScript project
+translatable: true
 ---
 
 ## Babel vs `tsc` for TypeScript

--- a/packages/documentation/copy/en/tutorials/DOM Manipulation.md
+++ b/packages/documentation/copy/en/tutorials/DOM Manipulation.md
@@ -3,6 +3,7 @@ title: DOM Manipulation
 layout: docs
 permalink: /docs/handbook/dom-manipulation.html
 oneline: Using the DOM with TypeScript
+translatable: true
 ---
 
 ## DOM Manipulation

--- a/packages/documentation/copy/en/tutorials/React.md
+++ b/packages/documentation/copy/en/tutorials/React.md
@@ -3,6 +3,7 @@ title: React
 layout: docs
 permalink: /docs/handbook/react.html
 oneline: Links to learn about TypeScript and React
+translatable: true
 ---
 
 TypeScript supports [JSX](/docs/handbook/jsx.html) and can correctly model the patterns used in React codebases like `useState`.

--- a/packages/documentation/copy/en/tutorials/TypeScript Tooling in 5 minutes.md
+++ b/packages/documentation/copy/en/tutorials/TypeScript Tooling in 5 minutes.md
@@ -3,6 +3,7 @@ title: TypeScript Tooling in 5 minutes
 layout: docs
 permalink: /docs/handbook/typescript-tooling-in-5-minutes.html
 oneline: A tutorial to understand how to create a small website with TypeScript
+translatable: true
 ---
 
 Let's get started by building a simple web application with TypeScript.

--- a/packages/typescriptlang-org/scripts/makeMarkdownOfTranslations.js
+++ b/packages/typescriptlang-org/scripts/makeMarkdownOfTranslations.js
@@ -1,5 +1,8 @@
+// @ts-enable
+
 const { join, basename } = require("path")
 const { recursiveReadDirSync } = require("../lib/utils/recursiveReadDirSync")
+const { read } = require("gray-matter")
 
 const getAllTODOFiles = lang => {
   const diffFolders = (root, lang) => {
@@ -35,12 +38,17 @@ const getAllTODOFiles = lang => {
   const appRoot = join(__dirname, "..", "src", "copy")
   const appTODO = diffFolders(appRoot, lang)
 
-  // Handbook TBD
+  const docsRoot = join(__dirname, "..", "..", "documentation", "copy")
+  const docsTODO = diffFolders(docsRoot, lang)
+  docsTODO.todo = docsTODO.todo.filter(
+    path => read(join(__dirname, "..", "..", path)).data.translatable
+  )
 
   const all = {
     tsconfig: tsconfigFilesTODO,
     playground: playgroundTODO,
     app: appTODO,
+    docs: docsTODO,
   }
 
   return all

--- a/packages/typescriptlang-org/scripts/updateGitHubTranslationIssues.ts
+++ b/packages/typescriptlang-org/scripts/updateGitHubTranslationIssues.ts
@@ -11,6 +11,7 @@ const languages = {
   pt: 233,
   es: 232,
   zh: 296,
+  kn: 910,
 }
 
 const go = async () => {
@@ -26,7 +27,8 @@ const go = async () => {
     const issueNumber = languages[lang]
 
     const files = getAllTODOFiles(lang)
-    const body = toMarkdown(files)
+    const header = `Hi! This issue is for keeping track of the localization effort for \`${lang}+"\`. You can learn about the whole roadmap in #100. If you see an un-ticked area below, that means there isn't an version of that file in this language.\n\n`
+    const body = header + toMarkdown(files)
 
     console.log("Updating: ", issueNumber)
     await octokit.issues.update({

--- a/packages/typescriptlang-org/scripts/updateGitHubTranslationIssues.ts
+++ b/packages/typescriptlang-org/scripts/updateGitHubTranslationIssues.ts
@@ -11,7 +11,7 @@ const languages = {
   pt: 233,
   es: 232,
   zh: 296,
-  kn: 910,
+  ko: 910,
 }
 
 const go = async () => {


### PR DESCRIPTION
When a doc is considered translatable, I've marked it via the yml at the top of the file in the `en` version.