### PR TITLE
Update link to types-publisher tool on Publishing.md

### DIFF
--- a/packages/documentation/copy/en/declaration-files/Publishing.md
+++ b/packages/documentation/copy/en/declaration-files/Publishing.md
@@ -157,6 +157,6 @@ That means in the above example, even though both the `>=3.2` and the `>=3.1` ma
 
 ## Publish to [@types](https://www.npmjs.com/~types)
 
-Packages under the [@types](https://www.npmjs.com/~types) organization are published automatically from [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) using the [types-publisher tool](https://github.com/Microsoft/types-publisher).
+Packages under the [@types](https://www.npmjs.com/~types) organization are published automatically from [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) using the [types-publisher tool](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher).
 To get your declarations published as an @types package, please submit a pull request to [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped).
 You can find more details in the [contribution guidelines page](http://definitelytyped.org/guides/contributing.html).


### PR DESCRIPTION
Existing link points to https://github.com/Microsoft/types-publisher which has been archived and the readme of that repo points to https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher