### PR TITLE
[pt-BR] Exclude, fallBackPolling, ImportsNotUaV

### DIFF
--- a/packages/tsconfig-reference/copy/pt/options/exclude.md
+++ b/packages/tsconfig-reference/copy/pt/options/exclude.md
@@ -1,0 +1,11 @@
+---
+display: "Excluir"
+oneline: "Arquivos ou padrões a serem ignorados pela opção de incluir"
+---
+
+Especifica uma array de nomes de arquivos ou padrões que devem ser ignorando durante o `include`.
+
+**Importante**: `exclude` altera _apenas_ os arquivos que estão nos resultados da configuração `include`.
+Um arquivo marcado como `exclude` ainda pode fazer parte do seu código através de uma instrução `import`, uma inclusão de `types`, uma diretiva `/// <reference` ou sendo relacionado na lista de `files`.
+
+Não é um mecanismo que **impede** um arquivo ser incluído no código base - apenas altera o que a configuração `include` pode selecionar.

--- a/packages/tsconfig-reference/copy/pt/options/fallbackPolling.md
+++ b/packages/tsconfig-reference/copy/pt/options/fallbackPolling.md
@@ -1,0 +1,11 @@
+---
+display: "Alternativas na ausência de observadores"
+oneline: "O que o observador deve fazer se o sistema ficar sem observadores de arquivos nativos."
+---
+
+Quando utilizar eventos de arquivos do sistema, essa opção indica as estratégias de verificação que o sistema deve executar quando estiver sem observadores e/ou não suportar os observadores nativos.
+
+- `fixedPollingInterval`: Verifica se há alterações em cada arquivo, várias vezes por segundo, durante um intervalo fixo.
+- `priorityPollingInterval`: Verifica se há alterações em cada arquivo, várias vezes por segundo, mas usa heurística para verificar mais alguns arquivos do que outros.
+- `dynamicPriorityPolling`: Uma fila dinâmica onde os arquivos com menos frequências de modificações são verificados com menos frequência.
+- `synchronousWatchDirectory`: Desativa a verificação adiada nos diretórios. Adiar a verificação é útil quando muitas mudanças podem acontecer de uma vez só (ex.: uma mudança em `node_modules` por executar o `npm install`), mas você pode querer desativar isso para configurações menos comuns.

--- a/packages/tsconfig-reference/copy/pt/options/fallbackPolling.md
+++ b/packages/tsconfig-reference/copy/pt/options/fallbackPolling.md
@@ -5,7 +5,7 @@ oneline: "O que o observador deve fazer se o sistema ficar sem observadores de a
 
 Quando utilizar eventos de arquivos do sistema, essa opção indica as estratégias de verificação que o sistema deve executar quando estiver sem observadores e/ou não suportar os observadores nativos.
 
-- `fixedPollingInterval`: Verifica se há alterações em cada arquivo, várias vezes por segundo, durante um intervalo fixo.
-- `priorityPollingInterval`: Verifica se há alterações em cada arquivo, várias vezes por segundo, mas usa heurística para verificar mais alguns arquivos do que outros.
-- `dynamicPriorityPolling`: Uma fila dinâmica onde os arquivos com menos frequências de modificações são verificados com menos frequência.
-- `synchronousWatchDirectory`: Desativa a verificação adiada nos diretórios. Adiar a verificação é útil quando muitas mudanças podem acontecer de uma vez só (ex.: uma mudança em `node_modules` por executar o `npm install`), mas você pode querer desativar isso para configurações menos comuns.
+- `fixedPollingInterval`: Checa por mudanças nos arquivos várias vezes por segundo a um intervalo pré-determinado.
+- `priorityPollingInterval`: Checa todos os arquivos por mudanças várias vezes por segundo, mas usando heurísticas para checar alguns tipos de arquivos mais frequentemente que outros.
+- `dynamicPriorityPolling`: Usa uma fila dinâmica onde diretórios que são menos alterados serão checados menos vezes.
+- `synchronousWatchDirectory`: Desativa a checagem adiada nos diretórios. Adiar a checagem é útil quando muitas mudanças podem acontecer de uma vez só (ex.: uma mudança em `node_modules` por executar o `npm install`), mas você pode querer desativar isso para configurações menos comuns.

--- a/packages/tsconfig-reference/copy/pt/options/importsNotUsedAsValues.md
+++ b/packages/tsconfig-reference/copy/pt/options/importsNotUsedAsValues.md
@@ -1,6 +1,6 @@
 ---
 display: "Importações não utilizadas como valores"
-oneline: "faz algo"
+oneline: "Controla qual a sintaxe você utiliza para importar tipos"
 ---
 
 Essa opção controla como o `import` funciona, são 3 opções diferentes:

--- a/packages/tsconfig-reference/copy/pt/options/importsNotUsedAsValues.md
+++ b/packages/tsconfig-reference/copy/pt/options/importsNotUsedAsValues.md
@@ -1,0 +1,15 @@
+---
+display: "Importações não utilizadas como valores"
+oneline: "faz algo"
+---
+
+Essa opção controla como o `import` funciona, são 3 opções diferentes:
+
+- `remove`: O comportamento padrão para descartar os `import` que apenas referenciam tipos.
+
+- `preserve`: Preserva todas as declarações `import` que os valores ou tipos nunca são usados. Isso pode permitir que importações/efeitos colaterais sejam mantidos.
+
+- `error`: Isso mantém todas as importações (as mesmas que a opção de preservar), mas apresentará um erro quando o valor da importação usada for apenas como tipo. Isto pode ser útil se você quiser garantir que nenhum valor vai ser acidentalmente importado, mas ainda vai manter os efeitos colaterais da importação explícitos.
+
+Essa opção funciona porque você pode usar `import type` para criar explicitamente uma regra `import` que nunca seja emitida em Javascript.
+


### PR DESCRIPTION
Hello @khaosdoctor, @alvarocamillont, @danilofuchs e @zanecop 

All files are from tsconfig:

> exclude.md
> fallbackPolling.md
> importsNotUsedAsValues.md

I had some doubts about the words to use in the file `fallbackPolling.md`, but tried to let the text clear and easily understandable. If you think that''s not the ideal yet, I can try other solutions. The same for the other files. Thank you!