### PR TITLE
Translate tsconfig-reference files to ko

### DIFF
--- a/packages/tsconfig-reference/copy/ko/intro.md
+++ b/packages/tsconfig-reference/copy/ko/intro.md
@@ -1,6 +1,6 @@
 ## TSConfig Reference 소개
 
-디렉토리의 TSConfig 파일은 현재 디렉토리가 TypeScript 또는 JavaScript 프로젝트의 루트 디렉토리임을 나타냅니다.
+디렉터리의 TSConfig 파일은 현재 디렉터리가 TypeScript 또는 JavaScript 프로젝트의 루트 디렉터리임을 나타냅니다.
 TSConfig 파일은 `tsconfig.json` 또는 `jsconfig.json` 일 수 있으며, 둘 다 같은 동작과 설정 변수의 집합을 가지고 있습니다.
 
 이 페이지에서는 TSConfig 파일 내에서 사용할 수 있는 다양한 플래그를 모두 다룹니다. 모든 플래그의 개요를 시작으로 JSON 파일의 루트 속성을 지나, 옵션의 대부분인 `compilerOptions` 을 거쳐 `watchOptions`으로 마무리합니다.

--- a/packages/tsconfig-reference/copy/ko/intro.md
+++ b/packages/tsconfig-reference/copy/ko/intro.md
@@ -1,6 +1,6 @@
 ## TSConfig Reference 소개
 
-디렉터리의 TSConfig 파일은 현재 디렉터리가 TypeScript 또는 JavaScript 프로젝트의 루트 디렉터리임을 나타냅니다.
+디렉터리의 TSConfig 파일은 그 디렉터리가 TypeScript 또는 JavaScript 프로젝트의 루트 디렉터리임을 나타냅니다.
 TSConfig 파일은 `tsconfig.json` 또는 `jsconfig.json` 일 수 있으며, 둘 다 같은 동작과 설정 변수의 집합을 가지고 있습니다.
 
 이 페이지에서는 TSConfig 파일 내에서 사용할 수 있는 다양한 플래그를 모두 다룹니다. 모든 플래그의 개요를 시작으로 JSON 파일의 루트 속성을 지나, 옵션의 대부분인 `compilerOptions` 을 거쳐 `watchOptions`으로 마무리합니다.

--- a/packages/tsconfig-reference/copy/ko/intro.md
+++ b/packages/tsconfig-reference/copy/ko/intro.md
@@ -3,4 +3,4 @@
 디렉터리의 TSConfig 파일은 그 디렉터리가 TypeScript 또는 JavaScript 프로젝트의 루트 디렉터리임을 나타냅니다.
 TSConfig 파일은 `tsconfig.json` 또는 `jsconfig.json` 일 수 있으며, 둘 다 같은 동작과 설정 변수의 집합을 가지고 있습니다.
 
-이 페이지에서는 TSConfig 파일 내에서 사용할 수 있는 다양한 플래그를 모두 다룹니다. 모든 플래그의 개요를 시작으로 JSON 파일의 루트 속성을 지나, 옵션의 대부분인 `compilerOptions` 을 거쳐 `watchOptions`으로 마무리합니다.
+이 페이지에서는 TSConfig 파일 내에서 사용할 수 있는 다양한 플래그를 모두 다룹니다. 모든 플래그의 개요를 시작으로 JSON 파일의 루트 속성을 살펴본 다음, 옵션의 대부분을 구성하는 `compilerOptions`를 거쳐 `watchOptions`로 마무리합니다.

--- a/packages/tsconfig-reference/copy/ko/intro.md
+++ b/packages/tsconfig-reference/copy/ko/intro.md
@@ -1,0 +1,6 @@
+## TSConfig Reference 소개
+
+디렉토리의 TSConfig 파일은 현재 디렉토리가 TypeScript 또는 JavaScript 프로젝트의 루트 디렉토리임을 나타냅니다.
+TSConfig 파일은 `tsconfig.json` 또는 `jsconfig.json` 일 수 있으며, 둘 다 같은 동작과 설정 변수의 집합을 가지고 있습니다.
+
+이 페이지에서는 TSConfig 파일 내에서 사용할 수 있는 다양한 플래그를 모두 다룹니다. 모든 플래그의 개요를 시작으로 JSON 파일의 루트 속성을 지나, 옵션의 대부분인 `compilerOptions` 을 거쳐 `watchOptions`으로 마무리합니다.

--- a/packages/tsconfig-reference/copy/ko/options/files.md
+++ b/packages/tsconfig-reference/copy/ko/options/files.md
@@ -3,7 +3,7 @@ display: "Files"
 oneline: "Include a set list of files, does not support globs"
 ---
 
-프로그램에 포함할 파일 허용 목록을 지정합니다. 파일을 찾지 못할 경우 오류가 발생합니다.
+프로그램에 포함할 파일 허용 목록을 지정합니다. 파일을 찾지 못하면 오류가 발생합니다.
 
 ```json
 {

--- a/packages/tsconfig-reference/copy/ko/options/files.md
+++ b/packages/tsconfig-reference/copy/ko/options/files.md
@@ -22,4 +22,4 @@ oneline: "Include a set list of files, does not support globs"
 }
 ```
 
-파일의 수가 많지 않아 파일 참조에 glob을 사용할 필요가 없을 때 유용합니다. 필요한 경우 [`include`](#include)을 사용합니다.
+파일 수가 적어 파일 참조에 glob을 사용할 필요가 없을 때 유용합니다. 필요한 경우 [`include`](#include)을 사용합니다.

--- a/packages/tsconfig-reference/copy/ko/options/files.md
+++ b/packages/tsconfig-reference/copy/ko/options/files.md
@@ -1,0 +1,25 @@
+---
+display: "Files"
+oneline: "Include a set list of files, does not support globs"
+---
+
+프로그램에 포함할 파일 허용 목록을 지정합니다. 파일을 찾지 못할 경우 오류가 발생합니다.
+
+```json
+{
+  "compilerOptions": {},
+  "files": [
+    "core.ts",
+    "sys.ts",
+    "types.ts",
+    "scanner.ts",
+    "parser.ts",
+    "utilities.ts",
+    "binder.ts",
+    "checker.ts",
+    "tsc.ts"
+  ]
+}
+```
+
+파일의 수가 많지 않아 파일 참조에 glob을 사용할 필요가 없을 때 유용합니다. 필요한 경우 [`include`](#include)을 사용합니다.


### PR DESCRIPTION
Hi :)
It's first commit to translate typescript file to Korean!

This current PR translate the following files:
- [intro.md](https://github.com/microsoft/TypeScript-Website/blob/v2/packages/tsconfig-reference/copy/en/intro.md)
- [files.md](https://github.com/microsoft/TypeScript-Website/blob/v2/packages/tsconfig-reference/copy/en/options/files.md)

Ref : #910 