### PR TITLE
Fixed dark mode switching bug

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/SiteFooter.tsx
+++ b/packages/typescriptlang-org/src/components/layout/SiteFooter.tsx
@@ -221,8 +221,8 @@ export const SiteFooter = (props: Props) => {
   const useDark = !customThemeOverride && systemIsDark ? true : customThemeOverride === "dark-theme"
   const [isDarkMode, setDarkMode] = useState(useDark)
 
-  const handleThemeChange = () => {
-    setDarkMode(!isDarkMode)
+  const handleThemeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setDarkMode(!event.currentTarget.checked)
     if (document.location.pathname.includes("/play")) {
       document.location.reload()
     }


### PR DESCRIPTION
This PR fixes the bug #839

The bug happens only on staging and production, locally it doesn't happen. the cause of this bug is that, the server-side rendered HTML is having light-them by default, thus the switch is checked
```html
<div class="switch-wrap">
    <input type="checkbox" checked>
    <div class="switch"></div>
</div>
```
and then, when the JS loads, due to the locally stored dark-them value, React will render this (removes the `checked` attribute)

```html
<div class="switch-wrap">
    <input type="checkbox">
    <div class="switch"></div>
</div>
```
which will cause the `onChange` event to fire for the input element (the switch), and here where the bug happens, because it's updating the`isDarkMode` like this:
```ts
setDarkMode(!isDarkMode)
```
instead of taking the input (the switch) value
```ts
setDarkMode(!event.currentTarget.checked)
```
this ensures that, whatever you select in the switch, will set the value of the `isDarkMode`