### PR TITLE
fix(playground): scroll to bottom does not work in Logs tab

### DIFF
--- a/packages/playground/src/sidebar/runtime.ts
+++ b/packages/playground/src/sidebar/runtime.ts
@@ -95,20 +95,21 @@ function rewireLoggingToElement(
       const prefix = '[<span class="log-' + name + '">' + id + "</span>]: "
       const eleContainerLog = eleOverflowLocator()
       allLogs = allLogs + prefix + output + "<br>"
-
-      if (eleLog && eleContainerLog) {
-        if (autoScroll) {
-          const atBottom = eleContainerLog.scrollHeight - eleContainerLog.clientHeight <= eleContainerLog.scrollTop + 1
-          eleLog.innerHTML = allLogs
-
-          if (atBottom) eleContainerLog.scrollTop = eleContainerLog.scrollHeight - eleContainerLog.clientHeight
-        } else {
-          eleLog.innerHTML = allLogs
-        }
+      eleLog.innerHTML = allLogs
+      const scrollElement = eleContainerLog.parentElement
+      if (autoScroll && scrollElement) {
+        scrollToBottom(scrollElement)
       }
-
       // @ts-ignore
       console["old" + name].apply(undefined, objs)
+    }
+  }
+
+  function scrollToBottom(element: Element) {
+    const overflowHeight = element.scrollHeight - element.clientHeight
+    const atBottom = element.scrollTop >= overflowHeight
+    if (!atBottom) {
+      element.scrollTop = overflowHeight
     }
   }
 


### PR DESCRIPTION
Scroll to bottom does not work in Logs tab of playground. 
It might be that the scroll target element has been changed without noticing.

I made the following changes
- Change scroll target from log-container to tabpanel
- Extract scroll to bottom logic as func and use it