### PR TITLE
Fix: Remove additional newline

### DIFF
--- a/packages/documentation/copy/en/get-started/TS for JS Programmers.md
+++ b/packages/documentation/copy/en/get-started/TS for JS Programmers.md
@@ -250,7 +250,6 @@ const rect = { x: 33, y: 3, width: 30, height: 80 };
 printPoint(rect); // prints "33, 3"
 
 const color = { hex: "#187ABF" };
-
 printPoint(color);
 ```
 


### PR DESCRIPTION
Changing example 3 in accord to example 1 and 2 where the call to the printPoint function are after one new line and not two.