### PR TITLE
1.0 for Twoslash

### DIFF
--- a/.github/workflows/builds-on-windows.yml
+++ b/.github/workflows/builds-on-windows.yml
@@ -13,6 +13,18 @@ jobs:
         with:
           node-version: "13.x"
 
+      # Cache yarn deps, to speed up CI
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       # Get local dependencies
       - run: yarn install
         env:

--- a/packages/gatsby-remark-shiki-twoslash/package.json
+++ b/packages/gatsby-remark-shiki-twoslash/package.json
@@ -19,8 +19,8 @@
     "lint": "tsdx lint"
   },
   "dependencies": {
-    "@typescript/twoslash": "0.6.2",
-    "@typescript/vfs": "1.1.2",
+    "@typescript/twoslash": "1.0.0",
+    "@typescript/vfs": "1.2.0",
     "shiki": "^0.1.6",
     "shiki-languages": "^0.1.6",
     "shiki-twoslash": "0.7.0",

--- a/packages/shiki-twoslash/package.json
+++ b/packages/shiki-twoslash/package.json
@@ -20,8 +20,8 @@
     "lint": "tsdx lint"
   },
   "dependencies": {
-    "@typescript/twoslash": "0.6.2",
-    "@typescript/vfs": "1.1.2",
+    "@typescript/twoslash": "1.0.0",
+    "@typescript/vfs": "1.2.0",
     "shiki": "^0.1.6",
     "shiki-languages": "^0.1.6",
     "typescript": "*"

--- a/packages/ts-twoslasher/CHANGELOG.md
+++ b/packages/ts-twoslasher/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0
+
+- Supports falling back to _your project's_ node modules for resolving types and imports. This drastically simplifies setting up a code sample which relies on types not shipped with TypeScript.
+- Support for adding vfs JSON files in a code sample
+
 ## 0.5.0
 
 - Support TS 4.0

--- a/packages/ts-twoslasher/package.json
+++ b/packages/ts-twoslasher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript/twoslash",
-  "version": "0.6.2",
+  "version": "1.0.0",
   "license": "MIT",
   "author": "TypeScript team",
   "main": "dist/index.js",
@@ -39,7 +39,7 @@
     "lz-string": false
   },
   "dependencies": {
-    "@typescript/vfs": "1.1.2",
+    "@typescript/vfs": "1.2.0",
     "debug": "^4.1.1",
     "lz-string": "^1.4.4"
   }

--- a/packages/ts-twoslasher/src/index.ts
+++ b/packages/ts-twoslasher/src/index.ts
@@ -621,16 +621,16 @@ export function twoslasher(code: string, extension: string, options: TwoSlashOpt
 
     if (!emitSource) {
       const allFiles = filenames.join(", ")
-      throw new Error(
-        `Cannot find the corresponding source file for ${emitFilename} (looking for: ${emitSourceFilename} in the vfs) - in ${allFiles}`
-      )
+      // prettier-ignore
+      throw new Error(`Cannot find the corresponding source file for ${emitFilename} (looking for: ${emitSourceFilename} in the vfs) - in ${allFiles}`)
     }
 
     const output = ls.getEmitOutput(emitSource)
     const file = output.outputFiles.find(o => o.name === fsRoot + handbookOptions.showEmittedFile)
     if (!file) {
       const allFiles = output.outputFiles.map(o => o.name).join(", ")
-      throw new Error(`Cannot find the file ${handbookOptions.showEmittedFile} - in ${allFiles}`)
+      // prettier-ignore
+      throw new Error(`Cannot find the file ${handbookOptions.showEmittedFile} (looking for: ${fsRoot + handbookOptions.showEmittedFile} in the vfs) - in ${allFiles}`)
     }
 
     code = file.text

--- a/packages/ts-twoslasher/src/index.ts
+++ b/packages/ts-twoslasher/src/index.ts
@@ -383,11 +383,15 @@ export function twoslasher(code: string, extension: string, options: TwoSlashOpt
   const handbookOptions = { ...filterHandbookOptions(codeLines), ...options.defaultOptions }
   const compilerOptions = filterCompilerOptions(codeLines, defaultCompilerOptions, ts)
 
+  const getRoot = () => {
+    const path = require("path")
+    return process.cwd().split(path.sep).join(path.posix.sep)
+  }
   // In a browser we want to DI everything, in node we can use local infra
   const useFS = !!options.fsMap
   const vfs = useFS && options.fsMap ? options.fsMap : new Map<string, string>()
-  const system = useFS ? createSystem(vfs) : createFSBackedSystem(vfs, process.cwd(), ts)
-  const fsRoot = useFS ? "/" : process.cwd() + "/"
+  const system = useFS ? createSystem(vfs) : createFSBackedSystem(vfs, getRoot(), ts)
+  const fsRoot = useFS ? "/" : getRoot() + "/"
 
   const env = createVirtualTypeScriptEnvironment(system, [], ts, compilerOptions, options.customTransformers)
   const ls = env.languageService

--- a/packages/ts-twoslasher/test/fixtures.test.ts
+++ b/packages/ts-twoslasher/test/fixtures.test.ts
@@ -1,34 +1,34 @@
-import { readdirSync, readFileSync, lstatSync } from 'fs'
-import { join, extname, parse } from 'path'
-import { toMatchFile } from 'jest-file-snapshot'
-import { twoslasher } from '../src/index'
-import { format } from 'prettier'
+import { readdirSync, readFileSync, lstatSync } from "fs"
+import { join, extname, parse } from "path"
+import { toMatchFile } from "jest-file-snapshot"
+import { twoslasher } from "../src/index"
+import { format } from "prettier"
 
 expect.extend({ toMatchFile })
 
 // To add a test, create a file in the fixtures folder and it will will run through
 // as though it was the codeblock.
 
-describe('with fixtures', () => {
+describe("with fixtures", () => {
   // Add all codefixes
-  const fixturesFolder = join(__dirname, 'fixtures')
-  const resultsFolder = join(__dirname, 'results')
+  const fixturesFolder = join(__dirname, "fixtures")
+  const resultsFolder = join(__dirname, "results")
 
-  readdirSync(join(fixturesFolder, 'tests')).forEach(fixtureName => {
-    const fixture = join(fixturesFolder, 'tests', fixtureName)
+  readdirSync(join(fixturesFolder, "tests")).forEach(fixtureName => {
+    const fixture = join(fixturesFolder, "tests", fixtureName)
     if (lstatSync(fixture).isDirectory()) {
       return
     }
 
-    // if(!fixtureName.includes("compiler_fl")) return
-    it('Hidden Fixtures: ' + fixtureName, () => {
-      const resultName = parse(fixtureName).name + '.json'
-      const result = join(resultsFolder, 'tests', resultName)
+    // if(!fixtureName.includes("imports")) return
+    it("Hidden Fixtures: " + fixtureName, () => {
+      const resultName = parse(fixtureName).name + ".json"
+      const result = join(resultsFolder, "tests", resultName)
 
-      const file = readFileSync(fixture, 'utf8')
+      const file = readFileSync(fixture, "utf8")
 
       const fourslashed = twoslasher(file, extname(fixtureName).substr(1))
-      const jsonString = format(JSON.stringify(fourslashed), { parser: 'json' })
+      const jsonString = format(JSON.stringify(fourslashed), { parser: "json" })
       expect(jsonString).toMatchFile(result)
     })
   })
@@ -40,38 +40,38 @@ describe('with fixtures', () => {
     }
 
     // if(!fixtureName.includes("compiler_fl")) return
-    it('README Fixtures: ' + fixtureName, () => {
-      const resultName = parse(fixtureName).name + '.json'
+    it("README Fixtures: " + fixtureName, () => {
+      const resultName = parse(fixtureName).name + ".json"
       const result = join(resultsFolder, resultName)
 
-      const file = readFileSync(fixture, 'utf8')
+      const file = readFileSync(fixture, "utf8")
 
       const fourslashed = twoslasher(file, extname(fixtureName).substr(1))
-      const jsonString = format(JSON.stringify(fourslashed), { parser: 'json' })
+      const jsonString = format(JSON.stringify(fourslashed), { parser: "json" })
       expect(jsonString).toMatchFile(result)
     })
   })
 
-  readdirSync(join(fixturesFolder, 'tests')).forEach(fixtureName => {
-    const fixture = join(fixturesFolder, 'tests', fixtureName)
+  readdirSync(join(fixturesFolder, "tests")).forEach(fixtureName => {
+    const fixture = join(fixturesFolder, "tests", fixtureName)
     if (lstatSync(fixture).isDirectory()) {
       return
     }
 
     // if(!fixtureName.includes("compiler_fl")) return
-    it('Hidden Fixtures: ' + fixtureName, () => {
-      const resultName = parse(fixtureName).name + '.json'
-      const result = join(resultsFolder, 'tests', resultName)
+    it("Hidden Fixtures: " + fixtureName, () => {
+      const resultName = parse(fixtureName).name + ".json"
+      const result = join(resultsFolder, "tests", resultName)
 
-      const file = readFileSync(fixture, 'utf8')
+      const file = readFileSync(fixture, "utf8")
 
       const fourslashed = twoslasher(file, extname(fixtureName).substr(1))
-      const jsonString = format(JSON.stringify(fourslashed), { parser: 'json' })
+      const jsonString = format(JSON.stringify(fourslashed), { parser: "json" })
       expect(jsonString).toMatchFile(result)
     })
   })
 
-  const throwingFixturesFolder = join(__dirname, 'fixtures', 'throws')
+  const throwingFixturesFolder = join(__dirname, "fixtures", "throws")
 
   readdirSync(throwingFixturesFolder).forEach(fixtureName => {
     const fixture = join(throwingFixturesFolder, fixtureName)
@@ -79,11 +79,11 @@ describe('with fixtures', () => {
       return
     }
 
-    it('Throwing Fixture: ' + fixtureName, () => {
-      const resultName = parse(fixtureName).name + '.json'
+    it("Throwing Fixture: " + fixtureName, () => {
+      const resultName = parse(fixtureName).name + ".json"
       const result = join(resultsFolder, resultName)
 
-      const file = readFileSync(fixture, 'utf8')
+      const file = readFileSync(fixture, "utf8")
 
       let thrown = false
       try {
@@ -93,7 +93,7 @@ describe('with fixtures', () => {
         expect(err.message).toMatchFile(result)
       }
 
-      if (!thrown) throw new Error('Did not throw')
+      if (!thrown) throw new Error("Did not throw")
     })
   })
 })

--- a/packages/ts-twoslasher/test/fixtures/importsModules.ts
+++ b/packages/ts-twoslasher/test/fixtures/importsModules.ts
@@ -1,0 +1,14 @@
+// @filename: Component.tsx
+import React from "react"
+
+export function Hello() {
+  return (
+    <div>
+      <h1>Hello World</h1>
+    </div>
+  )
+}
+
+// @filename: index.ts
+import { Hello } from "./Component"
+console.log(Hello)

--- a/packages/ts-twoslasher/test/fixtures/tests/handlesJSON.ts
+++ b/packages/ts-twoslasher/test/fixtures/tests/handlesJSON.ts
@@ -1,0 +1,6 @@
+// @moduleResolution: node
+// @filename: package.json
+{ "name": "thing" }
+// @filename: index.ts
+// ---cut---
+const i = 123

--- a/packages/ts-twoslasher/test/results/importsModules.json
+++ b/packages/ts-twoslasher/test/results/importsModules.json
@@ -1,0 +1,100 @@
+{
+  "code": "// @filename: Component.tsx\nimport React from \"react\"\n\nexport function Hello() {\n  return (\n    <div>\n      <h1>Hello World</h1>\n    </div>\n  )\n}\n\n// @filename: index.ts\nimport { Hello } from \"./Component\"\nconsole.log(Hello)\n",
+  "extension": "ts",
+  "highlights": [],
+  "queries": [],
+  "staticQuickInfos": [
+    {
+      "text": "(alias) namespace React\nimport React",
+      "docs": "",
+      "start": 35,
+      "length": 5,
+      "line": 1,
+      "character": 7,
+      "targetString": "React"
+    },
+    {
+      "text": "function Hello(): JSX.Element",
+      "docs": "",
+      "start": 71,
+      "length": 5,
+      "line": 3,
+      "character": 16,
+      "targetString": "Hello"
+    },
+    {
+      "text": "(property) JSX.IntrinsicElements.div: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>",
+      "docs": "",
+      "start": 97,
+      "length": 3,
+      "line": 5,
+      "character": 5,
+      "targetString": "div"
+    },
+    {
+      "text": "(property) JSX.IntrinsicElements.h1: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>",
+      "docs": "",
+      "start": 109,
+      "length": 2,
+      "line": 6,
+      "character": 7,
+      "targetString": "h1"
+    },
+    {
+      "text": "(property) JSX.IntrinsicElements.h1: React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>",
+      "docs": "",
+      "start": 125,
+      "length": 2,
+      "line": 6,
+      "character": 23,
+      "targetString": "h1"
+    },
+    {
+      "text": "(property) JSX.IntrinsicElements.div: React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>",
+      "docs": "",
+      "start": 135,
+      "length": 3,
+      "line": 7,
+      "character": 6,
+      "targetString": "div"
+    },
+    {
+      "text": "(alias) function Hello(): JSX.Element\nimport Hello",
+      "docs": "",
+      "start": 179,
+      "length": 5,
+      "line": 12,
+      "character": 9,
+      "targetString": "Hello"
+    },
+    {
+      "text": "var console: Console",
+      "docs": "",
+      "start": 206,
+      "length": 7,
+      "line": 13,
+      "character": 0,
+      "targetString": "console"
+    },
+    {
+      "text": "(method) Console.log(...data: any[]): void",
+      "docs": "",
+      "start": 214,
+      "length": 3,
+      "line": 13,
+      "character": 8,
+      "targetString": "log"
+    },
+    {
+      "text": "(alias) function Hello(): JSX.Element\nimport Hello",
+      "docs": "",
+      "start": 218,
+      "length": 5,
+      "line": 13,
+      "character": 12,
+      "targetString": "Hello"
+    }
+  ],
+  "errors": [],
+  "playgroundURL": "https://www.typescriptlang.org/play/#code/PTAEAEDMEsBsFMB2BDAtvAXKAwge1QA66JIAuAdKQM4AeAUNIbgE6mgBK8yAxm5M-lAAiZl15C6deDSKtQkAK6Je0YqAAS8WLFwAKAJSgA3nVChRpBc0Shdps6AA8AE2gA3AHz2HTgBYBGD01tXFAAdRZYZ0dgAK8fGNdPe306AF9JEAgYBBR0LGhEZ2lKKgYmOSMNLR1QNPkBVGFyYDwmEkRSCW5iKlwEch0Ac11gnVSgA"
+}

--- a/packages/ts-twoslasher/test/results/tests/handlesJSON.json
+++ b/packages/ts-twoslasher/test/results/tests/handlesJSON.json
@@ -1,0 +1,19 @@
+{
+  "code": "const i = 123\n",
+  "extension": "ts",
+  "highlights": [],
+  "queries": [],
+  "staticQuickInfos": [
+    {
+      "text": "const i: 123",
+      "docs": "",
+      "start": 6,
+      "length": 1,
+      "line": 0,
+      "character": 6,
+      "targetString": "i"
+    }
+  ],
+  "errors": [],
+  "playgroundURL": "https://www.typescriptlang.org/play/#code/PTAEAEFsHsBMFcA2BTASsgztR8AuBLaAOwC5Qi5kAoECAM3xSIENJkyAHZgYwGtmA5sgB0AKyxEqAb1AAiFm1llZuABb4iA2aAC+NMOAZNW7UBtjIAHsNwZ9oALRPueJw6rdiGXGdABeUABGACYAZiogA"
+}

--- a/packages/typescript-vfs/CHANGELOG.md
+++ b/packages/typescript-vfs/CHANGELOG.md
@@ -1,0 +1,7 @@
+### 1.2
+
+Updates `createFSBackedSystem` to rely more on the default TypeScript system object which should see twoslash code samples re-using the node_modules from the local project.
+
+### 0.0 - 1.0 - 1.1
+
+Created the lib, got it working

--- a/packages/typescript-vfs/package.json
+++ b/packages/typescript-vfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript/vfs",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "license": "MIT",
   "author": "TypeScript team",
   "homepage": "https://github.com/microsoft/TypeScript-Website/",

--- a/packages/typescript-vfs/test/fsbacked.test.ts
+++ b/packages/typescript-vfs/test/fsbacked.test.ts
@@ -1,0 +1,59 @@
+import { createFSBackedSystem, createVirtualTypeScriptEnvironment } from "../src"
+
+import path from "path"
+import ts from "typescript"
+
+it("can use a FS backed system ", () => {
+  const compilerOpts: ts.CompilerOptions = { target: ts.ScriptTarget.ES2016, esModuleInterop: true }
+  const fsMap = new Map<string, string>()
+
+  const content = `/// <reference types="node" />\nimport * as path from 'path';\npath.`
+  fsMap.set("index.ts", content)
+
+  const monorepoRoot = path.join(__dirname, "..", "..", "..")
+  const system = createFSBackedSystem(fsMap, monorepoRoot, ts)
+  const env = createVirtualTypeScriptEnvironment(system, ["index.ts"], ts, compilerOpts)
+
+  const completions = env.languageService.getCompletionsAtPosition("index.ts", content.length, {})
+  const hasPathJoinFunc = completions?.entries.find(c => c.name === "join")
+  expect(hasPathJoinFunc).toBeTruthy()
+})
+
+it("can use a FS backed system to extract node modules", () => {
+  const compilerOpts: ts.CompilerOptions = { target: ts.ScriptTarget.ES2016, esModuleInterop: true }
+  const fsMap = new Map<string, string>()
+
+  const content = `import React from "react"\nReact.Compone`
+  fsMap.set("index.ts", content)
+
+  const monorepoRoot = path.join(__dirname, "..", "..", "..")
+  const system = createFSBackedSystem(fsMap, monorepoRoot, ts)
+  const env = createVirtualTypeScriptEnvironment(system, ["index.ts"], ts, compilerOpts)
+
+  const completions = env.languageService.getCompletionsAtPosition("index.ts", content.length, {})
+
+  const hasReactComponentInCompletions = completions?.entries.find(c => c.name === "Component")
+  expect(hasReactComponentInCompletions).toBeTruthy()
+})
+
+it("can import files in the virtual fs", () => {
+  const compilerOpts: ts.CompilerOptions = { target: ts.ScriptTarget.ES2016, esModuleInterop: true }
+  const fsMap = new Map<string, string>()
+
+  const monorepoRoot = path.join(__dirname, "..", "..", "..")
+  const fakeFolder = path.join(monorepoRoot, "fake")
+  const exporter = path.join(fakeFolder, "file-with-export.ts")
+  const index = path.join(fakeFolder, "index.ts")
+
+  fsMap.set(exporter, `export const helloWorld = "Example string";`)
+  fsMap.set(index, `import {helloWorld} from "./file-with-export"; console.log(helloWorld)`)
+
+  const system = createFSBackedSystem(fsMap, monorepoRoot, ts)
+  const env = createVirtualTypeScriptEnvironment(system, [index, exporter], ts, compilerOpts)
+
+  const errs: import("typescript").Diagnostic[] = []
+  errs.push(...env.languageService.getSemanticDiagnostics(index))
+  errs.push(...env.languageService.getSyntacticDiagnostics(index))
+
+  expect(errs.map(e => e.messageText)).toEqual([])
+})

--- a/packages/typescript-vfs/test/index.test.ts
+++ b/packages/typescript-vfs/test/index.test.ts
@@ -1,13 +1,11 @@
 import {
   createSystem,
-  createFSBackedSystem,
   createVirtualTypeScriptEnvironment,
   createDefaultMapFromNodeModules,
   createDefaultMapFromCDN,
   knownLibFilesForCompilerOptions,
 } from "../src"
 
-import path from "path"
 import ts from "typescript"
 
 it("runs a virtual environment and gets the right results from the LSP", () => {
@@ -41,22 +39,6 @@ it("runs a virtual environment and gets the right results from the LSP", () => {
       },
     ]
   `)
-})
-
-it("can use a FS backed system", () => {
-  const compilerOpts: ts.CompilerOptions = { target: ts.ScriptTarget.ES2016, esModuleInterop: true }
-  const fsMap = new Map<string, string>()
-
-  const content = `/// <reference types="node" />\nimport * as path from 'path';\npath.`
-  fsMap.set("index.ts", content)
-
-  const monorepoRoot = path.join(__dirname, "..", "..", "..")
-  const system = createFSBackedSystem(fsMap, monorepoRoot)
-  const env = createVirtualTypeScriptEnvironment(system, ["index.ts"], ts, compilerOpts)
-
-  const completions = env.languageService.getCompletionsAtPosition("index.ts", content.length, {})
-  const hasPathJoinFunc = completions?.entries.find(c => c.name === "join")
-  expect(hasPathJoinFunc).toBeTruthy()
 })
 
 // Previously lib.dom.d.ts was not included

--- a/packages/typescriptlang-org/package.json
+++ b/packages/typescriptlang-org/package.json
@@ -25,7 +25,7 @@
     "@mdx-js/react": "^1.5.5",
     "@types/node-fetch": "^2.5.3",
     "@types/react-helmet": "^5.0.15",
-    "@typescript/twoslash": "0.6.2",
+    "@typescript/twoslash": "1.0.0",
     "canvas": "^2.6.1",
     "gatsby": "^2.19.18",
     "gatsby-plugin-catch-links": "^2.1.25",


### PR DESCRIPTION
Wraps up my final 1.0 blocker #962 which means I you can make a code sample like:

````
```ts twoslash
// @filename: Component.tsx
import React from "react"

export function Hello() {
  return (
    <div>
      <h1>Hello World</h1>
    </div>
  )
}

// @filename: index.ts
import { Hello } from "./Component"
console.log(Hello)
```
````

Without a bunch of faff.

Basically the underlaying vfs will first look for virtual files then it will think that you have a subfolder in your repo's root with this source code. It will then correctly look up through your repo's node_modules for the right types via the normal TS routing.