### PR TITLE
Add declare keyword in module.d.ts.md, fixes #966

### DIFF
--- a/packages/documentation/copy/en/declaration-files/templates/module.d.ts.md
+++ b/packages/documentation/copy/en/declaration-files/templates/module.d.ts.md
@@ -58,7 +58,7 @@ module.exports = /hello( world)?/;
 Which can be described by the following .d.ts:
 
 ```ts
-const helloWorld: RegExp;
+declare const helloWorld: RegExp;
 export default helloWorld;
 ```
 
@@ -69,7 +69,7 @@ module.exports = 3.142;
 ```
 
 ```ts
-const pi: number;
+declare const pi: number;
 export default pi;
 ```
 


### PR DESCRIPTION
Without the `declare` keyword in these code blocks, the TS compiler throws the following error: `Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.` Fixes #966.