### PR TITLE
fix: skipLibCheck should be recommended in the reference

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -34,6 +34,7 @@ export const recommended: CompilerOptionName[] = [
   "noImplicitThis",
   "noImplicitAny",
   "esModuleInterop",
+  "skipLibCheck",
 ];
 
 type RootProperties = "files" | "extends" | "include" | "exclude";


### PR DESCRIPTION
## Description

- it was [added as a default for `tsc --init`](https://github.com/microsoft/TypeScript/pull/37808) a few months ago and
  recently [added to the `@tsconfig/recommended` base](https://github.com/tsconfig/bases/blob/4c3e845b83b8485ffbad371540598cbf0bfa5890/bases/recommended.json#L7) as well

## Tags

Found this in https://github.com/formium/tsdx/issues/529#issuecomment-679746098 while exploring the docs to see updates on its recommended status