### PR TITLE
fix: ensure strict checks are all recommended and related to

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -28,9 +28,11 @@ export const internal: CompilerOptionName[] = ["preserveWatchOutput", "stripInte
 export const recommended: CompilerOptionName[] = [
   "strict",
   "forceConsistentCasingInFileNames",
+  "alwaysStrict",
   "strictNullChecks",
   "strictBindCallApply",
   "strictFunctionTypes",
+  "strictPropertyInitialization",
   "noImplicitThis",
   "noImplicitAny",
   "esModuleInterop",
@@ -43,7 +45,7 @@ type AnOption = WatchProperties | RootProperties | CompilerOptionName;
 
 /** Allows linking between options */
 export const relatedTo: [AnOption, AnOption[]][] = [
-  ["strict", ["strictBindCallApply", "strictFunctionTypes", "strictPropertyInitialization"]],
+  ["strict", ["alwaysStrict", "strictNullChecks", "strictBindCallApply", "strictFunctionTypes", "strictPropertyInitialization", "noImplicitAny", "noImplicitThis"]],
   ["allowSyntheticDefaultImports", ["esModuleInterop"]],
   ["esModuleInterop", ["allowSyntheticDefaultImports"]],
 


### PR DESCRIPTION
## Description

- strictPropertyInitialization and alwaysStrict were missing from
  recommended even though the other Strict Checks were in there and all
  of them are enabled if strict is enabled

- alwaysStrict, strictNullChecks, noImplicitAny, and noImplicitThis were
  missing from strict's relatedTo even though all are enabled if strict
  is enabled

## Tags

Found while working on #970.
Related to another PR I had on the topic of Strict Checks, #500 

## Review Notes

They're all listed as "recommended", but `strict` enables all of them and is the only one turned on [in `@tsconfig/recommend`](https://github.com/tsconfig/bases/blob/4c3e845b83b8485ffbad371540598cbf0bfa5890/bases/recommended.json#L5) and by `tsc --init`, so maybe all of them should be removed from "recommended" except for `strict` instead? Thoughts?