### PR TITLE
docs(tsconfig-reference): translate in folder sections

### DIFF
--- a/packages/tsconfig-reference/copy/id/sections/compilerOptions.md
+++ b/packages/tsconfig-reference/copy/id/sections/compilerOptions.md
@@ -1,0 +1,3 @@
+### Pilihan - Pilihan Compiler
+
+Banyak pilihan yang membuat jumlah besar di pengaturan Typescript's dan itu juga meliputi bagaimana bahasa seharusnya bekerja.

--- a/packages/tsconfig-reference/copy/id/sections/compilerOptions.md
+++ b/packages/tsconfig-reference/copy/id/sections/compilerOptions.md
@@ -1,3 +1,3 @@
-### Pilihan - Pilihan Compiler
+### Pilihan - Pilihan Kompiler
 
 Banyak pilihan yang membuat jumlah besar di pengaturan Typescript's dan itu juga meliputi bagaimana bahasa seharusnya bekerja.

--- a/packages/tsconfig-reference/copy/id/sections/top_level.md
+++ b/packages/tsconfig-reference/copy/id/sections/top_level.md
@@ -1,0 +1,3 @@
+### Sumber Bidang
+
+Memulai dari pilihan di dalam sumber TSConfig - banyak pilihan bagaimana berhubungan dengan projek Typescript atau Javascript yang kamu buat.


### PR DESCRIPTION
## Overview

This is part of [#938](https://github.com/microsoft/TypeScript-Website/issues/938)

## Changes

Translate for files:

- [x] compilerOptions.md
- [x] top_level.md
- [x] watchOptions.md 