### PR TITLE
Adds global versions of the @ts/* deps

### DIFF
--- a/.github/workflows/codeowners-merge.yml
+++ b/.github/workflows/codeowners-merge.yml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
       - name: Run Codeowners merge check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/gatsby-remark-shiki-twoslash/package.json
+++ b/packages/gatsby-remark-shiki-twoslash/package.json
@@ -19,8 +19,8 @@
     "lint": "tsdx lint"
   },
   "dependencies": {
-    "@typescript/twoslash": "1.0.2",
-    "@typescript/vfs": "1.2.0",
+    "@typescript/twoslash": "1.1.0",
+    "@typescript/vfs": "1.3.0",
     "shiki": "^0.1.6",
     "shiki-languages": "^0.1.6",
     "shiki-twoslash": "0.8.0",

--- a/packages/shiki-twoslash/package.json
+++ b/packages/shiki-twoslash/package.json
@@ -20,8 +20,8 @@
     "lint": "tsdx lint"
   },
   "dependencies": {
-    "@typescript/twoslash": "1.0.2",
-    "@typescript/vfs": "1.2.0",
+    "@typescript/twoslash": "1.1.0",
+    "@typescript/vfs": "1.3.0",
     "shiki": "^0.1.6",
     "shiki-languages": "^0.1.6",
     "typescript": "*"

--- a/packages/ts-twoslasher/CHANGELOG.md
+++ b/packages/ts-twoslasher/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.1.0
+
+- Adds a JS file into the npm tarball for using with a vanilla script tag, which sets `global.twoslash` with the main twoslash function. You need to include a copy of tsvfs beforehand.
+
+Unpkg URLS:
+
+- https://unpkg.com/browse/@typescript/vfs@dist/vfs.globals.js
+- https://unpkg.com/browse/@typescript/twoslash@dist/twoslash.globals.js
+
 ## 1.0.2
 
 - The `// @x`, `// ^?` and `// ^^^` comments ignore preceding whitespace

--- a/packages/ts-twoslasher/README.md
+++ b/packages/ts-twoslasher/README.md
@@ -846,6 +846,10 @@ export interface TwoSlashReturn {
 
 <!-- AUTO-GENERATED-CONTENT:END -->
 
+## Using this Dependency
+
+This package can be used as a commonjs import, an esmodule and directly via a script tag which edits the global namespace. All of these files are embedded inside the released packages.
+
 ## Local Development
 
 Below is a list of commands you will probably find useful. You can get debug logs by running with the env var of `DEBUG="*"`.

--- a/packages/ts-twoslasher/package.json
+++ b/packages/ts-twoslasher/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "start": "tsdx watch",
-    "build": "tsdx build && yarn readme && make-global",
+    "build": "tsdx build && yarn readme && yarn make-global",
     "make-global": "node scripts/makeGlobals.js",
     "readme": "yarn md-magic README.md --config ./scripts/inline-results.js && yarn prettier README.md --write",
     "test": "tsdx test",

--- a/packages/ts-twoslasher/package.json
+++ b/packages/ts-twoslasher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript/twoslash",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "license": "MIT",
   "author": "TypeScript team",
   "main": "dist/index.js",
@@ -11,7 +11,8 @@
   ],
   "scripts": {
     "start": "tsdx watch",
-    "build": "tsdx build && yarn readme",
+    "build": "tsdx build && yarn readme && make-global",
+    "make-global": "node scripts/makeGlobals.js",
     "readme": "yarn md-magic README.md --config ./scripts/inline-results.js && yarn prettier README.md --write",
     "test": "tsdx test",
     "lint": "tsdx lint"

--- a/packages/ts-twoslasher/package.json
+++ b/packages/ts-twoslasher/package.json
@@ -40,7 +40,7 @@
     "lz-string": false
   },
   "dependencies": {
-    "@typescript/vfs": "1.2.0",
+    "@typescript/vfs": "1.3.0",
     "debug": "^4.1.1",
     "lz-string": "^1.4.4"
   }

--- a/packages/ts-twoslasher/scripts/makeGlobals.js
+++ b/packages/ts-twoslasher/scripts/makeGlobals.js
@@ -1,0 +1,29 @@
+// @ts-check
+
+// Creates a web version of tstwoslash which sets a global of 'tstwoslash'.
+// Relies on tsvfs already existing
+
+const fs = require("fs")
+const path = require("path")
+
+const esm = fs.readFileSync(path.join(__dirname, "..", "dist", "twoslash.esm.js"), "utf8")
+const body = esm
+  .replace("import {", "const {")
+  .replace("} from '@typescript/vfs';", "} = globals.tsvfs")
+  .replace("export {", "const twoslash = {")
+const prefix = `
+const getGlobal = function () { 
+  if (typeof self !== 'undefined') { return self; } 
+  if (typeof window !== 'undefined') { return window; } 
+  if (typeof global !== 'undefined') { return global; } 
+  throw new Error('unable to locate global object'); 
+}; 
+
+const globals = getGlobal();
+if (typeof globals.tsvfs === 'undefined') throw new Error("Could not find tsvfs on the global object")
+`
+
+const suffix = `
+globals.twoslash = twoslash`
+
+fs.writeFileSync(path.join(__dirname, "..", "dist", "twoslash.globals.js"), prefix + body + suffix, "utf8")

--- a/packages/typescript-vfs/CHANGELOG.md
+++ b/packages/typescript-vfs/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 1.3
+
+- Adds a JS file into the npm tarball for using with a vanilla script tag, which sets `global.tsvfs` with exported function.
+
+Unpkg URLS:
+
+- https://unpkg.com/browse/@typescript/vfs@dist/vfs.globals.js
+
 ### 1.2
 
 Updates `createFSBackedSystem` to rely more on the default TypeScript system object which should see twoslash code samples re-using the node_modules from the local project.

--- a/packages/typescript-vfs/README.md
+++ b/packages/typescript-vfs/README.md
@@ -231,3 +231,7 @@ program.emit()
 // Now I can look at the AST for the .ts file too
 const index = program.getSourceFile("index.ts")
 ```
+
+## Using this Dependency
+
+This package can be used as a commonjs import, an esmodule and directly via a script tag which edits the global namespace. All of these files are embedded inside the released packages.

--- a/packages/typescript-vfs/package.json
+++ b/packages/typescript-vfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript/vfs",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": "MIT",
   "author": "TypeScript team",
   "homepage": "https://github.com/microsoft/TypeScript-Website/",
@@ -12,7 +12,9 @@
   ],
   "scripts": {
     "start": "tsdx watch",
-    "build": "tsdx build && cpy src/index.ts ../sandbox/src/vendor --rename=typescript-vfs.ts",
+    "build": "tsdx build && yarn make-for-website && yarn make-global",
+    "make-for-website": "cpy src/index.ts ../sandbox/src/vendor --rename=typescript-vfs.ts",
+    "make-global": "node scripts/makeGlobals.js",
     "test": "tsdx test",
     "lint": "tsdx lint"
   },

--- a/packages/typescript-vfs/scripts/makeGlobals.js
+++ b/packages/typescript-vfs/scripts/makeGlobals.js
@@ -1,0 +1,22 @@
+// @ts-check
+
+// Creates a web version of tsvfs which sets a global of 'tsvfs'.
+
+const fs = require("fs")
+const path = require("path")
+
+const esm = fs.readFileSync(path.join(__dirname, "..", "dist", "vfs.esm.js"), "utf8")
+const body = esm.replace("export {", "const tsvfs = {")
+const suffix = `
+const getGlobal = function () { 
+  if (typeof self !== 'undefined') { return self; } 
+  if (typeof window !== 'undefined') { return window; } 
+  if (typeof global !== 'undefined') { return global; } 
+  throw new Error('unable to locate global object'); 
+}; 
+
+const globals = getGlobal(); 
+globals.tsvfs = tsvfs;
+`
+
+fs.writeFileSync(path.join(__dirname, "..", "dist", "vfs.globals.js"), body + suffix, "utf8")

--- a/packages/typescriptlang-org/package.json
+++ b/packages/typescriptlang-org/package.json
@@ -25,7 +25,7 @@
     "@mdx-js/react": "^1.5.5",
     "@types/node-fetch": "^2.5.3",
     "@types/react-helmet": "^5.0.15",
-    "@typescript/twoslash": "1.0.2",
+    "@typescript/twoslash": "1.1.0",
     "canvas": "^2.6.1",
     "gatsby": "^2.19.18",
     "gatsby-plugin-catch-links": "^2.1.25",


### PR DESCRIPTION
https://github.com/microsoft/monaco-typescript/pull/65 could do with a non-trivial example, and I'd like to use tsvfs there - this makes a version of the dependencies which sets a key on the global object like the libraries of old.