### PR TITLE
Fix typo

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -165,7 +165,7 @@ export const defaultsForOptions = {
   strictNullChecks: "`false`, unless `strict` is set",
   suppressExcessPropertyErrors: "false",
   suppressImplicitAnyIndexErrors: "false",
-  target: "es5",
+  target: "ES3",
   traceResolution: "false",
   tsBuildInfoFile: ".tsbuildinfo",
   useDefineForClassFields: "false",


### PR DESCRIPTION
I've tested on tsc Version 3.9.7 and I can confirm that, the default is ES3 not ES5, because getter syntax is not supporter by default. And I have to set target to ES5 to support getter syntax. This also matches the document at https://www.typescriptlang.org/tsconfig#target where it says that ES3 is the default in the Allowed section.