### PR TITLE
Modify the number of built-in types from 7 to 8

### DIFF
--- a/packages/documentation/copy/en/get-started/TS for Functional Programmers.md
+++ b/packages/documentation/copy/en/get-started/TS for Functional Programmers.md
@@ -44,7 +44,7 @@ TypeScript uses postfix types, like so: `x: string` instead of `string x`.
 
 ## Built-in types
 
-JavaScript defines 7 built-in types:
+JavaScript defines 8 built-in types:
 
 | Type        | Explanation                                 |
 | ----------- | ------------------------------------------- |


### PR DESCRIPTION
With the addition of the bigint type, the number of built-in types is now 8 not 7.