### PR TITLE
Remove text that's sensitive to chapter order

### DIFF
--- a/packages/documentation/copy/en/handbook-v1/Enums.md
+++ b/packages/documentation/copy/en/handbook-v1/Enums.md
@@ -199,7 +199,7 @@ let c: Circle = {
 ```
 
 The other change is that enum types themselves effectively become a _union_ of each enum member.
-While we haven't discussed [union types](./advanced-types.html#union-types) yet, all that you need to know is that with union enums, the type system is able to leverage the fact that it knows the exact set of values that exist in the enum itself.
+With union enums, the type system is able to leverage the fact that it knows the exact set of values that exist in the enum itself.
 Because of that, TypeScript can catch bugs where we might be comparing values incorrectly.
 For example:
 


### PR DESCRIPTION
From this screenshot, we can see that we've already discussed union types when we are discussing about Enums. The best way to make the text not to depend on the order of chapters.

![image](https://user-images.githubusercontent.com/3063067/91999414-eefd8900-ed6e-11ea-9a1b-91874eee46da.png)

