### PR TITLE
Makes twoslash annotations work in the playground, and improve the bug workbench

### DIFF
--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -169,6 +169,7 @@ export const createTypeScriptSandbox = (
   // Then update it when the model changes, perhaps this could be a debounced plugin instead in the future?
   editor.onDidChangeModelContent(() => {
     const code = editor.getModel()!.getValue()
+
     if (config.supportTwoslashCompilerOptions) {
       const configOpts = getTwoSlashComplierOptions(code)
       updateCompilerSettings(configOpts)
@@ -193,6 +194,15 @@ export const createTypeScriptSandbox = (
   let didUpdateCompilerSettings = (opts: CompilerOptions) => {}
 
   const updateCompilerSettings = (opts: CompilerOptions) => {
+    const newKeys = Object.keys(opts)
+    if (!newKeys.length) return
+
+    // Don't update a compiler setting if it's the same
+    // as the current setting
+    newKeys.forEach(key => {
+      if (compilerOptions[key] === opts[key]) delete opts[key]
+    })
+
     if (!Object.keys(opts).length) return
 
     config.logger.log("[Compiler] Updating compiler options: ", opts)

--- a/packages/sandbox/src/twoslashSupport.ts
+++ b/packages/sandbox/src/twoslashSupport.ts
@@ -3,9 +3,8 @@ const booleanConfigRegexp = /^\/\/\s?@(\w+)$/
 // https://regex101.com/r/8B2Wwh/1
 const valuedConfigRegexp = /^\/\/\s?@(\w+):\s?(.+)$/
 
-type Sandbox = ReturnType<typeof import('.').createTypeScriptSandbox>
-type TS = typeof import('typescript')
-type CompilerOptions = import('typescript').CompilerOptions
+type TS = typeof import("typescript")
+type CompilerOptions = import("typescript").CompilerOptions
 
 /**
  * This is a port of the twoslash bit which grabs compiler options
@@ -13,14 +12,14 @@ type CompilerOptions = import('typescript').CompilerOptions
  */
 
 export const extractTwoSlashComplierOptions = (ts: TS) => (code: string) => {
-  const codeLines = code.split('\n')
+  const codeLines = code.split("\n")
   const options = {} as any
 
-  codeLines.forEach((line) => {
+  codeLines.forEach(line => {
     let match
     if ((match = booleanConfigRegexp.exec(line))) {
       options[match[1]] = true
-      setOption(match[1], 'true', options, ts)
+      setOption(match[1], "true", options, ts)
     } else if ((match = valuedConfigRegexp.exec(line))) {
       setOption(match[1], match[2], options, ts)
     }
@@ -29,18 +28,29 @@ export const extractTwoSlashComplierOptions = (ts: TS) => (code: string) => {
 }
 
 function setOption(name: string, value: string, opts: CompilerOptions, ts: TS) {
+  const skipList = [
+    "noErrors",
+    "showEmit",
+    "showEmittedFile",
+    "noStaticSemanticInfo",
+    "emit",
+    "noErrorValidation",
+    "filename",
+  ]
+  if (skipList.includes(name)) return
+
   // @ts-ignore - optionDeclarations is not public API
   for (const opt of ts.optionDeclarations) {
     if (opt.name.toLowerCase() === name.toLowerCase()) {
       switch (opt.type) {
-        case 'number':
-        case 'string':
-        case 'boolean':
+        case "number":
+        case "string":
+        case "boolean":
           opts[opt.name] = parsePrimitive(value, opt.type)
           break
 
-        case 'list':
-          opts[opt.name] = value.split(',').map((v) => parsePrimitive(v, opt.element!.type as string))
+        case "list":
+          opts[opt.name] = value.split(",").map(v => parsePrimitive(v, opt.element!.type as string))
           break
 
         default:
@@ -48,7 +58,7 @@ function setOption(name: string, value: string, opts: CompilerOptions, ts: TS) {
 
           if (opts[opt.name] === undefined) {
             const keys = Array.from(opt.type.keys() as any)
-            throw new Error(`Invalid value ${value} for ${opt.name}. Allowed values: ${keys.join(',')}`)
+            console.log(`Invalid value ${value} for ${opt.name}. Allowed values: ${keys.join(",")}`)
           }
           break
       }
@@ -57,19 +67,19 @@ function setOption(name: string, value: string, opts: CompilerOptions, ts: TS) {
   }
 
   // Skip the note of errors
-  if (name !== 'errors') {
-    throw new Error(`No compiler setting named '${name}' exists!`)
+  if (name !== "errors") {
+    console.log(`No compiler setting named '${name}' exists!`)
   }
 }
 
 export function parsePrimitive(value: string, type: string): any {
   switch (type) {
-    case 'number':
+    case "number":
       return +value
-    case 'string':
+    case "string":
       return value
-    case 'boolean':
-      return value.toLowerCase() === 'true' || value.length === 0
+    case "boolean":
+      return value.toLowerCase() === "true" || value.length === 0
   }
   console.log(`Unknown primitive type ${type} with - ${value}`)
 }

--- a/packages/typescriptlang-org/src/pages/dev/bug-workbench.tsx
+++ b/packages/typescriptlang-org/src/pages/dev/bug-workbench.tsx
@@ -88,7 +88,8 @@ const Play: React.FC<Props> = (props) => {
           compilerOptions: {},
           domID: "monaco-editor-embed",
           useJavaScript: !!params.get("useJavaScript"),
-          acquireTypes: !localStorage.getItem("disable-ata")
+          acquireTypes: !localStorage.getItem("disable-ata"),
+          supportTwoslashCompilerOptions: true
         }, main, ts)
 
         const playgroundConfig = {
@@ -121,6 +122,13 @@ const Play: React.FC<Props> = (props) => {
 
         const debouncedTwoslash = debounce(() => {
           if (dtsMap) runTwoslash()
+
+          const isTSErrorsEnabled = !sandboxEnv.languageServiceDefaults.getDiagnosticsOptions().noSemanticValidation
+          const shouldBeEnabled = !sandboxEnv.getText().includes("// @filename")
+          if (isTSErrorsEnabled !== shouldBeEnabled) {
+            // Turn off the suggestions for multi-file reports
+            sandboxEnv.languageServiceDefaults.setDiagnosticsOptions({ noSemanticValidation: !shouldBeEnabled })
+          }
         }, 1000)
 
         sandboxEnv.editor.onDidChangeModelContent(debouncedTwoslash)

--- a/packages/typescriptlang-org/src/templates/play.tsx
+++ b/packages/typescriptlang-org/src/templates/play.tsx
@@ -126,7 +126,8 @@ const Play: React.FC<Props> = (props) => {
           compilerOptions: {},
           domID: "monaco-editor-embed",
           useJavaScript: !!params.get("useJavaScript"),
-          acquireTypes: !localStorage.getItem("disable-ata")
+          acquireTypes: !localStorage.getItem("disable-ata"),
+          supportTwoslashCompilerOptions: true
         }, main, ts)
 
         const playgroundConfig = {


### PR DESCRIPTION
Lots of folks wanting to try some advance stuff with WIP PRs, this allows it to work https://github.com/microsoft/TypeScript/pull/39560#issuecomment-686368195

This improves the speed and accuracy of real-time twoslash annotations, and allows them to be used in the playground 
![Screen Shot 2020-09-03 at 11 07 09 AM](https://user-images.githubusercontent.com/49038/92132653-69f98a80-edd5-11ea-8455-3386f716cf08.png)
