### PR TITLE
[pt-BR] SkiptDefaultLib, SkipLib, SourceMap and SourceRoot

### DIFF
--- a/packages/tsconfig-reference/copy/pt/options/skipDefaultLibCheck.md
+++ b/packages/tsconfig-reference/copy/pt/options/skipDefaultLibCheck.md
@@ -1,0 +1,6 @@
+---
+display: "Ignorar a verificação da biblioteca padrão"
+oneline: "Utilize o SkipLibCheck ao invés dessa"
+---
+
+Usar [`--skipLibCheck`](#skipLibCheck) no lugar dessa. Ignora a checagem dos tipos de arquivos de declaração na biblioteca padrão.

--- a/packages/tsconfig-reference/copy/pt/options/skipLibCheck.md
+++ b/packages/tsconfig-reference/copy/pt/options/skipLibCheck.md
@@ -1,0 +1,10 @@
+---
+display: "Ignorar a verificação de biblioteca"
+oneline: "Pula a verificação dos arquivos de declaração"
+---
+
+Ignora a verificação dos arquivos de declaração.
+
+Isso pode economizar tempo durante a compilação, porém, às custas da precisão do sistema de tipos. Por exemplo, duas bibliotecas podem definir duas cópias do mesmo `type` de modo inconsistente. Em vez de fazer uma verificação completa de todos os arquivos `d.ts`, o TypeScript irá verificar o código ao qual você se refere no código-fonte do aplicativo.
+
+Um uso comum para se usar o `skipLibCheck` é quando há duas cópias de uma biblioteca no seu `node_modules`. Nesses casos você deve considerar usar um recurso como as [resoluções do yarn](https://classic.yarnpkg.com/pt-BR/docs/selective-version-resolutions) para garantir que há apenas uma única cópia de cada dependência na sua árvore, ou descobrir como se certificar, entendendo as resoluções de dependência, como manter uma única cópia sem utilizar nenhuma ferramenta adicional.

--- a/packages/tsconfig-reference/copy/pt/options/sourceMap.md
+++ b/packages/tsconfig-reference/copy/pt/options/sourceMap.md
@@ -4,7 +4,7 @@ oneline: "Cria mapas de origem para os arquivos JavaScript emitidos"
 
 ---
 
-Permite a geração de [mapas de origem](https://developer.mozilla.org/pt-PT/docs/Tools/Debugger/How_to/Use_a_source_map). Esses arquivos permitem a depuradores e outras ferramentas exibir o código fonte TypeScript original ao trabalhar com os arquivos JavaScript emitidos. Mapas de origem são emitidos como arquivos `js.map` (ou `jsx.map`) próximos aos arquivos de saída `.js` correspondentes.
+Permite a geração de [mapas de origem](https://developer.mozilla.org/pt-PT/docs/Tools/Debugger/How_to/Use_a_source_map). Esses arquivos permitem que depuradores e outras ferramentas exibam o código fonte TypeScript original ao trabalhar com os arquivos JavaScript emitidos. Mapas de origem são emitidos como arquivos `js.map` (ou `jsx.map`) ao lado dos arquivos de saída `.js` correspondentes.
 
 Os arquivos `.js` recebem um container com comentários do mapa de origem, indicando para as ferramentas externas onde os arquivos estão. Por exemplo:
 

--- a/packages/tsconfig-reference/copy/pt/options/sourceMap.md
+++ b/packages/tsconfig-reference/copy/pt/options/sourceMap.md
@@ -1,12 +1,12 @@
 ---
-display: "Mapas de origem"
-oneline: "Cria mapas de origem para os arquivos JavaScript emitidos"
+display: "Mapas de código"
+oneline: "Cria mapas de código para os arquivos JavaScript emitidos"
 
 ---
 
-Permite a geração de [mapas de origem](https://developer.mozilla.org/pt-PT/docs/Tools/Debugger/How_to/Use_a_source_map). Esses arquivos permitem que depuradores e outras ferramentas exibam o código fonte TypeScript original ao trabalhar com os arquivos JavaScript emitidos. Mapas de origem são emitidos como arquivos `js.map` (ou `jsx.map`) ao lado dos arquivos de saída `.js` correspondentes.
+Permite a geração de [mapas de código](https://developer.mozilla.org/pt-PT/docs/Tools/Debugger/How_to/Use_a_source_map). Esses arquivos permitem que depuradores e outras ferramentas exibam o código fonte TypeScript original ao trabalhar com os arquivos JavaScript emitidos. Mapas de código são emitidos como arquivos `js.map` (ou `jsx.map`) ao lado dos arquivos de saída `.js` correspondentes.
 
-Os arquivos `.js` recebem um container com comentários do mapa de origem, indicando para as ferramentas externas onde os arquivos estão. Por exemplo:
+Os arquivos `.js` recebem um container com comentários do mapa de código, indicando para as ferramentas externas onde os arquivos estão. Por exemplo:
 
 ```ts
 // helloWorld.ts

--- a/packages/tsconfig-reference/copy/pt/options/sourceMap.md
+++ b/packages/tsconfig-reference/copy/pt/options/sourceMap.md
@@ -1,0 +1,38 @@
+---
+display: "Mapas de origem"
+oneline: "Cria mapas de origem para os arquivos JavaScript emitidos"
+
+---
+
+Permite a geração de [mapas de origem](https://developer.mozilla.org/pt-PT/docs/Tools/Debugger/How_to/Use_a_source_map). Esses arquivos permitem a depuradores e outras ferramentas exibir o código fonte TypeScript original ao trabalhar com os arquivos JavaScript emitidos. Mapas de origem são emitidos como arquivos `js.map` (ou `jsx.map`) próximos aos arquivos de saída `.js` correspondentes.
+
+Os arquivos `.js` recebem um container com comentários do mapa de origem, indicando para as ferramentas externas onde os arquivos estão. Por exemplo:
+
+```ts
+// helloWorld.ts
+export declare const helloWorld = "Olá";
+```
+
+Compilando com o `sourceMap` configurado como `true`, a criação do arquivo JavaScript seguirá assim:
+
+```js
+// helloWorld.js
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.helloWorld = "Olá";
+//# sourceMappingURL=// helloWorld.js.map
+```
+
+E isso irá gerar o seguinte mapa json:
+
+```json
+// helloWorld.js.map
+{
+  "version": 3,
+  "file": "ex.js",
+  "sourceRoot": "",
+  "sources": ["../ex.ts"],
+  "names": [],
+  "mappings": ";;AAAa,QAAA,UAAU,GAAG,IAAI,CAAA"
+}
+```

--- a/packages/tsconfig-reference/copy/pt/options/sourceMap.md
+++ b/packages/tsconfig-reference/copy/pt/options/sourceMap.md
@@ -23,7 +23,7 @@ exports.helloWorld = "Olá";
 //# sourceMappingURL=// helloWorld.js.map
 ```
 
-E isso irá gerar o seguinte mapa json:
+E isso irá gerar o seguinte arquivo json do mapa:
 
 ```json
 // helloWorld.js.map

--- a/packages/tsconfig-reference/copy/pt/options/sourceRoot.md
+++ b/packages/tsconfig-reference/copy/pt/options/sourceRoot.md
@@ -1,0 +1,19 @@
+---
+display: "Raiz do código-fonte"
+oneline: "Configura o caminho da raiz para depuradores acharem o código-fonte referenciado"
+
+---
+
+Especifica a localização onde o depurador deve encontrar os arquivos TypeScript ao invés de outros locais relativos de origem.
+Essa string é processada literalmente dentro do mapa de origem, onde você pode utilizar um caminho ou uma URL:
+
+```json
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "sourceRoot": "https://my-website.com/debug/source/"
+  }
+}
+```
+
+Declara que o `index.js` tem um arquivo fonte em `https://my-website.com/debug/source/index.ts`.


### PR DESCRIPTION
Hello @khaosdoctor, @alvarocamillont, @danilofuchs e @orta

In this PR are the files:

> skipDefaultLibCheck.md
> skipLibCheck.md
> sourceMap.md
> sourceRoot.md

**Some notes about:**

> skipLibCheck.md
 
* I Kept the term `type` in English as in the `exclud.md` file, but in DeclarationDir.md` the term was translated. 

    * I did this because there several files that let terms between backticks on the original language.

* I changed the link to Yarn's resolutions, for the pt-BR version.

____

> sourceMap.md

* Changed the link from Sourcemap Files to the pt-PT version on Mozilla Website. They don't have a pt-Br version yet.

____

> sourceRoot.md

* I used "raiz do código-fonte" for the term "sourceRoot" thinking about what the function does. There other terms that can be used, like "Raiz de origem" or something like this, but I guess that this term fits a little better.  Open to suggestions anyway.

____

And that's it for now. Thank you, guys! 😃 

