### PR TITLE
chore(doc): fix error in classes/accessors section

### DIFF
--- a/packages/documentation/copy/en/handbook-v1/Classes.md
+++ b/packages/documentation/copy/en/handbook-v1/Classes.md
@@ -373,7 +373,7 @@ To preserve existing functionality, we also add a simple getter that retrieves `
 const fullNameMaxLength = 10;
 
 class Employee {
-  private _fullName: string;
+  private _fullName: string = "";
 
   get fullName(): string {
     return this._fullName;


### PR DESCRIPTION
Before this commit, when the playground to try class instance accessors
was launched the "errors" tab was saying the "_fulName" property was not
properly initialized. This commit fixes this issue.

fixes #1037