### PR TITLE
Explain `keyof any` === `string | number | symbol`

### DIFF
--- a/packages/documentation/copy/en/reference/Advanced Types.md
+++ b/packages/documentation/copy/en/reference/Advanced Types.md
@@ -822,6 +822,8 @@ type ThreeStringProps = Record<"prop1" | "prop2" | "prop3", string>;
 
 Non-homomorphic types are essentially creating new properties, so they can't copy property modifiers from anywhere.
 
+Note that `keyof any` represents the type of any value that can be used as an index to an object. In otherwords, `keyof any` is currently equal to `string | number | symbol`.
+
 ## Inference from mapped types
 
 Now that you know how to wrap the properties of a type, the next thing you'll want to do is unwrap them.


### PR DESCRIPTION
I was wondering what `keyof any` mean, then I found that the doc for [Record](https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkeystype) says `Record<K extends string | number | symbol, T>` and assumes it a typo.

Then I found that both https://github.com/microsoft/TypeScript/blob/master/src/lib/es5.d.ts#L1464-L1469 and https://github.com/microsoft/TypeScript/blob/master/lib/lib.es5.d.ts#L1484-L1489 says it's `Record<K extends keyof any, T>`. 

So I was confused, until I found https://stackoverflow.com/questions/55535598/why-does-keyof-any-have-type-of-string-number-symbol-in-typescript that says they are equal.