### PR TITLE
Fixing logic error in example code

### DIFF
--- a/packages/documentation/copy/en/handbook-v1/Interfaces.md
+++ b/packages/documentation/copy/en/handbook-v1/Interfaces.md
@@ -173,7 +173,7 @@ interface SquareConfig {
 }
 
 function createSquare(config: SquareConfig): { color: string; area: number } {
-  return { color: config.color || "red", area: config.width*config.width || 20 };
+  return { color: config.color || "red", area: config.width ? config.width*config.width : 20 };
 }
 
 let mySquare = createSquare({ colour: "red", width: 100 });
@@ -196,7 +196,7 @@ interface SquareConfig {
 }
 
 function createSquare(config: SquareConfig): { color: string; area: number } {
-  return { color: config.color || "red", area: config.width*config.width || 20 };
+  return { color: config.color || "red", area: config.width ? config.width*config.width : 20 };
 }
 // ---cut---
 let mySquare = createSquare({ colour: "red", width: 100 });
@@ -213,7 +213,7 @@ interface SquareConfig {
 }
 
 function createSquare(config: SquareConfig): { color: string; area: number } {
-  return { color: config.color || "red", area: config.width*config.width || 20 };
+  return { color: config.color || "red", area: config.width ? config.width*config.width : 20 };
 }
 // ---cut---
 let mySquare = createSquare({ width: 100, opacity: 0.5 } as SquareConfig);
@@ -243,7 +243,7 @@ interface SquareConfig {
 }
 
 function createSquare(config: SquareConfig): { color: string; area: number } {
-  return { color: config.color || "red", area: config.width*config.width || 20 };
+  return { color: config.color || "red", area: config.width ? config.width*config.width : 20 };
 }
 // ---cut---
 let squareOptions = { colour: "red", width: 100 };
@@ -261,7 +261,7 @@ interface SquareConfig {
 }
 
 function createSquare(config: SquareConfig): { color: string; area: number } {
-  return { color: config.color || "red", area: config.width*config.width || 20 };
+  return { color: config.color || "red", area: config.width ? config.width*config.width : 20 };
 }
 // ---cut---
 let squareOptions = { colour: "red" };

--- a/packages/documentation/copy/en/handbook-v1/Interfaces.md
+++ b/packages/documentation/copy/en/handbook-v1/Interfaces.md
@@ -173,7 +173,7 @@ interface SquareConfig {
 }
 
 function createSquare(config: SquareConfig): { color: string; area: number } {
-  return { color: config.color || "red", area: config.width || 20 };
+  return { color: config.color || "red", area: config.width*config.width || 20 };
 }
 
 let mySquare = createSquare({ colour: "red", width: 100 });
@@ -196,7 +196,7 @@ interface SquareConfig {
 }
 
 function createSquare(config: SquareConfig): { color: string; area: number } {
-  return { color: config.color || "red", area: config.width || 20 };
+  return { color: config.color || "red", area: config.width*config.width || 20 };
 }
 // ---cut---
 let mySquare = createSquare({ colour: "red", width: 100 });
@@ -213,7 +213,7 @@ interface SquareConfig {
 }
 
 function createSquare(config: SquareConfig): { color: string; area: number } {
-  return { color: config.color || "red", area: config.width || 20 };
+  return { color: config.color || "red", area: config.width*config.width || 20 };
 }
 // ---cut---
 let mySquare = createSquare({ width: 100, opacity: 0.5 } as SquareConfig);
@@ -243,7 +243,7 @@ interface SquareConfig {
 }
 
 function createSquare(config: SquareConfig): { color: string; area: number } {
-  return { color: config.color || "red", area: config.width || 20 };
+  return { color: config.color || "red", area: config.width*config.width || 20 };
 }
 // ---cut---
 let squareOptions = { colour: "red", width: 100 };
@@ -261,7 +261,7 @@ interface SquareConfig {
 }
 
 function createSquare(config: SquareConfig): { color: string; area: number } {
-  return { color: config.color || "red", area: config.width || 20 };
+  return { color: config.color || "red", area: config.width*config.width || 20 };
 }
 // ---cut---
 let squareOptions = { colour: "red" };


### PR DESCRIPTION
The point of the examples are described clearly, 
Though there is a minor logic error in the createSquare function. 

area: config.width || 20 should be area: config.width ? config.width*config.width : 20