### PR TITLE
fix: NYC Typescript meetup url

### DIFF
--- a/packages/community-meta/scripts/meetups.js
+++ b/packages/community-meta/scripts/meetups.js
@@ -84,7 +84,7 @@ const meetups = [
   },
   {
     title: "TypeScript NYC",
-    url: "https://www.meetup.com/TypeScriptNYC",
+    url: "https://www.meetup.com/NYC-Typescript",
     image: "typescript-nyc.jpg",
     country: "🇺🇸",
     continentish: "North America"


### PR DESCRIPTION
Fixes #1016 

Correct URL -> https://www.meetup.com/NYC-Typescript