### PR TITLE
fixing ts errors in class expressions example code

### DIFF
--- a/packages/documentation/copy/en/handbook-v1/Interfaces.md
+++ b/packages/documentation/copy/en/handbook-v1/Interfaces.md
@@ -537,13 +537,13 @@ Another simple way is to use class expressions:
 
 ```ts twoslash
 // @strictPropertyInitialization: false
-// @noImplicitAny: fals
+// @noImplicitAny: false
 interface ClockConstructor {
-  new (hour: number, minute: number);
+  new (hour: number, minute: number): ClockInterface;
 }
 
 interface ClockInterface {
-  tick();
+  tick(): void;
 }
 
 const Clock: ClockConstructor = class Clock implements ClockInterface {


### PR DESCRIPTION
When trying out the examples while reading the handbook, noticed some TS errors in the example code where types were not being defined in the interfaces, so TS was defaulting to the any type causing the example to break. Resolving these errors to assist future readers in playing with example code.