### PR TITLE
Improve wording for @ts-expect-error usage

### DIFF
--- a/packages/documentation/copy/en/release-notes/TypeScript 3.9.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 3.9.md
@@ -100,7 +100,7 @@ doStuff(123, 456);
 ```
 
 That's why TypeScript 3.9 brings a new feature: `// @ts-expect-error` comments.
-When a line is prefixed with a `// @ts-expect-error` comment, TypeScript will suppress that error from being reported;
+When a line is preceded by a `// @ts-expect-error` comment, TypeScript will suppress that error from being reported;
 but if there's no error, TypeScript will report that `// @ts-expect-error` wasn't necessary.
 
 As a quick example, the following code is okay


### PR DESCRIPTION
The original text reads 'prefixed', which might indicate that the comment should go in the suppressed line.

Changing the phrase to "when a line is preceded by a ..." might improve the understanding.