### PR TITLE
Fixes typos in DOM manipulation tutorial

### DIFF
--- a/packages/documentation/copy/en/tutorials/DOM Manipulation.md
+++ b/packages/documentation/copy/en/tutorials/DOM Manipulation.md
@@ -12,7 +12,7 @@ translatable: true
 
 In the 20+ years since its standardization, JavaScript has come a very long way. While in 2020, JavaScript can be used on servers, in data science, and even on IoT devices, it is important to remember its most popular use case: web browsers.
 
-Website are made up of HTML and/or XML documents. These documents are static, they do not change. The D*ocument Object Model (DOM) is* a programming interface implemented by browsers in order to make static websites functional. The DOM API can be used to change the document structure, style, and content. The API is so powerful that countless frontend frameworks (jQuery, React, Angular, etc.) have been developed around it in order to make dynamic websites even easier to develop.
+Websites are made up of HTML and/or XML documents. These documents are static, they do not change. The *Document Object Model (DOM)* is a programming interface implemented by browsers in order to make static websites functional. The DOM API can be used to change the document structure, style, and content. The API is so powerful that countless frontend frameworks (jQuery, React, Angular, etc.) have been developed around it in order to make dynamic websites even easier to develop.
 
 TypeScript is a typed superset of JavaScript, and it ships type definitions for the DOM API. These definitions are readily available in any default TypeScript project. Of the 20,000+ lines of definitions in _lib.dom.d.ts_, one stands out among the rest: `HTMLElement` . This type is the backbone for DOM manipulation with TypeScript.
 
@@ -58,7 +58,7 @@ After compiling and running the _index.html_ page, the resulting HTML will be:
 
 ## The `Document` Interface
 
-The first line of the TypeScript code uses a global variable `document` , inspecting the variable shows it is defined by the `Document` interface from the _lib.dom.d.ts_ file. The code snippet contains calls to two methods, `getElementById` and `createElement`.
+The first line of the TypeScript code uses a global variable `document`. Inspecting the variable shows it is defined by the `Document` interface from the _lib.dom.d.ts_ file. The code snippet contains calls to two methods, `getElementById` and `createElement`.
 
 ### `Document.getElementById`
 
@@ -85,7 +85,7 @@ For example `document.createElement('xyz')` returns a `<xyz></xyz>` element, cle
 
 > For those interested, you can interact with custom tag elements using the `document.getElementsByTagName`
 
-For the first definition of `createElement`, it is using some advanced generic patterns. It is best understood broken down into chunks. Starting with the generic expression: `<K extends keyof HTMLElementTagNameMap>`. This expression defines a generic parameter `K` that is _constrained_ to the keys of the interface `HTMLElementTagNameMap`. The map interface contains every specified HTML tag name and its corresponding type interface. For example here are the first 5 mapped values:
+For the first definition of `createElement`, it is using some advanced generic patterns. It is best understood broken down into chunks, starting with the generic expression: `<K extends keyof HTMLElementTagNameMap>`. This expression defines a generic parameter `K` that is _constrained_ to the keys of the interface `HTMLElementTagNameMap`. The map interface contains every specified HTML tag name and its corresponding type interface. For example here are the first 5 mapped values:
 
 ```ts
 interface HTMLElementTagNameMap {
@@ -100,7 +100,7 @@ interface HTMLElementTagNameMap {
 
 Some elements do not exhibit unique properties and so they just return `HTMLElement`, but other types do have unique properties and methods so they return their specific interface (which will extend from or implement `HTMLElement`).
 
-Now, for the remainder of the `createElement` definition: `(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]`. The first argument `tagName` is defined as the generic parameter `K` . The TypeScript interpreter is smart enough to _infer_ the generic parameter from this argument. This means that the developer does not actually have to specify the generic parameter when using the method; whatever value is passed to the `tagName` argument will be inferred as `K` and thus can be used throughout the remainder of the definition. Which is exactly what happens; the return value `HTMLElementTagNameMap[K]` takes the `tagName` argument and uses it to return the corresponding type. This definition is how the `p` variable from the code snippet gets a type of `HTMLParagraphElement`. And if the code was `document.createElement('a')`, then it would be a element of type `HTMLAnchorElement`.
+Now, for the remainder of the `createElement` definition: `(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]`. The first argument `tagName` is defined as the generic parameter `K` . The TypeScript interpreter is smart enough to _infer_ the generic parameter from this argument. This means that the developer does not actually have to specify the generic parameter when using the method; whatever value is passed to the `tagName` argument will be inferred as `K` and thus can be used throughout the remainder of the definition. Which is exactly what happens; the return value `HTMLElementTagNameMap[K]` takes the `tagName` argument and uses it to return the corresponding type. This definition is how the `p` variable from the code snippet gets a type of `HTMLParagraphElement`. And if the code was `document.createElement('a')`, then it would be an element of type `HTMLAnchorElement`.
 
 ## The `Node` interface
 
@@ -126,7 +126,7 @@ Previously, this document details the `HTMLElement` interface extends from `Elem
   <p>TypeScript!</p>
 </div>;
 
-const div = document.getElementByTagName("div")[0];
+const div = document.getElementsByTagName("div")[0];
 
 div.children;
 // HTMLCollection(2) [p, p]
@@ -145,7 +145,7 @@ Modify the html by removing one of the `p` tags, but keep the text.
   TypeScript!
 </div>;
 
-const div = document.getElementByTagName("div")[0];
+const div = document.getElementsByTagName("div")[0];
 
 div.children;
 // HTMLCollection(1) [p]
@@ -176,7 +176,7 @@ querySelectorAll<K extends keyof SVGElementTagNameMap>(selectors: K): NodeListOf
 querySelectorAll<E extends Element = Element>(selectors: string): NodeListOf<E>;
 ```
 
-The `querySelectorAll` definition is similar to `getElementByTagName`, except it returns a new type: `NodeListOf`. This return type is essentially a custom implementation of the standard JavaScript list element. Arguably, replacing `NodeListOf<E>` with `E[]` would result in a very similar user experience. `NodeListOf` only implements the following properties and methods: `length` , `item(index)`, `forEach((value, key, parent) => void)` , and numeric indexing. Additionally, this method returns a list of _elements_ not _nodes_, which is what `NodeList` was returning from the `.childNodes` method. While this may appear as a discrepancy, take note that interface `Element` extends from `Node`.
+The `querySelectorAll` definition is similar to `getElementsByTagName`, except it returns a new type: `NodeListOf`. This return type is essentially a custom implementation of the standard JavaScript list element. Arguably, replacing `NodeListOf<E>` with `E[]` would result in a very similar user experience. `NodeListOf` only implements the following properties and methods: `length` , `item(index)`, `forEach((value, key, parent) => void)` , and numeric indexing. Additionally, this method returns a list of _elements_, not _nodes_, which is what `NodeList` was returning from the `.childNodes` method. While this may appear as a discrepancy, take note that interface `Element` extends from `Node`.
 
 To see these methods in action modify the existing code to:
 


### PR DESCRIPTION
A few general typos and a repeated use of an undefined method `getElementByTagName` are fixed with this PR.