### PR TITLE
Correct link to outFile option

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/out.md
+++ b/packages/tsconfig-reference/copy/en/options/out.md
@@ -3,7 +3,7 @@ display: "Out"
 oneline: "Do not use this"
 ---
 
-Use [outFile](#outfile) instead.
+Use [outFile](#outFile) instead.
 
 The `out` option computes the final file location in a way that is not predictable or consistent.
 This option is retained for backward compatibility only and is deprecated.


### PR DESCRIPTION
The 'F' in '#outFile' was wrongly not capitalised, breaking the link in most browsers.