### PR TITLE
Fix twoslash error caused by incorrect spacing

### DIFF
--- a/packages/documentation/copy/en/reference/Utility Types.md
+++ b/packages/documentation/copy/en/reference/Utility Types.md
@@ -81,7 +81,7 @@ const nav: Record<Page, PageInfo> = {
 };
 
 nav.about;
-//      ^?
+// ^?
 ```
 
 ## `Pick<Type, Keys>`


### PR DESCRIPTION
Under the 'Record' section of the [Utility Types page](https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkeystype) there is a twoslash spacing error which results in the error `//      ^ = Could not get LSP result: bou>t<;` being shown:

![ts-error](https://user-images.githubusercontent.com/37877450/93000964-d0944c00-f52b-11ea-9463-132a4e497d2c.jpg)

The error is caused by a few errant tabs before the caret.

Issue fixed by removing the tabs.