### PR TITLE
Switch KeyboardEvent attribute from keyCode to key

### DIFF
--- a/packages/playground/src/createElements.ts
+++ b/packages/playground/src/createElements.ts
@@ -142,16 +142,16 @@ export const createTabBar = () => {
   tabBar.addEventListener("keydown", e => {
     const tabs = document.querySelectorAll('.playground-plugin-tabview [role="tab"]')
     // Move right
-    if (e.key === "ArrowRight" || e.code === "ArrowRight" || e.key === "ArrowRight" || e.code === "ArrowRight") {
+    if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
       tabs[tabFocus].setAttribute("tabindex", "-1")
-      if (e.key === "ArrowRight" || e.code === "ArrowRight") {
+      if (e.key === "ArrowRight") {
         tabFocus++
         // If we're at the end, go to the start
         if (tabFocus >= tabs.length) {
           tabFocus = 0
         }
         // Move left
-      } else if (e.key === "ArrowLeft" || e.code === "ArrowLeft") {
+      } else if (e.key === "ArrowLeft") {
         tabFocus--
         // If we're at the start, move to the end
         if (tabFocus < 0) {

--- a/packages/playground/src/createElements.ts
+++ b/packages/playground/src/createElements.ts
@@ -142,16 +142,16 @@ export const createTabBar = () => {
   tabBar.addEventListener("keydown", e => {
     const tabs = document.querySelectorAll('.playground-plugin-tabview [role="tab"]')
     // Move right
-    if (e.keyCode === 39 || e.keyCode === 37) {
+    if (e.key === "ArrowRight" || e.code === "ArrowRight" || e.key === "ArrowRight" || e.code === "ArrowRight") {
       tabs[tabFocus].setAttribute("tabindex", "-1")
-      if (e.keyCode === 39) {
+      if (e.key === "ArrowRight" || e.code === "ArrowRight") {
         tabFocus++
         // If we're at the end, go to the start
         if (tabFocus >= tabs.length) {
           tabFocus = 0
         }
         // Move left
-      } else if (e.keyCode === 37) {
+      } else if (e.key === "ArrowLeft" || e.code === "ArrowLeft") {
         tabFocus--
         // If we're at the start, move to the end
         if (tabFocus < 0) {

--- a/packages/playground/src/createUI.ts
+++ b/packages/playground/src/createUI.ts
@@ -100,7 +100,7 @@ export const createUI = (): UI => {
     modal.appendChild(buttonContainer)
     const close = modal.querySelector(".close") as HTMLElement
     close.addEventListener("keydown", e => {
-      if (e.key === "Tab" || e.code === "Tab") {
+      if (e.key === "Tab") {
         ;(modal.querySelector("textarea") as any).focus()
         e.preventDefault()
       }
@@ -124,7 +124,7 @@ export const createUI = (): UI => {
     const buttons = modal.querySelectorAll("button")
     const lastButton = buttons.item(buttons.length - 1) as HTMLElement
     lastButton.addEventListener("keydown", e => {
-      if (e.key === "Tab" || e.code === "Tab") {
+      if (e.key === "Tab") {
         ;(document.querySelector(".close") as any).focus()
         e.preventDefault()
       }

--- a/packages/playground/src/createUI.ts
+++ b/packages/playground/src/createUI.ts
@@ -100,7 +100,7 @@ export const createUI = (): UI => {
     modal.appendChild(buttonContainer)
     const close = modal.querySelector(".close") as HTMLElement
     close.addEventListener("keydown", e => {
-      if (e.keyCode === 9) {
+      if (e.key === "Tab" || e.code === "Tab") {
         ;(modal.querySelector("textarea") as any).focus()
         e.preventDefault()
       }
@@ -124,7 +124,7 @@ export const createUI = (): UI => {
     const buttons = modal.querySelectorAll("button")
     const lastButton = buttons.item(buttons.length - 1) as HTMLElement
     lastButton.addEventListener("keydown", e => {
-      if (e.keyCode === 9) {
+      if (e.key === "Tab" || e.code === "Tab") {
         ;(document.querySelector(".close") as any).focus()
         e.preventDefault()
       }

--- a/packages/playground/src/ds/createDesignSystem.ts
+++ b/packages/playground/src/ds/createDesignSystem.ts
@@ -171,16 +171,16 @@ export const createDesignSystem = (sandbox: Sandbox) => {
       tabBar.addEventListener("keydown", e => {
         const tabs = tabBar.querySelectorAll('[role="tab"]')
         // Move right
-        if (e.keyCode === 39 || e.keyCode === 37) {
+        if (e.key === "ArrowRight" || e.code === "ArrowRight" || e.key === "ArrowLeft" || e.code === "ArrowLeft") {
           tabs[tabFocus].setAttribute("tabindex", "-1")
-          if (e.keyCode === 39) {
+          if (e.key === "ArrowRight" || e.code === "ArrowRight") {
             tabFocus++
             // If we're at the end, go to the start
             if (tabFocus >= tabs.length) {
               tabFocus = 0
             }
             // Move left
-          } else if (e.keyCode === 37) {
+          } else if (e.key === "ArrowLeft" || e.code === "ArrowLeft") {
             tabFocus--
             // If we're at the start, move to the end
             if (tabFocus < 0) {
@@ -432,7 +432,7 @@ export const createDesignSystem = (sandbox: Sandbox) => {
 
       // Suppress the enter key
       textbox.onkeydown = (evt: KeyboardEvent) => {
-        if (evt.keyCode == 13) {
+        if (evt.key === "Enter" || evt.code === "Enter") {
           return false
         }
       }

--- a/packages/playground/src/ds/createDesignSystem.ts
+++ b/packages/playground/src/ds/createDesignSystem.ts
@@ -171,16 +171,16 @@ export const createDesignSystem = (sandbox: Sandbox) => {
       tabBar.addEventListener("keydown", e => {
         const tabs = tabBar.querySelectorAll('[role="tab"]')
         // Move right
-        if (e.key === "ArrowRight" || e.code === "ArrowRight" || e.key === "ArrowLeft" || e.code === "ArrowLeft") {
+        if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
           tabs[tabFocus].setAttribute("tabindex", "-1")
-          if (e.key === "ArrowRight" || e.code === "ArrowRight") {
+          if (e.key === "ArrowRight") {
             tabFocus++
             // If we're at the end, go to the start
             if (tabFocus >= tabs.length) {
               tabFocus = 0
             }
             // Move left
-          } else if (e.key === "ArrowLeft" || e.code === "ArrowLeft") {
+          } else if (e.key === "ArrowLeft") {
             tabFocus--
             // If we're at the start, move to the end
             if (tabFocus < 0) {

--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -415,7 +415,7 @@ export const setupPlayground = (
 
     settingsToggle.addEventListener("keydown", e => {
       const isOpen = settingsToggle.parentElement!.classList.contains("open")
-      if (e.keyCode === 9 && isOpen) {
+      if ((e.key === "Tab" || e.code === "Tab") && isOpen) {
         const result = document.querySelector(".playground-options li input") as any
         result.focus()
         e.preventDefault()
@@ -619,7 +619,7 @@ export type Playground = ReturnType<typeof setupPlayground>
 
 const redirectTabPressTo = (element: HTMLElement, container: HTMLElement | undefined, query: string) => {
   element.addEventListener("keydown", e => {
-    if (e.keyCode === 9) {
+    if (e.key === "Tab" || e.code === "Tab") {
       const host = container || document
       const result = host.querySelector(query) as any
       if (!result) throw new Error(`Expected to find a result for keydown`)

--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -415,7 +415,7 @@ export const setupPlayground = (
 
     settingsToggle.addEventListener("keydown", e => {
       const isOpen = settingsToggle.parentElement!.classList.contains("open")
-      if ((e.key === "Tab" || e.code === "Tab") && isOpen) {
+      if (e.key === "Tab" && isOpen) {
         const result = document.querySelector(".playground-options li input") as any
         result.focus()
         e.preventDefault()
@@ -619,7 +619,7 @@ export type Playground = ReturnType<typeof setupPlayground>
 
 const redirectTabPressTo = (element: HTMLElement, container: HTMLElement | undefined, query: string) => {
   element.addEventListener("keydown", e => {
-    if (e.key === "Tab" || e.code === "Tab") {
+    if (e.key === "Tab") {
       const host = container || document
       const result = host.querySelector(query) as any
       if (!result) throw new Error(`Expected to find a result for keydown`)

--- a/packages/typescriptlang-org/src/components/layout/Sidebar-keyboard.tsx
+++ b/packages/typescriptlang-org/src/components/layout/Sidebar-keyboard.tsx
@@ -12,16 +12,16 @@ const childOfType = (tag: string, element: any) => {
   return found
 }
 
-/** 
- * Handles moving up and down through the navigation hierarchy 
+/**
+ * Handles moving up and down through the navigation hierarchy
  * selecting leaf nodes and jumping up into section categories
  */
-export const onAnchorKeyDown: KeyboardEventHandler = (event) => {
-  const li = getTagFromParents("li", event.target as any);
+export const onAnchorKeyDown: KeyboardEventHandler = event => {
+  const li = getTagFromParents("li", event.target as any)
 
   // Up, and jump into section headers
   if (event.keyCode == UpArrow) {
-    const aboveLI = li.previousElementSibling;
+    const aboveLI = li.previousElementSibling
     const a = aboveLI && childOfType("a", aboveLI)
     const button = aboveLI && childOfType("button", aboveLI)
 
@@ -29,28 +29,28 @@ export const onAnchorKeyDown: KeyboardEventHandler = (event) => {
       // next link
       a.focus()
     } else if (aboveLI && button) {
-      // Jump to the subnav above, either at the bottom item if open or 
+      // Jump to the subnav above, either at the bottom item if open or
       // the main button otherwise
       const open = aboveLI.classList.contains("open")
       if (open) {
         const listOfLinks = childOfType("ul", aboveLI)!
         const lastLI = listOfLinks.lastElementChild
-        childOfType("a", lastLI)!.focus();
+        childOfType("a", lastLI)!.focus()
       } else {
         button.focus()
       }
     } else {
-      // at the top 
-      const sectionHostingLI = getTagFromParents("li", li);
-      childOfType("button", sectionHostingLI)!.focus();
+      // at the top
+      const sectionHostingLI = getTagFromParents("li", li)
+      childOfType("button", sectionHostingLI)!.focus()
     }
 
-    event.preventDefault();
+    event.preventDefault()
   }
 
   // Down, and jump into section header belows
   if (event.keyCode === DownArrow) {
-    const belowLI = li.nextElementSibling;
+    const belowLI = li.nextElementSibling
     const a = belowLI && childOfType("a", belowLI)
     const button = belowLI && childOfType("button", belowLI)
 
@@ -61,9 +61,9 @@ export const onAnchorKeyDown: KeyboardEventHandler = (event) => {
       // potential subnav above
       button.focus()
     } else {
-      // at the bottom 
-      const sectionHostingLI = getTagFromParents("li", li);
-      const nextLI = sectionHostingLI.nextElementSibling;
+      // at the bottom
+      const sectionHostingLI = getTagFromParents("li", li)
+      const nextLI = sectionHostingLI.nextElementSibling
       const a = nextLI && childOfType("a", nextLI)
       const button = nextLI && childOfType("button", nextLI)
 
@@ -76,22 +76,22 @@ export const onAnchorKeyDown: KeyboardEventHandler = (event) => {
       }
     }
 
-    event.preventDefault();
+    event.preventDefault()
   }
 }
 
-/** 
- * Handles moving up and down through the navigation hierarchy 
+/**
+ * Handles moving up and down through the navigation hierarchy
  * when it's at a section category, which has different semantics
  * from the a's above
  */
-export const onButtonKeydown: KeyboardEventHandler = (event) => {
-  const li = getTagFromParents("li", event.target as any);
-  // Up, either go to the bottom of the a's in the section above 
+export const onButtonKeydown: KeyboardEventHandler = event => {
+  const li = getTagFromParents("li", event.target as any)
+  // Up, either go to the bottom of the a's in the section above
   // if it's open or jump to the previous sibling button
   if (event.keyCode == UpArrow) {
-    const aboveLI = li.previousElementSibling;
-    if (!aboveLI) return; // Hit the top
+    const aboveLI = li.previousElementSibling
+    if (!aboveLI) return // Hit the top
 
     const a = aboveLI && childOfType("a", aboveLI)
     const button = aboveLI && childOfType("button", aboveLI)
@@ -105,31 +105,29 @@ export const onButtonKeydown: KeyboardEventHandler = (event) => {
       if (open) {
         const listOfLinks = childOfType("ul", aboveLI)!
         const lastLI = listOfLinks.lastElementChild
-        childOfType("a", lastLI)!.focus();
+        childOfType("a", lastLI)!.focus()
       } else {
         button.focus()
       }
     } else {
-      // at the top 
-      const sectionHostingLI = getTagFromParents("li", li);
-      childOfType("button", sectionHostingLI)!.focus();
+      // at the top
+      const sectionHostingLI = getTagFromParents("li", li)
+      childOfType("button", sectionHostingLI)!.focus()
     }
 
-    event.preventDefault();
+    event.preventDefault()
   }
 
   // Down, and jump into section header belows
   if (event.keyCode == DownArrow) {
-
     const open = li.classList.contains("open")
     if (open) {
       // Need to jump to first in the section
       const listOfLinks = childOfType("ul", li)!
       const lastLI = listOfLinks.firstElementChild
-      childOfType("a", lastLI)!.focus();
-
+      childOfType("a", lastLI)!.focus()
     } else {
-      const belowLI = li.nextElementSibling;
+      const belowLI = li.nextElementSibling
       if (belowLI) {
         const a = belowLI && childOfType("a", belowLI)
         const button = belowLI && childOfType("button", belowLI)
@@ -143,23 +141,22 @@ export const onButtonKeydown: KeyboardEventHandler = (event) => {
         }
       }
     }
-    event.preventDefault();
+    event.preventDefault()
   }
 
   // Right, open
-  if (event.keyCode == 39) {
+  if (event.key === "ArrowRight" || event.code === "ArrowRight") {
     li.classList.remove("closed")
     li.classList.add("open")
 
-    event.preventDefault();
+    event.preventDefault()
   }
 
   // Right, close
-  if (event.keyCode == 37) {
+  if (event.key === "ArrowLeft" || event.code === "ArrowLeft") {
     li.classList.remove("open")
     li.classList.add("closed")
 
-    event.preventDefault();
+    event.preventDefault()
   }
-
 }

--- a/packages/typescriptlang-org/src/components/layout/Sidebar-keyboard.tsx
+++ b/packages/typescriptlang-org/src/components/layout/Sidebar-keyboard.tsx
@@ -145,7 +145,7 @@ export const onButtonKeydown: KeyboardEventHandler = event => {
   }
 
   // Right, open
-  if (event.key === "ArrowRight" || event.code === "ArrowRight") {
+  if (event.key === "ArrowRight") {
     li.classList.remove("closed")
     li.classList.add("open")
 
@@ -153,7 +153,7 @@ export const onButtonKeydown: KeyboardEventHandler = event => {
   }
 
   // Right, close
-  if (event.key === "ArrowLeft" || event.code === "ArrowLeft") {
+  if (event.key === "ArrowLeft") {
     li.classList.remove("open")
     li.classList.add("closed")
 


### PR DESCRIPTION
In this code base, I saw that the code is using `key` instead of `keyCode`.
I guess unifying could be good.

Keycodes list
http://www.javascripter.net/faq/keycodes.htm

Did double-check on MDN
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code