### PR TITLE
[PT-BR] Nominal Typing and Meta-Types

### DIFF
--- a/packages/playground-examples/copy/pt/TypeScript/Language Extensions/Nominal Typing.ts
+++ b/packages/playground-examples/copy/pt/TypeScript/Language Extensions/Nominal Typing.ts
@@ -1,0 +1,66 @@
+// Um sistema de tipos nominal significa que cada tipo é
+// único e, mesmo se os tipos possuam os mesmos dados, eles
+// não podem ser atribuídos entre tipos.
+
+// O sistema de tipos do TypeScript é estrutural, o que
+// significa que se um tipo tem a forma de um pato, ele é
+// um pato. Se um ganso tem todos os atributos de um pato,
+// então ele também é um pato. Você pode aprender mais em:
+// example:structural-typing
+
+// Isso pode trazer desvantagens, por exemplo, existem casos
+// em que uma string ou número podem ter um contexto especial
+// e você não quer que esses valores sejam transferíveis.
+// Por exemplo:
+
+// - Strings com entradas de usuários (inseguro)
+// - Strings de tradução
+// - Números de identificação de usuário
+// - Tokens de acesso
+
+// É possível implementar a maior parte das funções de um 
+// sistema de tipos nominal com um pouco de código adicional.
+
+// Utilizando um tipo de interseção, com uma restrição na
+// forma de uma propriedade chamada __brand (isso é uma
+// convenção), tornamos impossível atribuir uma string comum
+// a um tipo StringDeEntradaValidada.
+
+type StringDeEntradaValidada = string & { __brand: "Entrada de Usuário Após Validação" };
+
+// Agora utilizaremos uma função para transformar uma string
+// em uma StringDeEntradaValidada - mas algo a se notar é que
+// nós estamos apenas dizendo ao TypeScript que isso é verdade.
+
+const validarEntradaDeUsuario = (entrada: string) => {
+  const validacaoSimplesDeEntrada = entrada.replace(/\</g, "≤");
+  return validacaoSimplesDeEntrada as StringDeEntradaValidada;
+};
+
+// Assim, podemos criar funções que aceitam somente o nosso
+// novo tipo nominal, e não o tipo string mais genérico.
+
+const imprimirNome = (nome: StringDeEntradaValidada) => {
+  console.log(nome);
+};
+
+// Por exemplo, aqui temos uma entrada insegura de um usuário
+// que, após passar pelo validador, é impressa sem problemas:
+
+const entrada = "\n<script>alert('bobby tables')</script>";
+const validatedInput = validarEntradaDeUsuario(entrada);
+imprimirNome(validatedInput);
+
+// Por outro lado, passar uma string não-validada para a função
+// imprimirNome causará um erro no compilador:
+
+imprimirNome(entrada);
+
+// Você pode consultar uma visão geral das diferentes maneiras
+// de criar tipos nominais, com suas vantagens e desvantagens,
+// nesse issue do GitHub (em inglês):
+
+// https://github.com/Microsoft/TypeScript/issues/202
+
+// Também pode acessar um ótimo sumário neste post (em inglês):
+// https://michalzalecki.com/nominal-typing-in-typescript/

--- a/packages/playground-examples/copy/pt/TypeScript/Meta-Types/Discriminate Types.ts
+++ b/packages/playground-examples/copy/pt/TypeScript/Meta-Types/Discriminate Types.ts
@@ -1,0 +1,66 @@
+// Uma união de tipos discriminados é quando você usa análise
+// de fluxo de código para reduzir um conjunto de objetos
+// para um objeto específico.
+
+// Esse padrão funciona muito bem para conjuntos de objetos
+// semelhantes com propriedades em comum, por exemplo: uma
+// lista de eventos nomeados, ou um conjunto de objetos
+// versionados.
+
+type EventoCronometrado = { nome: "inicio"; usuarioIniciou: boolean } | { nome: "encerrado"; duracao: number };
+
+// Quando o evento chega na função abaixo, ele pode ser
+// qualquer um dos dois tipos possíveis.
+
+const tratarEvento = (evento: EventoCronometrado) => {
+  // Usando um switch com evento.nome, a análise de fluxo de
+  // código do TypeScript consegue determinar que um objeto
+  // pode ser representado somente por um tipo da união.
+
+  switch (evento.nome) {
+    case "inicio":
+      // Isso significa que você pode acessar usuarioIniciou
+      // com segurança, porque esse é o único tipo dentro de
+      // EventoCronometrado onde nome é "inicio".
+      const usuarioIniciou = evento.usuarioIniciou;
+      break;
+
+    case "encerrado":
+      const intervaloDeTempo = evento.duracao;
+      break;
+  }
+};
+
+// Também podemos usar números como o discriminador, seguindo
+// o mesmo padrão.
+
+// Nesse exemplo, temos uma união discriminada e um estado
+// de erro adicional para tratar.
+
+type RespostasAPI = { versao: 0; mensagem: string } | { versao: 1; mensagem: string; status: number } | { erro: string };
+
+const tratarResposta = (resposta: RespostasAPI) => {
+  // Tratar o caso de erro, e então retornar.
+  if ("erro" in resposta) {
+    console.error(resposta.erro);
+    return;
+  }
+
+  // O TypeScript agora sabe que respostas não pode ser do
+  // tipo erro. Caso fosse, a função teria retornado. Você
+  // pode verificar isso passando o mouse sobre resposta no
+  // trecho abaixo.
+
+  if (resposta.versao === 0) {
+    console.log(resposta.mensagem);
+  } else if (resposta.versao === 1) {
+    console.log(resposta.status, resposta.mensagem);
+  }
+};
+
+// É recomendado utilizar um bloco switch no lugar de um
+// bloco if porque assim você pode garantir que todas as
+// partes da união são checadas. Existe um bom padrão para
+// isso usando o tipo never no manual (em inglês):
+//
+// https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions

--- a/packages/playground-examples/copy/pt/TypeScript/Meta-Types/Indexed Types.ts
+++ b/packages/playground-examples/copy/pt/TypeScript/Meta-Types/Indexed Types.ts
@@ -1,0 +1,38 @@
+// Existem situações em que você se encontra duplicando
+// tipos, um exemplo comum são recursos aninhados em uma
+// resposta de API gerada automaticamente.
+
+interface ResultadosBuscaDeObras {
+  artistas: {
+    nome: string;
+    obras: {
+      nome: string;
+      dataFalecimento: string | null;
+      bio: string;
+    }[];
+  }[];
+}
+
+// Se essa interface fosse feita manualmente, é fácil imaginar
+// que as obras seriam separadas em uma interface como:
+
+interface Obras {
+  nome: string;
+  dataFalecimento: string | null;
+  bio: string;
+}
+
+// No entanto, nesse caso não temos controle da API e, se
+// criarmos a interface manualmente, é possível que o campo
+// obras em ResultadosBuscaDeObras e Obras fiquem defasados
+// quando houver uma mudança na resposta.
+
+// Para resolver esse problema utilizamos tipos indexados,
+// que replicam como JavaScript permite acessar propriedades
+// de objetos via strings.
+
+type ObrasInferidas = ResultadosBuscaDeObras["artistas"][0]["obras"][0];
+
+// A interface ObrasInferidas é gerada percorrendo as
+// propriedades do tipo e dando um novo nome ao subconjunto
+// que você indexou.

--- a/packages/playground-examples/copy/pt/TypeScript/Meta-Types/Mapped Types.ts
+++ b/packages/playground-examples/copy/pt/TypeScript/Meta-Types/Mapped Types.ts
@@ -1,0 +1,57 @@
+// Tipos mapeados são uma maneira de criar tipos baseados
+// em outros tipos. É praticamente um tipo transformacional.
+
+// Um caso comum para se usar um tipo mapeado é quando
+// lidamos com subconjuntos opcionais. Por exemplo, uma
+// API pode retornar um Artista:
+
+interface Artista {
+  id: number;
+  nome: string;
+  bio: string;
+}
+
+// No entanto, caso fosse necessário enviar para a API uma
+// atualização que alterasse apenas uma parte de Artista, 
+// normalmente seria necessário criar uma interface adicional:
+
+interface ArtistParaEdicao {
+  id: number;
+  nome?: string;
+  bio?: string;
+}
+
+// É provável que ela acabe defasada da interface Artista
+// acima. Tipos mapeados resolvem esse problema, permitindo
+// que seja criado um novo tipo que altera um tipo existente.
+
+type MeuTipoParcial<Tipo> = {
+  // Para cada propriedade existente em Tipo, converta
+  // ela em uma propriedade opcional (?).
+  [Propriedade in keyof Tipo]?: Tipo[Propriedade];
+};
+
+// Agora podemos usar o tipo mapeado para criar nosso tipo
+// para edição:
+type ArtistaMapeadoParaEdicao = MeuTipoParcial<Artista>;
+
+// Já está quase perfeito, porém esse tipo permite que o id
+// seja nulo, o que nunca deve acontecer. Então, vamos fazer
+// uma pequena melhoria usando um tipo de interseção (veja:
+// example:union-and-intersection-types).
+
+type MeuTipoParcialParaEdicao<Tipo> = {
+  [Propriedade in keyof Tipo]?: Tipo[Propriedade];
+} & { id: number };
+
+// Isso faz com que o tipo mapeado parcial seja combinado
+// com um objeto que tem o id obrigatório, efetivamente
+// forçando o id a estar definido no tipo.
+
+type ArtistaMapeadoCorretamenteParaEdicao = MeuTipoParcialParaEdicao<Artista>;
+
+// Esse é um exemplo bastante simples de como tipos mapeados
+// funcionam, mas cobre os conceitos mais básicos. Se você
+// quiser se aprofundar, veja o manual (em inglês):
+//
+// https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types


### PR DESCRIPTION
This PR contains the Brazilian Portuguese translation of the following files:

- `Nominal Typing.ts`
- `Discriminate Types.ts`
- `Indexed Types.ts`
- `Mapped Types.ts`

In the Nominal Typing file, I left `__brand` untranslated, as it is a convention.
Please let me know if it should be translated (maybe to `__marca` ?)

@khaosdoctor, @alvarocamillont, @danilofuchs @orta