### PR TITLE
fix: declaration is actually false by default

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -101,7 +101,7 @@ export const defaultsForOptions = {
   charset: "utf8",
   checkJs: "false",
   composite: "true",
-  declaration: "True when TS",
+  declaration: "false",
   declarationDir: " n/a",
   declarationMap: "false",
   diagnostics: "false",


### PR DESCRIPTION
## Description

- previously said "True when TS", but that isn't accurate
  - upon testing, it appears to be false by default
  - an explicit `declaration: true` is required in `tsconfig.json` for
    declaration files (`.d.ts`) to be output

- the Compiler Options docs also say it's default false too, so not sure
  why it's different in the TSConfig Reference
  - c.f. https://github.com/microsoft/TypeScript-Website/blob/46b960968f994968b237060065f651a368e5fc63/packages/documentation/copy/en/project-config/Compiler%20Options.md#L47

## Tags

This was discovered in https://github.com/formium/tsdx/pull/823#discussion_r481083608

## Review Notes

Is there some way to auto-generate these from TS itself so that these are never incorrect/out-of-date?

I'm not sure what other discrepancies there may still be between the TSConfig Reference and Compiler Options docs
