### PR TITLE
typo: extraneous word in link to TSConfig Reference

### DIFF
--- a/packages/documentation/copy/en/project-config/Compiler Options.md
+++ b/packages/documentation/copy/en/project-config/Compiler Options.md
@@ -134,4 +134,4 @@ Option                                         | Type      | Default            
 
 - Setting compiler options in [`tsconfig.json`](/docs/handbook/tsconfig-json.html) files.
 - Setting compiler options in [MSBuild projects](/docs/handbook/compiler-options-in-msbuild.html).
-- There's also out the [TSConfig Reference](/tsconfig).
+- There's also the [TSConfig Reference](/tsconfig).


### PR DESCRIPTION
## Description

- seems like one was thinking "Check out the" and "There's also the",
  which came out as "There's also out the" 😄

## Tags

Discovered while reading through Compiler Options doc for discrepancies like those in #1092 
