### PR TITLE
fix: remove extraneous declaration in relatedTo

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -72,7 +72,6 @@ export const relatedTo: [AnOption, AnOption[]][] = [
 
   ["types", ["typeRoots"]],
   ["typeRoots", ["types"]],
-  ["declaration", ["emitDeclarationOnly"]],
 
   ["noLib", ["lib"]],
 


### PR DESCRIPTION
## Description

- it was specified twice, once grouped with types and typeRoots for some
  reason and missing declarationDir
  - so remove that one, leave in the one that has both declarationDir
    _and_ emitDeclarationOnly
 - second one that remains is ~5 lines below this: https://github.com/microsoft/TypeScript-Website/blob/2ab62adbfaf69e3e74c0a90dcdd7ea48fb21f17e/packages/tsconfig-reference/scripts/tsconfigRules.ts#L80

## Tags

Stumbled upon this after writing #971 

This seems to have been erroneously added in #163 [here](https://github.com/microsoft/TypeScript-Website/pull/163/files#diff-a912c6af3a16bf4288093c1264955bc6R77)

## Screenshot

Currently the first one supersedes the second one, so `declarationDir` isn't mentioned as related on the website:

![Screen Shot 2020-09-16 at 12 04 44 AM](https://user-images.githubusercontent.com/4970083/93292666-0a778380-f7b4-11ea-8ee7-eaaa181f6e9c.png)
