### PR TITLE
fix: allowJs and checkJs shouldn't be relatedTo emitDeclarationOnly

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -76,8 +76,9 @@ export const relatedTo: [AnOption, AnOption[]][] = [
 
   ["noLib", ["lib"]],
 
-  ["allowJs", ["checkJs", "emitDeclarationOnly"]],
-  ["checkJs", ["allowJs", "emitDeclarationOnly"]],
+  ["allowJs", ["checkJs"]],
+  ["checkJs", ["allowJs"]],
+
   ["declaration", ["declarationDir", "emitDeclarationOnly"]],
 
   ["moduleResolution", ["module"]],


### PR DESCRIPTION
## Description

- remove emitDeclarationOnly from their relatedTo and group them
  separately from declaration by adding a newline

- these only seem quite loosely related, only by the DTS/JS doc
  - c.f. https://github.com/microsoft/TypeScript-Website/blob/2a57f7116b72217e47550657826cd650d258ba20/packages/documentation/copy/en/javascript/Creating%20DTS%20files%20From%20JS.md#L46
  - the relationship is not even mentioned in their notes or otherwise
    in the Reference, which was very confusing to me
  - the commit that adds this relationship seems to put
    `emitDeclarationOnly` elsewhere too, so maybe this was a mistake?
    - c.f. https://github.com/microsoft/TypeScript-Website/commit/4627aa39a0fed1722b71cc7e00a79ec11a12f8cd#diff-a912c6af3a16bf4288093c1264955bc6R75

## Tags

Found while writing #1095 / #971

These relationships seem to have been originally added in #163 [here](https://github.com/microsoft/TypeScript-Website/pull/163/files#diff-a912c6af3a16bf4288093c1264955bc6R75)

## Review Notes

If this was an intentional `relatedTo`, feel free to close this. If so, then a link to the DTS/JS doc should probably be added from the Reference in order to explain this relationship instead.
