### PR TITLE
fix: add missing inverses in relatedTo

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -47,6 +47,14 @@ type AnOption = WatchProperties | RootProperties | CompilerOptionName;
 /** Allows linking between options */
 export const relatedTo: [AnOption, AnOption[]][] = [
   ["strict", ["alwaysStrict", "strictNullChecks", "strictBindCallApply", "strictFunctionTypes", "strictPropertyInitialization", "noImplicitAny", "noImplicitThis"]],
+  ["alwaysStrict", ["strict"]],
+  ["strictNullChecks", ["strict"]],
+  ["strictBindCallApply", ["strict"]],
+  ["strictFunctionTypes", ["strict"]],
+  ["strictPropertyInitialization", ["strict"]],
+  ["noImplicitAny", ["strict"]],
+  ["noImplicitThis", ["strict"]],
+
   ["allowSyntheticDefaultImports", ["esModuleInterop"]],
   ["esModuleInterop", ["allowSyntheticDefaultImports"]],
 
@@ -66,21 +74,27 @@ export const relatedTo: [AnOption, AnOption[]][] = [
 
   ["importHelpers", ["noEmitHelpers", "downlevelIteration", "importHelpers"]],
   ["noEmitHelpers", ["importHelpers"]],
+  ["downlevelIteration", ["importHelpers"]],
 
   ["incremental", ["composite", "tsBuildInfoFile"]],
   ["composite", ["incremental", "tsBuildInfoFile"]],
+  ["tsBuildInfoFile", ["incremental", "composite"]],
 
   ["types", ["typeRoots"]],
   ["typeRoots", ["types"]],
   ["declaration", ["emitDeclarationOnly"]],
 
   ["noLib", ["lib"]],
+  ["lib", ["noLib"]],
 
   ["allowJs", ["checkJs", "emitDeclarationOnly"]],
   ["checkJs", ["allowJs", "emitDeclarationOnly"]],
   ["declaration", ["declarationDir", "emitDeclarationOnly"]],
+  ["declarationDir", ["declaration"]],
+  ["emitDeclarationOnly", ["declaration"]],
 
   ["moduleResolution", ["module"]],
+  ["module", ["moduleResolution"]],
 
   ["jsxFactory", ["jsxFragmentFactory"]],
   ["jsxFragmentFactory", ["jsxFactory"]],


### PR DESCRIPTION
## Description

- one side of the relationship existed but not the other side, ensure
  both sides of the relationship are relatedTo each other for proper
  backlinking etc

- add a new line after all the strict options for proper grouping same
  as the other groups

## Tags

Found while writing #1095 / #971 

## Review Notes

I omitted `allowJs` and `checkJs` from `emitDeclarationOnly`'s `relatedTo` because of #1098 , but can add them if that PR is rejected