### PR TITLE
fix: remove importHelpers' erroneous relatedTo self

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -64,7 +64,7 @@ export const relatedTo: [AnOption, AnOption[]][] = [
   ["include", ["files", "exclude"]],
   ["exclude", ["include", "files"]],
 
-  ["importHelpers", ["noEmitHelpers", "downlevelIteration", "importHelpers"]],
+  ["importHelpers", ["noEmitHelpers", "downlevelIteration"]],
   ["noEmitHelpers", ["importHelpers"]],
 
   ["incremental", ["composite", "tsBuildInfoFile"]],


### PR DESCRIPTION
## Description

- it listed itself relatedTo which would link to itself when clicked

## Tags

Found while writing #1099 

## Screenshot

Here's how it looks before this change 😅 :

![Screen Shot 2020-09-17 at 2 03 19 AM](https://user-images.githubusercontent.com/4970083/93426492-26e5ef80-f88a-11ea-8043-2113001f3c66.png)
