### PR TITLE
fix: allowUnreachableCode default should be undefined

### DIFF
--- a/packages/documentation/copy/en/project-config/Compiler Options.md
+++ b/packages/documentation/copy/en/project-config/Compiler Options.md
@@ -35,7 +35,7 @@ Option                                         | Type      | Default            
 `--allowJs`                                    | `boolean` | `false`                        | Allow JavaScript files to be compiled.
 `--allowSyntheticDefaultImports`               | `boolean` | `module === "system"` or `--esModuleInterop` | Allow default imports from modules with no default export. This does not affect code emit, just typechecking.
 `--allowUmdGlobalAccess`                       | `boolean` | `false`                        | Allow accessing UMD globals from modules.
-`--allowUnreachableCode`                       | `boolean` | `false`                        | Do not report errors on unreachable code.
+`--allowUnreachableCode`                       | `boolean` |                                | Do not report errors on unreachable code.
 `--allowUnusedLabels`                          | `boolean` | `false`                        | Do not report errors on unused labels.
 `--alwaysStrict`                               | `boolean` | `false`                        | Parse in strict mode and emit `"use strict"` for each source file
 `--assumeChangesOnlyAffectDirectDependencies`  | `boolean` | `false`                        | Have recompiles in `--incremental` and `--watch` assume that changes within a file will only affect files directly depending on it


### PR DESCRIPTION
## Description 

- it was recently changed to undefined in the TSConfig Reference in
  ea8407c28fee7555446a869c095f2a4d2bab1ed4
  - this carries over that change to the Compiler Options docs as well

- and it being undefined seems to align with my past experience with
  unreachable code in TS, but have not tested directly recently

## Tags

Found while investigating discrepancies between the TSConfig Reference and Compiler Options after finding #1092 

This goes along with the changes to the Reference in #776