### PR TITLE
feat: add relatedTo for `jsx` in TSConfig Reference

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -82,8 +82,9 @@ export const relatedTo: [AnOption, AnOption[]][] = [
 
   ["moduleResolution", ["module"]],
 
-  ["jsxFactory", ["jsxFragmentFactory"]],
-  ["jsxFragmentFactory", ["jsxFactory"]],
+  ["jsx", ["jsxFactory", "jsxFragmentFactory"]],
+  ["jsxFactory", ["jsx", "jsxFragmentFactory"]],
+  ["jsxFragmentFactory", ["jsx", "jsxFactory"]],
 ];
 
 /**


### PR DESCRIPTION
## Description

- jsxFactory and jsxFragmentFactory are relatedTo each other, so would
  think jsx itself should be as well

## Tags

Found that it was missing during #1102 and #1099 

## Review Notes

Feel free to close this if they shouldn't be `relatedTo`