### PR TITLE
fix: incremental is default true only if composite is

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -117,7 +117,7 @@ export const defaultsForOptions = {
   generateCpuProfile: " profile.cpuprofile",
   importHelpers: "false",
   includes: ' `[]` if `files` is specified, otherwise `["**/*"]`',
-  incremental: "true",
+  incremental: "`true` if `composite`, `false` otherwise",
   inlineSourceMap: "false",
   inlineSources: "false",
   isolatedModules: "false",


### PR DESCRIPTION
## Description

- Compiler Options docs specify this behavior as such
  - which I assume means if composite is false, incremental is also
    false unless set explicitly, but I have never used it myself

## Tags

Similar to #1102 and #1101 , found while investigating discrepancies between the TSConfig Reference and Compiler Options after finding #1092 

## Review Notes

I've not actually used this option per the description, so I haven't tested to see which is accurate. Perhaps the TSConfig Reference was correct and the Compiler Options docs were wrong and so this alignment change should be inverted
