### PR TITLE
Twoslash perf improvements

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,6 +51,9 @@ jobs:
       - name: "Validates that TypeScript plugins work"
         run: npm init typescript-playground-plugin playground-my-plugin
 
+      - name: "Copy PR JSON"
+        run: cp $GITHUB_EVENT_PATH ${{ github.workspace }}/packages/typescriptlang-org/public/pr.json
+
       - uses: actions/upload-artifact@v2
         with:
           name: built-site

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -12,7 +12,8 @@ import { readFileSync } from "fs"
 
 export default () => {
   // JSON reference: https://github.com/haya14busa/github-actions-playground/runs/987846369
-  const contextText = readFileSync(process.env.GITHUB_EVENT_PATH, "utf8")
+  const contextText = readFileSync("built/public/pr.json", "utf8")
+  console.log(contextText)
   const context = JSON.parse(contextText)
 
   const repo = { owner: context.event.repository.owner.login, repo: context.event.repository.name }

--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -12,7 +12,7 @@ import {
   createDragBar,
   setupSidebarToggle,
 } from "./createElements"
-import { runWithCustomLogs } from "./sidebar/runtime"
+import { runWithCustomLogs, clearLogs } from "./sidebar/runtime"
 import { createExporter } from "./exporter"
 import { createUI } from "./createUI"
 import { getExampleSourceCode } from "./getExample"

--- a/packages/playground/src/sidebar/runtime.ts
+++ b/packages/playground/src/sidebar/runtime.ts
@@ -151,7 +151,9 @@ function rewireLoggingToElement(
       textRep = '"' + arg + '"'
     } else if (isObj) {
       const name = arg.constructor && arg.constructor.name
-      const prefix = name ? `${name}: ` : ""
+      // No one needs to know an obj is an obj
+      const nameWithoutObject = name && name === "Object" ? "" : name
+      const prefix = nameWithoutObject ? `${nameWithoutObject}: ` : ""
       textRep = prefix + JSON.stringify(arg, null, 2)
     } else {
       textRep = arg as any

--- a/packages/playground/src/sidebar/runtime.ts
+++ b/packages/playground/src/sidebar/runtime.ts
@@ -1,13 +1,21 @@
+import { Sandbox } from "typescriptlang-org/static/js/sandbox"
 import { PlaygroundPlugin, PluginFactory } from ".."
+import { createUI, UI } from "../createUI"
 import { localize } from "../localizeWithFallback"
 
 let allLogs = ""
+let addedClearAction = false
 
 export const runPlugin: PluginFactory = (i, utils) => {
   const plugin: PlaygroundPlugin = {
     id: "logs",
     displayName: i("play_sidebar_logs"),
     willMount: (sandbox, container) => {
+      if (!addedClearAction) {
+        const ui = createUI()
+        addClearAction(sandbox, ui, i)
+      }
+
       if (allLogs.length === 0) {
         const noErrorsMessage = document.createElement("div")
         noErrorsMessage.id = "empty-message-container"
@@ -31,6 +39,14 @@ export const runPlugin: PluginFactory = (i, utils) => {
   }
 
   return plugin
+}
+
+export const clearLogs = () => {
+  allLogs = ""
+  const logs = document.getElementById("log")
+  if (logs) {
+    logs.textContent = ""
+  }
 }
 
 export const runWithCustomLogs = (closure: Promise<string>, i: Function) => {
@@ -62,6 +78,9 @@ function rewireLoggingToElement(
   fixLoggingFunc("warn", "WRN")
   fixLoggingFunc("error", "ERR")
   fixLoggingFunc("info", "INF")
+  // @ts-expect-error
+  console["oldclear"] = console.clear
+  console.clear = clearLogs
 
   closure.then(js => {
     try {
@@ -73,11 +92,14 @@ function rewireLoggingToElement(
 
     allLogs = allLogs + "<hr />"
 
+    // @ts-expect-error
+    console["clear"] = console["oldclear"]
     undoLoggingFunc("log")
     undoLoggingFunc("debug")
     undoLoggingFunc("warn")
     undoLoggingFunc("error")
     undoLoggingFunc("info")
+    undoLoggingFunc("clear")
   })
 
   function undoLoggingFunc(name: string) {
@@ -113,22 +135,54 @@ function rewireLoggingToElement(
     }
   }
 
+  const objectToText = (arg: any): string => {
+    const isObj = typeof arg === "object"
+    let textRep = ""
+    if (arg && arg.stack && arg.message) {
+      // special case for err
+      textRep = arg.message
+    } else if (arg === null) {
+      textRep = "<span class='literal'>null</span>"
+    } else if (arg === undefined) {
+      textRep = "<span class='literal'>undefined</span>"
+    } else if (Array.isArray(arg)) {
+      textRep = "[" + arg.map(objectToText).join("<span class='comma'>, </span>") + "]"
+    } else if (typeof arg === "string") {
+      textRep = '"' + arg + '"'
+    } else if (isObj) {
+      const name = arg.constructor && arg.constructor.name
+      const prefix = name ? `${name}: ` : ""
+      textRep = prefix + JSON.stringify(arg, null, 2)
+    } else {
+      textRep = arg as any
+    }
+    return textRep
+  }
+
   function produceOutput(args: any[]) {
     return args.reduce((output: any, arg: any, index) => {
-      const isObj = typeof arg === "object"
-      let textRep = ""
-      if (arg && arg.stack && arg.message) {
-        // special case for err
-        textRep = arg.message
-      } else if (isObj) {
-        textRep = JSON.stringify(arg, null, 2)
-      } else {
-        textRep = arg as any
-      }
-
+      const textRep = objectToText(arg)
       const showComma = index !== args.length - 1
       const comma = showComma ? "<span class='comma'>, </span>" : ""
       return output + textRep + comma + "&nbsp;"
     }, "")
   }
+}
+
+const addClearAction = (sandbox: Sandbox, ui: UI, i: any) => {
+  const clearLogsAction = {
+    id: "clear-logs-play",
+    label: "Clear Playground Logs",
+    keybindings: [sandbox.monaco.KeyMod.CtrlCmd | sandbox.monaco.KeyCode.KEY_K],
+
+    contextMenuGroupId: "run",
+    contextMenuOrder: 1.5,
+
+    run: function () {
+      clearLogs()
+      ui.flashInfo(i("play_clear_logs"))
+    },
+  }
+
+  sandbox.editor.addAction(clearLogsAction)
 }

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -200,13 +200,14 @@ export const createTypeScriptSandbox = (
     // Don't update a compiler setting if it's the same
     // as the current setting
     newKeys.forEach(key => {
-      if (compilerOptions[key] === opts[key]) delete opts[key]
+      if (compilerOptions[key] == opts[key]) delete opts[key]
     })
 
     if (!Object.keys(opts).length) return
 
     config.logger.log("[Compiler] Updating compiler options: ", opts)
-    compilerOptions = { ...opts, ...compilerOptions }
+
+    compilerOptions = { ...compilerOptions, ...opts }
     defaults.setCompilerOptions(compilerOptions)
     didUpdateCompilerSettings(compilerOptions)
   }

--- a/packages/sandbox/src/twoslashSupport.ts
+++ b/packages/sandbox/src/twoslashSupport.ts
@@ -12,7 +12,7 @@ type CompilerOptions = import("typescript").CompilerOptions
  */
 
 export const extractTwoSlashComplierOptions = (ts: TS) => {
-  const optMap = new Map<string, any>()
+  let optMap = new Map<string, any>()
 
   // @ts-ignore - optionDeclarations is not public API
   for (const opt of ts.optionDeclarations) {
@@ -26,10 +26,14 @@ export const extractTwoSlashComplierOptions = (ts: TS) => {
     codeLines.forEach(line => {
       let match
       if ((match = booleanConfigRegexp.exec(line))) {
-        options[match[1]] = true
-        setOption(match[1], "true", options, optMap)
+        if (optMap.has(match[1])) {
+          options[match[1]] = true
+          setOption(match[1], "true", options, optMap)
+        }
       } else if ((match = valuedConfigRegexp.exec(line))) {
-        setOption(match[1], match[2], options, optMap)
+        if (optMap.has(match[1])) {
+          setOption(match[1], match[2], options, optMap)
+        }
       }
     })
     return options

--- a/packages/sandbox/src/twoslashSupport.ts
+++ b/packages/sandbox/src/twoslashSupport.ts
@@ -26,12 +26,13 @@ export const extractTwoSlashComplierOptions = (ts: TS) => {
     codeLines.forEach(line => {
       let match
       if ((match = booleanConfigRegexp.exec(line))) {
-        if (optMap.has(match[1])) {
+        if (optMap.has(match[1].toLowerCase())) {
           options[match[1]] = true
           setOption(match[1], "true", options, optMap)
         }
       } else if ((match = valuedConfigRegexp.exec(line))) {
-        if (optMap.has(match[1])) {
+        console.log(match)
+        if (optMap.has(match[1].toLowerCase())) {
           setOption(match[1], match[2], options, optMap)
         }
       }

--- a/packages/sandbox/test/twoslashSupport.test.ts
+++ b/packages/sandbox/test/twoslashSupport.test.ts
@@ -1,13 +1,13 @@
-import { extractTwoSlashComplierOptions } from '../src/twoslashSupport'
-import typescript from 'typescript'
+import { extractTwoSlashComplierOptions } from "../src/twoslashSupport"
+import typescript from "typescript"
 
 const sandboxMock: any = (code: string) => ({
   getText: () => code,
   ts: typescript,
 })
 
-describe('gets twoslash compiler error messages', () => {
-  it('gets the right vars', () => {
+describe("gets twoslash compiler error messages", () => {
+  it.only("gets the right vars", () => {
     const sandbox = sandboxMock(`
 // @noImplicitAny: false
 // @target: ES2015
@@ -23,6 +23,26 @@ fn(42)
     expect(compilerOptions).toMatchInlineSnapshot(`
       Object {
         "noImplicitAny": false,
+        "target": 2,
+      }
+    `)
+  })
+
+  it("ignores unknown vars", () => {
+    const sandbox = sandboxMock(`
+// @noImplicny: false
+// @target: ES2015
+
+// This will not throw because of the noImplicitAny
+function fn(s) {
+  console.log(s.subtr(3))
+}
+
+fn(42)
+`)
+    const compilerOptions = extractTwoSlashComplierOptions(sandbox.ts)(sandbox.getText())
+    expect(compilerOptions).toMatchInlineSnapshot(`
+      Object {
         "target": 2,
       }
     `)

--- a/packages/typescriptlang-org/src/copy/en/playground.ts
+++ b/packages/typescriptlang-org/src/copy/en/playground.ts
@@ -47,6 +47,7 @@ export const playCopy = {
   play_export_sandbox: "Open in CodeSandbox",
   play_export_stackblitz: "Open in StackBlitz",
   play_export_clipboard: "URL copied to clipboard",
+  play_clear_logs: "Logs cleared",
   play_run_js: "Executed JavaScript",
   play_run_ts: "Executed transpiled TypeScript",
   play_run_js_fail: "Executed JavaScript Failed:",


### PR DESCRIPTION
Previously a twoslash annotation could cause re-creating all the web workers on every keypress... Not exactly efficient. Looks like I missed the log clearing code in #1108 too