### PR TITLE
Fixed example that should fail

### DIFF
--- a/packages/documentation/copy/en/handbook-v1/Interfaces.md
+++ b/packages/documentation/copy/en/handbook-v1/Interfaces.md
@@ -254,6 +254,7 @@ The above workaround will work as long as you have a common property between `sq
 In this example, it was the property `width`. It will however, fail if the variable does not have any common object property. For example:
 
 ```ts twoslash
+// @errors: 2559
 interface SquareConfig {
   color?: string;
   width?: number;

--- a/packages/documentation/copy/en/handbook-v1/Interfaces.md
+++ b/packages/documentation/copy/en/handbook-v1/Interfaces.md
@@ -257,7 +257,6 @@ In this example, it was the property `width`. It will however, fail if the varia
 interface SquareConfig {
   color?: string;
   width?: number;
-  [propName: string]: any;
 }
 
 function createSquare(config: SquareConfig): { color: string; area: number } {


### PR DESCRIPTION
The text tells us:
`The above workaround will work as long as you have a common property between squareOptions and SquareConfig. In this example, it was the property width. It will however, fail if the variable does not have any common object property. For example:`

and then comes an example that in fact not fail, but works fine. Changed the example to fail instead, as intended in its description text.