### PR TITLE
Fixed typeof type guard documentation

### DIFF
--- a/packages/documentation/copy/en/reference/Advanced Types.md
+++ b/packages/documentation/copy/en/reference/Advanced Types.md
@@ -158,7 +158,7 @@ function padLeft(value: string, padding: string | number) {
 }
 ```
 
-These _`typeof` type guards_ are recognized in two different forms: `typeof v === "typename"` and `typeof v !== "typename"`, where `"typename"` must be `"number"`, `"string"`, `"boolean"`, or `"symbol"`.
+These _`typeof` type guards_ are recognized in two different forms: `typeof v === "typename"` and `typeof v !== "typename"`, where `"typename"` can be one of [`typeof` operator's return values](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#Description) (`"undefined"`, `"number"`, `"string"`, `"boolean"`, `"bigint"`, `"symbol"`, `"object"`, or `"function"`).
 While TypeScript won't stop you from comparing to other strings, the language won't recognize those expressions as type guards.
 
 ## `instanceof` type guards


### PR DESCRIPTION
The `typeof` operator works as a type guard with all the values it returns. The compiler successfully infers the types in all these functions:
```typescript
function f1(a: string | { [key: string]: string }): string {
  return typeof a === 'object' ? a['foo']: a;
}

function f2(a: string | (() => string)): string {
  return typeof a === 'function' ? a() : a;
}

function f3(a: string | null): string {
  return typeof a === 'object' ? String(a): a;
}


function f4(a: string | undefined): string {
  return typeof a === 'undefined' ? String(a): a;
}

function f5(a: string | bigint): string {
  return typeof a === 'bigint' ? a.toString(): a;
}
```