### PR TITLE
Fix gramatical error "then" to "than"

### DIFF
--- a/packages/documentation/copy/en/reference/Mixins.md
+++ b/packages/documentation/copy/en/reference/Mixins.md
@@ -246,7 +246,7 @@ playerTwo.shouldFreeze;
 
 #### Static Property Mixins [`#17829`](https://github.com/microsoft/TypeScript/issues/17829)
 
-More of a gotcha then a constraint.
+More of a gotcha than a constraint.
 The class expression pattern creates singletons, so they can't be mapped at the type system to support different variable types.
 
 You can work around this by using functions to return your classes which differ based on a generic:


### PR DESCRIPTION
"Then" declares order, and "than" declares comparison. Fixed the choice of word.