### PR TITLE
Fix variable name in Advanced Types reference material

### DIFF
--- a/packages/documentation/copy/en/reference/Advanced Types.md
+++ b/packages/documentation/copy/en/reference/Advanced Types.md
@@ -228,8 +228,8 @@ You can include them explicitly using a union type:
 
 ```ts twoslash
 // @errors: 2322
-let examapleString = "foo";
-examapleString = null;
+let exampleString = "foo";
+exampleString = null;
 
 let stringOrNull: string | null = "bar";
 stringOrNull = null;


### PR DESCRIPTION
Fix variable name in Advanced Types reference material