### PR TITLE
fix: Typo: 'synonomous' should be 'synonymous'

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -193,7 +193,7 @@ export const allowedValues = {
   target: [
     "`ES3` (default)",
     "`ES5`",
-    "`ES6`/`ES2015` (synonomous)",
+    "`ES6`/`ES2015` (synonymous)",
     "`ES7`/`ES2016`",
     "`ES2017`",
     "`ES2018`",


### PR DESCRIPTION
I'm using the default (`v2`) branch as the destination.  Hope that's correct.  If not, I can adjust.  Thanks!