### PR TITLE
Update Modules.md

### DIFF
--- a/packages/documentation/copy/en/reference/Modules.md
+++ b/packages/documentation/copy/en/reference/Modules.md
@@ -316,7 +316,7 @@ define(["require", "exports", "./mod"], function (require, exports, mod_1) {
 ##### CommonJS / Node SimpleModule.js
 
 ```js
-var mod_1 = require("./mod");
+var mod_1 = require("./mod.js");
 exports.t = mod_1.something + 1;
 ```
 


### PR DESCRIPTION
According to https://nodejs.org/api/esm.html#esm_differences_between_es_modules_and_commonjs, filename extension is required for ES modules.