### PR TITLE
Children should be typedchecked as React.ReactNode

### DIFF
--- a/packages/documentation/copy/en/reference/JSX.md
+++ b/packages/documentation/copy/en/reference/JSX.md
@@ -140,7 +140,7 @@ Because a Function Component is simply a JavaScript function, function overloads
 
 ```ts
 interface ClickableProps {
-  children: JSX.Element[] | JSX.Element
+  children: React.ReactNode
 }
 
 interface HomeProps extends ClickableProps {


### PR DESCRIPTION
It is recomended to cover all the edge cases.
Reference: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L825

I'm happy to create a new section stating how react props with children should be typed by default. But I think in the rest of the examples it should be encouraged to use ReactNode 😃 