### PR TITLE
Update Modules.md

### DIFF
--- a/packages/documentation/copy/en/reference/Modules.md
+++ b/packages/documentation/copy/en/reference/Modules.md
@@ -358,7 +358,7 @@ System.register(["./mod"], function (exports_1) {
 ##### Native ECMAScript 2015 modules SimpleModule.js
 
 ```js
-import { something } from "./mod";
+import { something } from "./mod.js";
 export var t = something + 1;
 ```
 


### PR DESCRIPTION
According to https://nodejs.org/api/esm.html#esm_differences_between_es_modules_and_commonjs, filename extension is required for ES modules.