### PR TITLE
remove search box outline

### DIFF
--- a/packages/typescriptlang-org/src/components/search/SearchArea.scss
+++ b/packages/typescriptlang-org/src/components/search/SearchArea.scss
@@ -22,6 +22,10 @@
   padding-bottom: 0.5rem;
 }
 
+input#search-box-top:focus {
+  outline: none;
+}
+
 .searchInput {
   background: none;
   border: none;


### PR DESCRIPTION
remove the rounded border outline around the search box when it has focus


![image](https://user-images.githubusercontent.com/1202528/94930100-ee523280-0493-11eb-8b76-d1356d46f209.png)

to


![image](https://user-images.githubusercontent.com/1202528/94930315-396c4580-0494-11eb-8a2a-bd6b4459cf98.png)


cc @orta