### PR TITLE
Fixes broken link in playground example

### DIFF
--- a/packages/playground-examples/copy/en/JavaScript/Modern JavaScript/Immutability.ts
+++ b/packages/playground-examples/copy/en/JavaScript/Modern JavaScript/Immutability.ts
@@ -54,4 +54,4 @@ myFrozenArray.push("World");
 // section of the examples:
 //
 // example:literals
-// example:type-type-widening-and-narrowing
+// example:type-widening-and-narrowing

--- a/packages/playground-examples/copy/pt/JavaScript/Modern JavaScript/Immutability.ts
+++ b/packages/playground-examples/copy/pt/JavaScript/Modern JavaScript/Immutability.ts
@@ -54,4 +54,4 @@ meuArrayCongelado.push("Mundo");
 // na seção de exemplos do TypeScript:
 //
 // example:literals
-// example:type-type-widening-and-narrowing
+// example:type-widening-and-narrowing


### PR DESCRIPTION
# Description
Hello TypeScript team! This PR fixes the broken example link in this [page](https://www.typescriptlang.org/play?target=1#example/immutability). The link is `example:type-type-widening-and-narrowing` but the right link should be `example:type-widening-and-narrowing`.

# Screenshots
## Image of the broken link
![Screen Shot 2020-10-04 at 9 02 01 AM](https://user-images.githubusercontent.com/9213155/95004629-79603380-0620-11eb-8eaf-77495da5aaae.png)
## Image of the result of this branch fixing the issue
![Screen Shot 2020-10-04 at 9 04 45 AM](https://user-images.githubusercontent.com/9213155/95004643-ac0a2c00-0620-11eb-97b1-9ff6a466f2b2.png)

