### PR TITLE
Fixes broken link in the Getting Started section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Some useful knowledge you need to know:
 
 You can manually via GH Actions for [production here](https://github.com/microsoft/TypeScript-Website/actions?query=workflow%3A%22Monday+Website+Push+To+Production%22) and [staging here](https://github.com/microsoft/TypeScript-Website/actions?query=workflow%3A%22Build+Website+To+Staging%22).
 
-Having issues getting set up? [Consult the troubleshooting](./docs/Setup Troubleshooting.md).
+Having issues getting set up? [Consult the troubleshooting](./docs/Setup%20Troubleshooting.md).
 
 ## Deployment
 


### PR DESCRIPTION
# Description
Good day, TypeScript team! 🚀   This very small PR fixes the broken link in the Getting Started section of the README.

# Screenshots
## Image of the broken link in README
![Screen Shot 2020-10-04 at 9 08 27 AM](https://user-images.githubusercontent.com/9213155/95004723-b5e05f00-0621-11eb-88ea-1e38000e624d.png)
## Image of the result of the fix being applied
![Screen Shot 2020-10-04 at 9 10 07 AM](https://user-images.githubusercontent.com/9213155/95004727-d90b0e80-0621-11eb-8913-001d7531268f.png)
