### PR TITLE
add noop catch for duplicate module paths

### DIFF
--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -160,12 +160,9 @@ export const createTypeScriptSandbox = (
   // In the future it'd be good to add support for an 'add many files'
   const addLibraryToRuntime = (code: string, path: string) => {
     defaults.addExtraLib(code, path)
-    try {
-      monaco.editor.createModel(code, "javascript", monaco.Uri.file(path))
-    } catch (err) {
-      if (err?.message === 'Cannot add model because it already exists!') {
-        // noop skip
-      }
+    const uri = monaco.Uri.file(path)
+    if (monaco.editor.getModel(uri) === null) {
+      monaco.editor.createModel(code, "javascript", uri)
     }
     config.logger.log(`[ATA] Adding ${path} to runtime`)
   }

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -160,7 +160,13 @@ export const createTypeScriptSandbox = (
   // In the future it'd be good to add support for an 'add many files'
   const addLibraryToRuntime = (code: string, path: string) => {
     defaults.addExtraLib(code, path)
-    monaco.editor.createModel(code, "javascript", monaco.Uri.file(path))
+    try {
+      monaco.editor.createModel(code, "javascript", monaco.Uri.file(path))
+    } catch (err) {
+      if (err?.message === 'Cannot add model because it already exists!') {
+        // noop skip
+      }
+    }
     config.logger.log(`[ATA] Adding ${path} to runtime`)
   }
 


### PR DESCRIPTION
fixes #1208 

catching and noop seems to work fine for this error; not sure if there is a way to check for an existing model; will spend a little more time combing through monaco api but this solution works for now