### PR TITLE
Adds CSS for markdown tables

### DIFF
--- a/packages/documentation/copy/en/reference/JSX.md
+++ b/packages/documentation/copy/en/reference/JSX.md
@@ -184,7 +184,7 @@ var myComponent = new MyComponent();
 
 function MyFactoryFunction() {
   return {
-    render: () => {}
+    render: () => {},
   };
 }
 
@@ -378,18 +378,26 @@ It is a black box.
 JSX allows you to embed expressions between tags by surrounding the expressions with curly braces (`{ }`).
 
 ```ts
-var a = <div>
-  {["foo", "bar"].map(i => <span>{i / 2}</span>)}
-</div>
+var a = (
+  <div>
+    {["foo", "bar"].map((i) => (
+      <span>{i / 2}</span>
+    ))}
+  </div>
+);
 ```
 
 The above code will result in an error since you cannot divide a string by a number.
 The output, when using the `preserve` option, looks like:
 
 ```ts
-var a = <div>
-  {["foo", "bar"].map(function (i) { return <span>{i / 2}</span>; })}
-</div>
+var a = (
+  <div>
+    {["foo", "bar"].map(function (i) {
+      return <span>{i / 2}</span>;
+    })}
+  </div>
+);
 ```
 
 ## React integration

--- a/packages/typescriptlang-org/src/components/layout/main.scss
+++ b/packages/typescriptlang-org/src/components/layout/main.scss
@@ -5,6 +5,7 @@
   --background-color: #{$ts-dark-bg-color};
   --text-color: #fff;
   --border-color: #444;
+  --background-minor-highlight-color: #343434;
   --inline-code-background-color: rgb(58, 58, 92);
   --link-color: #{$ts-main-blue-lightest-color};
   --raised-background-color: #{$ts-dark-bg-for-foreground-color};
@@ -41,6 +42,7 @@ html.light-theme {
   --background-color: #{$ts-light-bg-sandy-color};
   --text-color: #333;
   --border-color: #eee;
+  --background-minor-highlight-color: #fcfcfc;
   --inline-code-background-color: rgb(241, 241, 254);
   --link-color: #{$ts-main-blue-darker-color};
   --raised-background-color: #fff;

--- a/packages/typescriptlang-org/src/components/layout/main.scss
+++ b/packages/typescriptlang-org/src/components/layout/main.scss
@@ -4,6 +4,7 @@
 .dark-theme {
   --background-color: #{$ts-dark-bg-color};
   --text-color: #fff;
+  --border-color: #444;
   --inline-code-background-color: rgb(58, 58, 92);
   --link-color: #{$ts-main-blue-lightest-color};
   --raised-background-color: #{$ts-dark-bg-for-foreground-color};
@@ -39,6 +40,7 @@ html.light-theme {
   // light theme
   --background-color: #{$ts-light-bg-sandy-color};
   --text-color: #333;
+  --border-color: #eee;
   --inline-code-background-color: rgb(241, 241, 254);
   --link-color: #{$ts-main-blue-darker-color};
   --raised-background-color: #fff;

--- a/packages/typescriptlang-org/src/templates/markdown.scss
+++ b/packages/typescriptlang-org/src/templates/markdown.scss
@@ -39,8 +39,32 @@
 
   table {
     max-width: 100%;
+    width: 100%;
     overflow-x: auto;
     display: block;
+    table-layout: auto;
+    font-size: 0.875rem;
+    border-collapse: separate;
+    border-spacing: 0;
+
+    td,
+    th {
+      text-align: left;
+      display: table-cell;
+      word-wrap: break-word;
+      padding: 0.75rem 1rem;
+      line-height: 1.5;
+      vertical-align: top;
+      border-top: 1px solid hsla(0, 0%, 89%, 1);
+      border-top: 1px solid var(--border-color);
+      border-right: 0;
+      border-left: 0;
+      border-bottom: 0;
+      border-style: solid;
+    }
+    th {
+      border-top: none;
+    }
   }
 
   img {

--- a/packages/typescriptlang-org/src/templates/markdown.scss
+++ b/packages/typescriptlang-org/src/templates/markdown.scss
@@ -62,6 +62,9 @@
       border-bottom: 0;
       border-style: solid;
     }
+    tr:nth-child(2n) {
+      background-color: var(--background-minor-highlight-color);
+    }
     th {
       border-top: none;
     }


### PR DESCRIPTION
Fixes #1221 - we used to leave the table styling to be the browser's default, this ended up meh - so I mixed some of the bits I like from GitHub and Microsoft Docs

#### Before
![https://user-images.githubusercontent.com/972891/95396224-471b3400-08b5-11eb-9a91-83f5b898affb.png](https://user-images.githubusercontent.com/972891/95396224-471b3400-08b5-11eb-9a91-83f5b898affb.png)

#### After
![Screen Shot 2020-10-08 at 11 37 22 AM](https://user-images.githubusercontent.com/49038/95481159-b26b1180-095a-11eb-9b95-d8a1c454e385.png)
![Screen Shot 2020-10-08 at 11 37 13 AM](https://user-images.githubusercontent.com/49038/95481161-b303a800-095a-11eb-858e-98a7ac523e22.png)

----

Also makes the massive CLI options table feel better:

![Screen Shot 2020-10-08 at 11 36 48 AM](https://user-images.githubusercontent.com/49038/95481339-e3e3dd00-095a-11eb-98db-27d38b793657.png)
