### PR TITLE
Fix: minor typo in link to /tsconfig page

### DIFF
--- a/packages/documentation/copy/en/tutorials/Babel with TypeScript.md
+++ b/packages/documentation/copy/en/tutorials/Babel with TypeScript.md
@@ -31,7 +31,7 @@ The downside to using babel is that you don't get type checking during the trans
 
 In addition to that, Babel cannot create `.d.ts` files for your TypeScript which can make it harder to work with your project if it is a library.
 
-To fix these issues, you would probably want to set up a command to type check your project using TSC. This likely means duplicating some of your babel config into a corresponding [`tsconfig.json`](/tconfig) and ensuring these flags are enabled:
+To fix these issues, you would probably want to set up a command to type check your project using TSC. This likely means duplicating some of your babel config into a corresponding [`tsconfig.json`](/tsconfig) and ensuring these flags are enabled:
 
 ```json tsconfig
 "compilerOptions": {


### PR DESCRIPTION
Broken link found at the end of the section [here](https://www.typescriptlang.org/docs/handbook/babel-with-typescript.html#type-checking-and-dts-file-generation).

Currently getting:

>The resource you are looking for has been removed, had its name changed, or is temporarily unavailable.

Fixing from '/tconfig' to '/tsconfig'