### PR TITLE
docs(i18n-id): Provide Indonesian translation for documentation 

### DIFF
--- a/packages/documentation/copy/id/Nightly Builds.md
+++ b/packages/documentation/copy/id/Nightly Builds.md
@@ -1,0 +1,80 @@
+---
+title: Nightly Builds
+layout: docs
+permalink: /id/docs/handbook/nightly-builds.html
+oneline: Cara menggunakan nightly build TypeScript
+translatable: true
+---
+
+Nightly build dari branch [master TypeScript](https://github.com/Microsoft/TypeScript/tree/master) diterbitkan pada tengah malam, di zona waktu PST ke npm.
+Berikut adalah cara untuk mendapatkan versi ini dan cara menggunakannya.
+
+## Menggunakan npm
+
+```shell
+npm install -g typescript@next
+```
+
+## Memperbarui IDE-mu untuk menggunakan nightly builds
+
+Anda juga dapat memperbarui IDE-mu untuk menggunakan nightly drop.
+Pertama, anda akan perlu untuk memasang package melalui npm.
+Anda juga dapat memasang npm package secara global atau pada folder `node_modules` di dalam proyek-mu.
+
+Pada tahap ini diasumsikan bahwa `typescript@next` sudah di-install.
+
+### Visual Studio Code
+
+Perbarui `.vscode/settings.json` dengan cara berikut:
+
+```json
+"typescript.tsdk": "<path ke folder-mu>/node_modules/typescript/lib"
+```
+
+Informasi lebih lanjut ada di [VSCode documentation](https://code.visualstudio.com/Docs/languages/typescript#_using-newer-typescript-versions).
+
+### Sublime Text
+
+Perbarui file `Settings - User` dengan cara berikut:
+
+```json
+"typescript_tsdk": "<path ke folder-mu>/node_modules/typescript/lib"
+```
+
+Informasi lebih lanjut ada di [TypeScript Plugin for Sublime Text installation documentation](https://github.com/Microsoft/TypeScript-Sublime-Plugin#installation).
+
+### Visual Studio 2013 dan 2015
+
+> Catatan: Sebagian besar perubahan tidak mengharuskan anda untuk memasang versi terbaru dari plugin VS TypeScript.
+
+Saat ini, Nightly build tidak menyertakan plugin secara lengkap, tapi kami sedang mengupayakan untuk menerbitkan sebuah installer di nightly.
+
+1. Unduh skrip [VSDevMode.ps1](https://github.com/Microsoft/TypeScript/blob/master/scripts/VSDevMode.ps1) script.
+
+   > Lihat juga halaman wiki kami di [menggunakan custom language service file](https://github.com/Microsoft/TypeScript/wiki/Dev-Mode-in-Visual-Studio#using-a-custom-language-service-file).
+
+2. Melalui perintah PowerShell, jalankan:
+
+Untuk VS 2015:
+
+```posh
+VSDevMode.ps1 14 -tsScript <path ke folder-mu>/node_modules/typescript/lib
+```
+
+Untuk VS 2013:
+
+```posh
+VSDevMode.ps1 12 -tsScript <path ke folder-mu>/node_modules/typescript/lib
+```
+
+### IntelliJ IDEA (Mac)
+
+Masuk ke `Preferences` > `Languages & Frameworks` > `TypeScript`:
+
+> TypeScript Version: Jika anda memasangnya dengan npm, maka akan ada di `/usr/local/lib/node_modules/typescript/lib`
+
+### IntelliJ IDEA (Windows)
+
+Masuk ke `File` > `Settings` > `Languages & Frameworks` > `TypeScript`:
+
+> TypeScript Version: Jika anda memasangnya dengan npm, maka akan ada di `C:\Users\USERNAME\AppData\Roaming\npm\node_modules\typescript\lib`

--- a/packages/documentation/copy/id/javascript/Creating DTS files From JS.md
+++ b/packages/documentation/copy/id/javascript/Creating DTS files From JS.md
@@ -1,0 +1,87 @@
+---
+title: Creating .d.ts Files from .js files
+layout: docs
+permalink: /id/docs/handbook/declaration-files/dts-from-js.html
+oneline: "Bagaimana cara menambahkan hasil d.ts ke proyek JavaScript"
+translatable: true
+---
+
+[Dengan TypeScript 3.7](/docs/handbook/release-notes/typescript-3-7.html#--declaration-and---allowjs), TypeScript menambahkan dukungan untuk menghasilkan file .d.ts dari JavaScript menggunakan sintaks JSDoc.
+
+Pengaturan ini berarti Anda memiliki editor yang mendukung TypeScript tanpa memindahkan proyek anda ke TypeScript, atau harus memelihara file .d.ts di basis kodemu.
+TypeScript mendukung sebagian besar tag JSDoc, Anda bisa menemukannya [di referensi ini](/docs/handbook/type-checking-javascript-files.html#supported-jsdoc).
+
+## Menyiapkan proyekmu untuk menggunakan file .d.ts
+
+Untuk menambahkan pembuatan file .d.ts di proyekmu, Anda perlu melakukan hingga empat langkah:
+
+- Tambahkan TypeScript ke dependensi dev Anda
+- Tambahkan `tsconfig.json` untuk mengkonfigurasi TypeScript
+- Jalankan compiler TypeScript untuk menghasilkan file d.ts yang sesuai untuk file JS
+- (opsional) Edit package.json Anda untuk mereferensikan tipe
+
+### Menambahkan TypeScript
+
+Anda bisa mempelajari cara melakukan ini di [halaman instalasi](/download) kami.
+
+### TSConfig
+
+TSConfig adalah file jsonc yang mengkonfigurasi kedua flag compiler Anda, dan menyatakan di mana mencari file.
+Dalam kasus ini, Anda menginginkan file seperti berikut:
+
+```json5
+{
+  // Change this to match your project
+  include: ["src/**/*"],
+
+  compilerOptions: {
+    // Tells TypeScript to read JS files, as
+    // normally they are ignored as source files
+    allowJs: true,
+    // Generate d.ts files
+    declaration: true,
+    // This compiler run should
+    // only output d.ts files
+    emitDeclarationOnly: true,
+    // Types should go into this directory.
+    // Removing this would place the .d.ts files
+    // next to the .js files
+    outDir: "dist",
+  },
+}
+```
+
+Anda dapat mempelajari lebih lanjut tentang opsi di [referensi tsconfig](/reference).
+Alternatif untuk menggunakan file TSConfig adalah CLI, ini adalah perilaku yang sama seperti perintah CLI.
+
+```sh
+npx typescript src/**/*.js --declaration --allowJs --emitDeclarationOnly --outDir types
+```
+
+## Menjalankan compiler
+
+Anda bisa mempelajari bagaimana melakukan ini di [halaman pemasangan](/download) TypeScript kami.
+Anda perlu memastikan file-file ini disertakan dalam package Anda jika Anda memiliki file dalam `gitignore` proyek Anda.
+
+## Meng-edit file package.json
+
+TypeScript mereplikasi resolusi node untuk modul di `package.json`, dengan langkah tambahan untuk menemukan file .d.ts.
+Secara kasar, resolusi pertama-tama akan memeriksa bidang `"types"` opsional, kemudian bidang `"main"`, dan terakhir akan mencoba `index.d.ts` di root.
+
+| Package.json              | Location of default .d.ts      |
+| :------------------------ | :----------------------------- |
+| No "types" field          | checks "main", then index.d.ts |
+| "types": "main.d.ts"      | main.d.ts                      |
+| "types": "./dist/main.js" | ./main/main.d.ts               |
+
+Jika tidak ada, maka "main" akan digunakan
+
+| Package.json             | Location of default .d.ts |
+| :----------------------- | :------------------------ |
+| No "main" field          | index.d.ts                |
+| "main":"index.js"        | index.d.ts                |
+| "main":"./dist/index.js" | ./dist/index.d.ts         |
+
+## Tips
+
+Jika kamu suka menulis tes untuk file .d.ts, coba [tsd](https://github.com/SamVerschueren/tsd).

--- a/packages/documentation/copy/id/javascript/Intro to JS with TS.md
+++ b/packages/documentation/copy/id/javascript/Intro to JS with TS.md
@@ -1,0 +1,70 @@
+---
+title: JS Projects Utilizing TypeScript
+layout: docs
+permalink: /id/docs/handbook/intro-to-js-ts.html
+oneline: Cara menambahkan pemeriksaan type ke file JavaScript menggunakan TypeScript
+translatable: true
+---
+
+Sistem tipe di TypeScript memiliki tingkat keketatan yang berbeda saat bekerja dengan basis kode:
+
+- Sistem tipe yang hanya berdasarkan pada inferensi dengan kode JavaScript
+- Pengetikkan incremental di JavaScript [melalui JSDoc](/docs/handbook/jsdoc-supported-types.html)
+- Menggunakan `// @ts-check` di file JavaScript
+- Kode TypeScript
+- TypeScript dengan [`strict`](/tsconfig#strict) diaktifkan
+
+Setiap langkah mewakili gerakan menuju sistem tipe yang lebih aman, tetapi tidak setiap proyek membutuhkan tingkat verifikasi seperti itu.
+
+## TypeScript dengan JavaScript
+
+Ini ketika editor-mu yang menggunakan TypeScript untuk menyediakan tool, seperti auto-complete, jump to symbil, dan refactoring, misalnya penamaan ulang.
+Di [Homepage](/) tersedia daftar editor yang memiliki plugin TypeScript.
+
+## Menyediakan Type Hints di JS melalui JSDoc
+
+Di file `.js`, type sering kali dapat diketahui. Namun ketika type tidak diketahui, mereka bisa ditentukan menggunakan sintaks JSDoc.
+
+Anotasi JSDoc diletakkan sebelum mendeklarasikan suatu hal. Seperti contoh berikut:
+
+```js twoslash
+/** @type {number} */
+var x;
+
+x = 0; // OK
+x = false; // OK?!
+```
+
+Anda dapat menemukan daftar lengkap mengenai dukungan pola JSDoc [di Tipe-tipe yang didukung JSDoc](/docs/handbook/jsdoc-supported-types.html)
+
+## `@ts-check`
+
+Baris terakhir dari contoh kode sebelumnya akan menimbulkan kesalahan dalam TypeScript, tetapi tidak secara default dalam proyek JS.
+Untuk mengaktifkan error dalam file JavaScript-mu, tambahkan: `// @ ts-check` ke baris pertama dalam file`.js` Anda agar TypeScript dapat memeriksa kesalahan.
+
+```js twoslash
+// @ts-check
+// @errors: 2322
+/** @type {number} */
+var x;
+
+x = 0; // OK
+x = false; // Not OK
+```
+
+Jika anda memiliki banyak file JavaScript yang ingin ditambahkan pemeriksaan error-nya, anda bisa beralhir menggunakan [`jsconfig.json`](/docs/handbook/tsconfig-json.html).
+Dengan begitu, anda tidak perlu menambahkan `// @ts-nocheck` di tiap file-nya.
+
+TypeScript mungkin memberikan error yang kamu tidak sepakati. Pada kasus tersebut, anda bisa membiarkan error itu spesifik dibaris manapun dengan menambahkan `// @ts-ignore` atau `// @ts-expect-error`.
+
+```js twoslash
+// @ts-check
+/** @type {number} */
+var x;
+
+x = 0; // OK
+// @ts-expect-error
+x = false; // Not OK
+```
+
+Untuk mempelajari lebih lanjut bagaimana JavaScript diinterpretasi oleh TypeScript, anda dapat membaca [Bagaimana TS Type Memeriksa JS](/docs/handbook/type-checking-javascript-files.html)

--- a/packages/documentation/copy/id/javascript/JSDoc Reference.md
+++ b/packages/documentation/copy/id/javascript/JSDoc Reference.md
@@ -1,0 +1,693 @@
+---
+title: JSDoc Reference
+layout: docs
+permalink: /id/docs/handbook/jsdoc-supported-types.html
+oneline: JSDoc apa yang didukung JavaScript dan TypeScript?
+translatable: true
+---
+
+Dibawah ini adalah daftar anotasi yang didukung saat menggunakan JSDoc untuk menyediakan informasi di file Javscript.
+
+Perhatikan semua tag yang tidak secara eksplisit dicantumkan di bawah (seperti `@ async`) belum didukung.
+
+- `@type`
+- `@param` (atau `@arg` atau `@argument`)
+- `@returns` (atau `@return`)
+- `@typedef`
+- `@callback`
+- `@template`
+- `@class` (atau `@constructor`)
+- `@this`
+- `@extends` (atau `@augments`)
+- `@enum`
+
+#### Ekstensi `class`
+
+- [Property Modifiers](#jsdoc-property-modifiers) `@public`, `@private`, `@protected`, `@readonly`
+
+Artinya biasanya sama, atau superset, dari arti tag yang diberikan di [jsdoc.app](https://jsdoc.app).
+Kode dibawah mendeskripsikan perbedaan dan beberapa contoh dari setiap tag-nya.
+
+**Catatan:** Anda bisa menggunakan [playground untuk mengeksplor dukungan JSDoc](/play?useJavaScript=truee=4#example/jsdoc-support).
+
+## `@type`
+
+Anda dapat menggunakan tag "@type" dan mereferensikan nama jenis (baik primitif, ditentukan dalam deklarasi TypeScript, atau dalam tag "@typedef" JSDoc).
+Anda dapat menggunakan sebagian besar jenis JSDoc dan jenis TypeScript apa pun, dari [yang paling dasar seperti `string`](/docs/handbookbasic-types.html) hingga [yang paling canggih, seperti jenis bersyarat](/docs/handbook/advanced-types.html).
+
+```js twoslash
+/**
+ * @type {string}
+ */
+var s;
+
+/** @type {Window} */
+var win;
+
+/** @type {PromiseLike<string>} */
+var promisedString;
+
+// Anda dapat menentukan Elemen HTML dengan properti DOM
+/** @type {HTMLElement} */
+var myElement = document.querySelector(selector);
+element.dataset.myData = "";
+```
+
+`@type` dapat menetapkan tipe gabungan &mdash; misalnya, sesuatu bisa berupa string atau boolean.
+
+```js twoslash
+/**
+ * @type {(string | boolean)}
+ */
+var sb;
+```
+
+Perhatikan bahwa tanda kurung bersifat opsional untuk tipe gabungan.
+
+```js twoslash
+/**
+ * @type {string | boolean}
+ */
+var sb;
+```
+
+Anda dapat menentukan tipe array menggunakan berbagai sintaks:
+
+```js twoslash
+/** @type {number[]} */
+var ns;
+/** @type {Array.<number>} */
+var nds;
+/** @type {Array<number>} */
+var nas;
+```
+
+Anda juga dapat menentukan tipe literal objek.
+Misalnya, objek dengan properti 'a' (string) dan 'b' (angka) menggunakan sintaks berikut:
+
+```js twoslash
+/** @type {{ a: string, b: number }} */
+var var9;
+```
+
+Anda dapat menentukan objek seperti map dan array menggunakan index signature string dan angka, menggunakan sintaks JSDoc standar atau sintaks TypeScript.
+
+```js twoslash
+/**
+ * Objek map yang memetakan kunci string dan nilainya bertipe number.
+ *
+ * @type {Object.<string, number>}
+ */
+var stringToNumber;
+
+/** @type {Object.<number, object>} */
+var arrayLike;
+```
+
+Dua jenis sebelumnya sama dengan type TypeScript `{ [x: string]: number }` dan `{ [x: number]: any }`. Compiler memahami kedua sintaks tersebut.
+
+Anda dapat menentukan jenis fungsi menggunakan sintaks TypeScript atau Closure:
+
+```js twoslash
+/** @type {function(string, boolean): number} Closure syntax */
+var sbn;
+/** @type {(s: string, b: boolean) => number} TypeScript syntax */
+var sbn2;
+```
+
+Atau anda dapat menggunakan type `Function` yang tidak ditentukan:
+
+```js twoslash
+/** @type {Function} */
+var fn7;
+/** @type {function} */
+var fn6;
+```
+
+Type lainnya dari Closure juga berfungsi:
+
+```js twoslash
+/**
+ * @type {*} - can be 'any' type
+ */
+var star;
+/**
+ * @type {?} - unknown type (same as 'any')
+ */
+var question;
+```
+
+### Casts
+
+TypeScript meminjam sintaks cast dari Closure.
+Ini memungkinkan Anda mentransmisikan type ke type lain dengan menambahkan tag `@type` sebelum ekspresi dalam tanda kurung.
+
+```js twoslash
+/**
+ * @type {number | string}
+ */
+var numberOrString = Math.random() < 0.5 ? "hello" : 100;
+var typeAssertedNumber = /** @type {number} */ (numberOrString);
+```
+
+### Impor type
+
+Anda bisa juga mengimpor deklarasi dari file lain menggunakan impor type.
+Sintaks ini khusus untuk TypeScript dan berbeda dari standar JSDoc:
+
+```js twoslash
+// @filename: types.d.ts
+export type Pet = {
+  name: string,
+};
+
+// @filename: main.js
+/**
+ * @param p { import("./types").Pet }
+ */
+function walk(p) {
+  console.log(`Walking ${p.name}...`);
+}
+```
+
+mengimpor type juga dapat digunakan di deklarasi type alias:
+
+```js twoslash
+// @filename: types.d.ts
+export type Pet = {
+  name: string,
+};
+// @filename: main.js
+// ---cut---
+/**
+ * @typedef { import("./types").Pet } Pet
+ */
+
+/**
+ * @type {Pet}
+ */
+var myPet;
+myPet.name;
+```
+
+Mengimpor type dapat digunakan untuk mendapatkan type nilai dari module, jika Anda tidak mengetahui jenisnya, atau jika nilai tersebut memiliki type yang besar yang dapat mengganggu untuk diketik:
+
+```js twoslash
+// @filename: accounts.d.ts
+export const userAccount = {
+  name: "Name",
+  address: "An address",
+  postalCode: "",
+  country: "",
+  planet: "",
+  system: "",
+  galaxy: "",
+  universe: "",
+};
+// @filename: main.js
+// ---cut---
+/**
+ * @type {typeof import("./accounts").userAccount }
+ */
+var x = require("./accounts").userAccount;
+```
+
+## `@param` and `@returns`
+
+`@param` menggunakan jenis sintaks yang sama dengan `@type`, tapi dengan tambahan sebuah nama parameter.
+Parameter juga dapat dideklarasikan secara opsional dengan membungkus namanya menggunakan kurung siku:
+
+```js twoslash
+// Parameter dapat dideklarasikan dalam berbagai bentuk sintaksis
+/**
+ * @param {string}  p1 - Parameter string.
+ * @param {string=} p2 - Opsional param (sintaks Closure)
+ * @param {string} [p3] - Opsional param lainnya (sintaks JSDoc).
+ * @param {string} [p4="test"] - Opsional param dengan nilai standar
+ * @return {string} Ini adalah hasilnya
+ */
+function stringsStringStrings(p1, p2, p3, p4) {
+  // MELAKUKAN
+}
+```
+
+Demikian juga, untuk type kembalian suatu fungsi:
+
+```js twoslash
+/**
+ * @return {PromiseLike<string>}
+ */
+function ps() {}
+
+/**
+ * @returns {{ a: string, b: number }} - Dapat menggunakan '@returns' serta '@return'
+ */
+function ab() {}
+```
+
+## `@typedef`, `@callback`, and `@param`
+
+`@ty[edef` juga dapat digunakan untuk mendefinisikan type yang kompleks.
+Sintaks yang bekerja dengan `@params`.
+
+```js twoslash
+/**
+ * @typedef {Object} SpecialType - buat type baru bernama 'SpecialType'
+ * @property {string} prop1 - property string dari SpecialType
+ * @property {number} prop2 - property number dari SpecialType
+ * @property {number=} prop3 - opsional property number dari SpecialType
+ * @prop {number} [prop4] - opsional property number dari SpecialType
+ * @prop {number} [prop5=42] - opsional property number dari SpecialType dengan nilai standar
+ */
+
+/** @type {SpecialType} */
+var specialTypeObject;
+specialTypeObject.prop3;
+```
+
+Anda bisa menggunakan `object` atau `Object` pada baris pertama.
+
+```js twoslash
+/**
+ * @typedef {object} SpecialType1 - buat type baru bernama 'SpecialType'
+ * @property {string} prop1 - property string dari SpecialType
+ * @property {number} prop2 - property number dari SpecialType
+ * @property {number=} prop3 - opsional property number dari SpecialType
+ */
+
+/** @type {SpecialType1} */
+var specialTypeObject1;
+```
+
+`@params` memperbolehkan sintaks yang serupa untuk spesifikasi type-nya.
+Perhatikan bahwa nama nested property harus diawali dengan nama parameternya:
+
+```js twoslash
+/**
+ * @param {Object} options - Bentuknya sama dengan SpecialType di atas
+ * @param {string} options.prop1
+ * @param {number} options.prop2
+ * @param {number=} options.prop3
+ * @param {number} [options.prop4]
+ * @param {number} [options.prop5=42]
+ */
+function special(options) {
+  return (options.prop4 || 1001) + options.prop5;
+}
+```
+
+`@callback` mirip dengan `@typedef`, tetapi ini menetapkan type fungsi daripada type objek:
+
+```js twoslash
+/**
+ * @callback Predicate
+ * @param {string} data
+ * @param {number} [index]
+ * @returns {boolean}
+ */
+
+/** @type {Predicate} */
+const ok = (s) => !(s.length % 2);
+```
+
+Tentu saja, salah satu dari jenis ini dapat dideklarasikan menggunakan sintaks TypeScript dalam satu baris `@typedef`:
+
+```js
+/** @typedef {{ prop1: string, prop2: string, prop3?: number }} SpecialType */
+/** @typedef {(data: string, index?: number) => boolean} Predicate */
+```
+
+## `@template`
+
+Anda dapat mendeklarasikan fungsi generik dengan tag `@template`:
+
+```js twoslash
+/**
+ * @template T
+ * @param {T} x - Parameter umum yang mengalir ke return type
+ * @return {T}
+ */
+function id(x) {
+  return x;
+}
+
+const a = id("string");
+const b = id(123);
+const c = id({});
+```
+
+Gunakan koma atau beberapa tag untuk mendeklarasikan beberapa parameter type:
+
+```js
+/**
+ * @template T,U,V
+ * @template W,X
+ */
+```
+
+Anda juga bisa menentukan batasan type sebelum nama parameternya.
+Hanya parameter type pertama dalam sebuah list yang dibatasi.
+
+```js twoslash
+/**
+ * @template {string} K - K harus berupa string atau string literal
+ * @template {{ serious(): string }} Seriousalizable - harus memiliki method serious
+ * @param {K} key
+ * @param {Seriousalizable} object
+ */
+function seriousalize(key, object) {
+  // ????
+}
+```
+
+Mendeklarasikan kelas generik atau type yang tidak didukung.
+
+## Classes
+
+Kelas yang dapat dideklarasikan sebagai kelas ES6.
+
+```js twoslash
+class C {
+  /**
+   * @param {number} data
+   */
+  constructor(data) {
+    // tipe properti yang bisa diketahui
+    this.name = "foo";
+
+    // atau mengaturnya secara eksplisit
+    /** @type {string | null} */
+    this.title = null;
+
+    // atau hanya diberi anotasi, jika disetel di tempat lain
+    /** @type {number} */
+    this.size;
+
+    this.initialize(data); // Seharusnya error, karena initialize mengharapkan string
+  }
+  /**
+   * @param {string} s
+   */
+  initialize = function (s) {
+    this.size = s.length;
+  };
+}
+
+var c = new C(0);
+
+// C seharusnya hanya dipanggil dengan yang baru,
+// tetapi karena ini adalah JavaScript, ini
+// diperbolehkan dan dianggap sebagai 'any'.
+var result = C(1);
+```
+
+Mereka juga dapat dideklarasikan sebagai fungsi konstruktor, seperti yang dijelaskan di bagian selanjutnya:
+
+## `@constructor`
+
+Compiler menyimpulkan fungsi konstruktor berdasarkan penetapan properti ini, tetapi Anda dapat membuat pemeriksaan lebih ketat dan saran lebih baik jika Anda menambahkan tag `@constructor`:
+
+```js twoslash
+// @checkJs
+// @errors: 2345 2348
+/**
+ * @constructor
+ * @param {number} data
+ */
+function C(data) {
+  // type property yang dapat diketahui
+  this.name = "foo";
+
+  // atau atur secara eksplisit
+  /** @type {string | null} */
+  this.title = null;
+
+  // atau hanya diberi anotasi, jika disetel di tempat lain
+  /** @type {number} */
+  this.size;
+
+  this.initialize(data);
+}
+/**
+ * @param {string} s
+ */
+C.prototype.initialize = function (s) {
+  this.size = s.length;
+};
+
+var c = new C(0);
+c.size;
+
+var result = C(1);
+```
+
+> Catatan: Pesan error hanya tampil di basis kode JS dengan [JSConfig](/docs/handbook/tsconfig-json.html) dan [`checkJS`](/tsconfig#checkJs) yang diaktifkan.
+
+Dengan `@constructor`, `this` diperiksa didalam fungsi konstruktor `C`, jadi anda akan mendapatkan saran untuk method `initialize` dan sebuah error jika anda memasukkan sebuah angka. Editor-mu mungkin akan menampilkan peringatan jika memanggil `C` daripada mengkonstruksikannya.
+
+Sayangnya, ini berarti bahwa fungsi konstruktor yang juga dapat dipanggil tidak dapat menggunakan `@constructor`.
+
+## `@this`
+
+Compiler biasanya dapat mengetahui type `this` ketika ia memiliki beberapa konteks untuk dikerjakan. Jika tidak, Anda dapat secara eksplisit menentukan jenis `this` dengan `@this`:
+
+```js twoslash
+/**
+ * @this {HTMLElement}
+ * @param {*} e
+ */
+function callbackForLater(e) {
+  this.clientHeight = parseInt(e); // seharusnya baik-baik saja!
+}
+```
+
+## `@extends`
+
+Ketika kelas JavaScript memperluas _base class_, tidak ada tempat untuk menentukan seharusnya menggunakan parameter type yang seperti apa. Tag `@extends` menyediakan tempat untuk parameter jenis itu:
+
+```js twoslash
+/**
+ * @template T
+ * @extends {Set<T>}
+ */
+class SortableSet extends Set {
+  // ...
+}
+```
+
+Perhatikan bahwa `@extends` hanya berfungsi dengan kelas. Saat ini, tidak ada cara untuk fungsi konstruktor memperluas kelas.
+
+## `@enum`
+
+Tag `@enum` memungkinkan Anda membuat literal objek yang type anggotanya spesifik. Tidak seperti kebanyakan literal objek di JavaScript, ini tidak mengizinkan anggota lain.
+
+```js twoslash
+/** @enum {number} */
+const JSDocState = {
+  BeginningOfLine: 0,
+  SawAsterisk: 1,
+  SavingComments: 2,
+};
+
+JSDocState.SawAsterisk;
+```
+
+Perhatikan bahwa `@enum` sangat berbeda, dan jauh lebih sederhana daripada `enum` TypeScript. Namun, tidak seperti enum TypeScript, `@enum` dapat memiliki tipe apa saja:
+
+```js twoslash
+/** @enum {function(number): number} */
+const MathFuncs = {
+  add1: (n) => n + 1,
+  id: (n) => -n,
+  sub1: (n) => n - 1,
+};
+
+MathFuncs.add1;
+```
+
+## Lebih banyak contoh
+
+```js twoslash
+class Foo {}
+// ---cut---
+var someObj = {
+  /**
+   * @param {string} param1 - Dokumen tentang tugas property
+   */
+  x: function (param1) {},
+};
+
+/**
+ * Seperti halnya dokumen tentang tugas variabel
+ * @return {Window}
+ */
+let someFunc = function () {};
+
+/**
+ * Dan method kelas
+ * @param {string} greeting Salam untuk digunakan
+ */
+Foo.prototype.sayHi = (greeting) => console.log("Hi!");
+
+/**
+ * Dan ekspresi arrow function
+ * @param {number} x - Pengganda
+ */
+let myArrow = (x) => x * x;
+
+/**
+ * Artinya, ini juga berfungsi untuk komponen fungsi stateless di JSX
+ * @param {{a: string, b: number}} test - Beberapa param
+ */
+var sfc = (test) => <div>{test.a.charAt(0)}</div>;
+
+/**
+ * Parameter bisa menjadi konstruktor kelas, menggunakan sintaks Closure.
+ *
+ * @param {{new(...args: any[]): object}} C - Kelas untuk mendaftar
+ */
+function registerClass(C) {}
+
+/**
+ * @param {...string} p1 - A 'rest' arg (array) of strings. (treated as 'any')
+ */
+function fn10(p1) {}
+
+/**
+ * @param {...string} p1 - A 'rest' arg (array) of strings. (treated as 'any')
+ */
+function fn9(p1) {
+  return p1.join();
+}
+```
+
+## Pola yang diketahui TIDAK didukung
+
+Mengacu pada objek di value space sebagai type yang tidak berfungsi, kecuali objek tersebut juga membuat type, seperti fungsi konstruktor.
+
+```js twoslash
+function aNormalFunction() {}
+/**
+ * @type {aNormalFunction}
+ */
+var wrong;
+/**
+ * Gunakan 'typeof' sebagai gantinya:
+ * @type {typeof aNormalFunction}
+ */
+var right;
+```
+
+Postfix sama dengan type property dalam type literal objek yang tidak menetapkan properti opsional:
+
+```js twoslash
+/**
+ * @type {{ a: string, b: number= }}
+ */
+var wrong;
+/**
+ * Gunakan postfix question pada nama properti sebagai gantinya:
+ * @type {{ a: string, b?: number }}
+ */
+var right;
+```
+
+Jenis Nullable hanya memiliki arti jika `strictNullChecks` aktif:
+
+```js twoslash
+/**
+ * @type {?number}
+ * With strictNullChecks: true  -- number | null
+ * With strictNullChecks: false -- number
+ */
+var nullable;
+```
+
+Anda juga bisa menggunakan tipe gabungan:
+
+```js twoslash
+/**
+ * @type {number | null}
+ * With strictNullChecks: true  -- number | null
+ * With strictNullChecks: false -- number
+ */
+var unionNullable;
+```
+
+Type non-nullable tidak memiliki arti dan diperlakukan seperti jenis aslinya:
+
+```js twoslash
+/**
+ * @type {!number}
+ * Hanya ber-type number
+ */
+var normal;
+```
+
+If it is off, then `number` is nullable.
+Tidak seperti sistem type JSDoc, TypeScript hanya memungkinkan Anda untuk menandai type, apakah mengandung null atau tidak.
+Tidak ada non-nullability eksplisit - jika strictNullChecks aktif, `number` tidak dapat dinihilkan.
+Jika tidak aktif, maka `number` adalah nullable.
+
+### Tag yang tidak didukung
+
+TypeScript mengabaikan semua tag JSDoc yang tidak didukung.
+
+Tag berikut memiliki isu terbuka untuk mendukungnya:
+
+- `@const` ([issue #19672](https://github.com/Microsoft/TypeScript/issues/19672))
+- `@inheritdoc` ([issue #23215](https://github.com/Microsoft/TypeScript/issues/23215))
+- `@memberof` ([issue #7237](https://github.com/Microsoft/TypeScript/issues/7237))
+- `@yields` ([issue #23857](https://github.com/Microsoft/TypeScript/issues/23857))
+- `{@link …}` ([issue #35524](https://github.com/Microsoft/TypeScript/issues/35524))
+
+## Extensi kelas JS
+
+### Modifier Property JSDoc
+
+Dari TypeScript 3.8 dan seterusnya, Anda dapat menggunakan JSDoc untuk mengubah properti kelas. Pertama adalah pengubah aksesibilitas: `@public`,`@private`, dan `@protected`.
+Tag ini bekerja persis seperti `public`,`private`, dan `protected`, masing-masing berfungsi di TypeScript.
+
+```js twoslash
+// @errors: 2341
+// @ts-check
+
+class Car {
+  constructor() {
+    /** @private */
+    this.identifier = 100;
+  }
+
+  printIdentifier() {
+    console.log(this.identifier);
+  }
+}
+
+const c = new Car();
+console.log(c.identifier);
+```
+
+- `@public` ini berarti property dapat diakses dari mana saja.
+- `@private` berarti bahwa properti hanya dapat digunakan di dalam kelas yang memuatnya.
+- `@protected` berarti bahwa properti hanya dapat digunakan di dalam kelas penampung, dan semua subkelas turunan, tetapi tidak pada instance kelas penampung yang berbeda.
+
+Selanjutnya, kita juga telah menambahkan modifier `@readonly` untuk memastikan bahwa sebuah property hanya dapat di-write selama inisialisasi.
+
+```js twoslash
+// @errors: 2540
+// @ts-check
+
+class Car {
+  constructor() {
+    /** @readonly */
+    this.identifier = 100;
+  }
+
+  printIdentifier() {
+    console.log(this.identifier);
+  }
+}
+
+const c = new Car();
+console.log(c.identifier);
+```

--- a/packages/documentation/copy/id/project-config/Configuring Watch.md
+++ b/packages/documentation/copy/id/project-config/Configuring Watch.md
@@ -1,0 +1,66 @@
+---
+title: Configuring Watch
+layout: docs
+permalink: /id/docs/handbook/configuring-watch.html
+oneline: Cara mengkonfigurasi mode watch TypeScript
+translatable: true
+---
+
+Compiler mendukung konfigurasi cara mengawasi file dan direktori menggunakan compiler flags di TypeScript 3.8+, dan variabel environment.
+
+## Latar Belakang
+
+Implementasi `--watch` dari compiter bergantung pada penggunaan `fs.watch` dan `fs.watchFile` yang disediakan oleh node, kedua metode ini memiliki kelebihan dan kekurangan.
+
+`fs.watch` menggunakan system event file untuk memberi tahu perubahan dalam file/direktori. Tetapi ini bergantung pada OS dan notifikasi tidak sepenuhnya dapat diandalkan dan tidak berfungsi seperti yang diharapkan pada banyak OS. Juga mungkin ada batasan jumlah watch yang dapat dibuat, misalnya. linux dan kami dapat melakukannya dengan cukup cepat dengan program yang menyertakan banyak file. Tetapi karena ini menggunakan system event file, tidak banyak siklus CPU yang terlibat. Compiler biasanya menggunakan `fs.watch` untuk melihat direktori (misalnya. Direktori sumber disertakan oleh file konfigurasi, direktori di mana resolusi modul gagal, dll.) Ini dapat menangani ketepatan yang hilang dalam memberi tahu tentang perubahan. Tetapi memantau secara rekursif hanya didukung pada Windows dan OSX. Artinya kita membutuhkan sesuatu untuk menggantikan sifat rekursif di OS lain.
+
+`fs.watchFile` menggunakan polling dan karenanya melibatkan siklus CPU. Tetapi ini adalah mekanisme yang paling andal untuk mendapatkan pembaruan status file/direktori. Compiler biasanya menggunakan `fs.watchFile` untuk melihat file sumber, file konfigurasi dan file yang hilang (referensi file hilang) yang berarti penggunaan CPU bergantung pada jumlah file dalam program.
+
+## Konfigurasi file watching menggunakan `tsconfig.json`
+
+```json tsconfig
+{
+  // Beberapa opsi compiler umumnya
+  "compilerOptions": {
+    "target": "es2020",
+    "moduleResolution": "node"
+    // ...
+  },
+
+  // BARU: Opsi untuk memantau file/direktori
+  "watchOptions": {
+    // Gunakan native file system events untuk file dan direktori
+    "watchFile": "useFsEvents",
+    "watchDirectory": "useFsEvents",
+
+    // Dapatkan pembaruan file
+    // ketika terdapat update yang besar.
+    "fallbackPolling": "dynamicPriority"
+  }
+}
+```
+
+Anda dapat membacanya lebih lanjut di [catatan rilis](/docs/handbook/release-notes/typescript-3-8.html#better-directory-watching-on-linux-and-watchoptions).
+
+## Konfigurasi file watching menggunakan variabel environment `TSC_WATCHFILE`
+
+<!-- prettier-ignore -->
+Opsi                                         | Deskripsi
+-----------------------------------------------|----------------------------------------------------------------------
+`PriorityPollingInterval`                      | Gunakan `fs.watchFile` tetapi gunakan interval polling yang berbeda untuk file sumber, file konfigurasi, dan file yang hilang
+`DynamicPriorityPolling`                       | Gunakan antrian dinamis di mana dalam file yang sering dimodifikasi akan memiliki interval yang lebih pendek dan file yang tidak diubah akan lebih jarang diperiksa
+`UseFsEvents`                                  | Gunakan `fs.watch` untuk memanfaatkan system event file (tetapi mungkin tidak akurat pada OS yang berbeda) untuk mendapatkan pemberitahuan terhadap perubahan/pembuatan/penghapusan file. Perhatikan bahwa beberapa OS misalnya. linux memiliki batasan jumlah pengamatan dan jika gagal melakukan pengamatan menggunakan `fs.watch`, maka pengamatan akan dilakukan dengan `fs.watchFile`
+`UseFsEventsWithFallbackDynamicPolling`        | Opsi ini mirip dengan `UseFsEvents` kecuali jika gagal memantau menggunakan `fs.watch`, pengawasan dilakukan melalui antrean polling dinamis (seperti dijelaskan dalam `DynamicPriorityPolling`)
+`UseFsEventsOnParentDirectory`                 | Opsi ini mengawasi direktori induk dari file dengan `fs.watch` (menggunakan system event file) sehingga menjadi rendah pada CPU tetapi dengan keakuratan yang rendah.
+standar (tanpa menspesifikkan nilainya)                   | Jika variabel environment `TSC_NONPOLLING_WATCHER` di-set ke true, maka akan mengawasi direktori induk dari file (seperti `UseFsEventsOnParentDirectory`). Jika tidak, akan menggunakan `fs.watchFile` dengan `250ms` sebagai waktu tunggu untuk file apa pun.
+
+## Mengonfigurasi pengawasan direktori menggunakan variabel environment `TSC_WATCHDIRECTORY`
+
+Pemantauan direktori pada platform yang tidak mendukung pemantau direktori rekursif secara native di node, maka akan menggunakan opsi yang berbeda, yang dipilih oleh`TSC_WATCHDIRECTORY`. Perlu dicatat bahwa, platform yang mendukung pemantauan direktori secara rekursif (misalnya Windows), nilai dari variabel environment tersebut akan diabaikan.
+
+<!-- prettier-ignore -->
+Opsi                                         | Deskripsi
+-----------------------------------------------|----------------------------------------------------------------------
+`RecursiveDirectoryUsingFsWatchFile`           | Gunakan `fs.watchFile` untuk mengawasi direktori dan direktori anak yang merupakan polling watch (menggunakan siklus CPU)
+`RecursiveDirectoryUsingDynamicPriorityPolling`| Gunakan antrian polling dinamis untuk mengumpulkan perubahan pada direktori dan sub direktori.
+default (no value specified)                   | Gunakan `fs.watch` untuk memantau direktoru dan sub direktorinya

--- a/packages/documentation/copy/id/reference/Decorators.md
+++ b/packages/documentation/copy/id/reference/Decorators.md
@@ -1,0 +1,573 @@
+---
+title: Decorators
+layout: docs
+permalink: /id/docs/handbook/decorators.html
+oneline: Ringkasan Dekorator TypeScript
+translatable: true
+---
+
+## Pengenalan
+
+Dengan pengenalan Kelas-kelas yang ada di TypeScript dan ES6, sekarang ada skenario tertentu yang memerlukan fitur tambahan untuk mendukung anotasi atau modifikasi kelas dan anggota kelas.
+Decorators menyediakan cara untuk menambahkan anotasi-anotasi dan sebuah sintaks pemrogragaman meta untuk deklarasi kelas dan anggota kelas.
+Decorators ada pada [stage 2 proposal](https://github.com/tc39/proposal-decorators) untuk JavaScript dan juga tersedia pada TypeScript sebagai fitur eksperimental.
+
+> CATATAN&emsp; Decorators adalah fitur eksperimental yang mungkin dapat berubah ketika dirilis nanti.
+
+Untuk mengaktifkan Decorators eksperimental, anda harus menambahkan opsi `experimentalDecorators` ke baris perintah atau ke berkas `tsconfig.json`.
+
+**Command Line**:
+
+```shell
+tsc --target ES5 --experimentalDecorators
+```
+
+**tsconfig.json**:
+
+```json  tsconfig
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "experimentalDecorators": true
+  }
+}
+```
+
+## Decorator
+
+_Decorator_ adalah jenis deklarasi khusus yang dapat dilampirkan ke [deklarasi kelas](#class-decorators), [method](#method-decorators), [accessor](#accessor-decorators), [property](#property-decorators), atau [parameter](#parameter-decorators).
+Decorators menggunakan bentuk `@expression`, dimana `expression` harus mengevaluasi fungsi yang akan dipanggil saat proses dengan informasi tentang deklarasi yang didekorasi.
+
+Sebagai contoh, ada decorator `@sealed` yang mungkin kita akan menuliskan fungsi `sealed` sebagai berikut:
+
+```ts
+function sealed(target) {
+  // lakukan sesuatu dengan 'target' ...
+}
+```
+
+> CATATAN&emsp; Anda dapat melihat contoh lengkapnya di [Decorator Kelas](#class-decorators).
+
+## Decorator Factories
+
+Jika kita ingin menyesuaikan penerapan decorator pada sebuah deklarasi, kita dapat menuliskan sebuah decorator factory. _Decorator Factory_ adalah sebuah fungsi yang mengembalikan ekspresi yang akan dipanggil oleh decorator ketika proses.
+
+Kita dapat menuliskan decorator factory seperti berikut:
+
+```ts
+function color(value: string) {
+  // ini adalah decorator factory
+  return function (target) {
+    // ini adalah decorator
+    // lakukan sesuatu dengan 'target' dan 'value'...
+  };
+}
+```
+
+> CATATAN&emsp; Anda dapat melihat contoh lengkap dari penggunaan decorator factory di [Method Decorators](#method-decorators)
+
+## Komposisi Decorator
+
+Lebih dari satu decorator dapat diterapkan pada sebuah deklarasi, seperti contoh berikut:
+
+- Penerapan dengan satu baris:
+
+  ```ts
+  @f @g x
+  ```
+
+- Penerapan lebih dari satu baris:
+
+  ```ts
+  @f
+  @g
+  x
+  ```
+
+Ketika lebih dari satu decorator diterapkan ke sebuah deklarasi, evaluasi yang dilakukan mirip seperti [fungsi komposisi pada matematika](http://wikipedia.org/wiki/Function_composition). Pada model ini, ketika mengkomposisikan fungsi _f_ dan _g_, maka akan menjadi (_f_ ∘ _g_)(_x_) yang sama dengan _f_(_g_(_x_)).
+
+Dengan demikian, langkah-langkah berikut dilakukan saat mengevaluasi beberapa dekorator pada satu deklarasi di TypeScript:
+
+1. Ekspresi untuk setiap dekorator dievaluasi dari atas ke bawah.
+2. Hasilnya kemudian disebut sebagai fungsi dari bawah ke atas.
+
+If we were to use [decorator factories](#decorator-factories), we can observe this evaluation order with the following example:
+
+JIka kita menggunakan [decorator factories](#decorator-factories), kita dapat mengamati urutan evaluasi ini dengan contoh berikut:
+
+```ts
+function f() {
+  console.log("f(): evaluated");
+  return function (
+    target,
+    propertyKey: string,
+    descriptor: PropertyDescriptor
+  ) {
+    console.log("f(): called");
+  };
+}
+
+function g() {
+  console.log("g(): evaluated");
+  return function (
+    target,
+    propertyKey: string,
+    descriptor: PropertyDescriptor
+  ) {
+    console.log("g(): called");
+  };
+}
+
+class C {
+  @f()
+  @g()
+  method() {}
+}
+```
+
+Yang akan mencetak keluaran ini ke console:
+
+```shell
+f(): evaluated
+g(): evaluated
+g(): called
+f(): called
+```
+
+## Evaluasi Decorator
+
+Ada urutan yang jelas tentang bagaimana decorator diterapkan ke berbagai deklarasi yang ada di dalam kelas:
+
+1. _Parameter Decorators_, diikuti oleh _Method_, _Accessor_, atau _Property Decorators_ diterapkan untuk setiap anggota instance.
+1. _Parameter Decorators_, diikuti oleh _Method_, _Accessor_, atau _Property Decorators_ diterapkan untuk setiap anggota statis.
+1. _Parameter Dekorator_ diterapkan untuk konstruktor.
+1. _Class Decorators_ diterapkan untuk kelas.
+
+## Decorator Kelas
+
+_Class Decorator_ dideklarasikan tepat sebelum deklarasi kelas.
+Dekorator kelas diterapkan ke konstruktor kelas dan dapat digunakan untuk mengamati, memodifikasi, atau mengganti definisi kelas.
+Dekorator kelas tidak dapat digunakan dalam file deklarasi, atau dalam konteks ambien lainnya (seperti pada kelas `deklarasi`).
+
+Ekspresi untuk dekorator kelas akan dipanggil sebagai fungsi pada waktu proses, dengan konstruktor kelas yang didekorasi sebagai satu-satunya argumennya.
+
+Jika dekorator kelas mengembalikan nilai, deklarasi kelas akan diganti dengan fungsi konstruktor yang disediakan.
+
+> CATATAN&nbsp; Jika Anda memilih untuk mengembalikan fungsi konstruktor baru, Anda harus berhati-hati dalam mempertahankan prototipe asli.
+> Logika yang menerapkan dekorator pada waktu proses **tidak akan** melakukannya untukmu.
+
+Berikut ini adalah contoh decorator kelas (`@sealed`) yang diterapkan ke kelas `Greeter`:
+
+```ts
+@sealed
+class Greeter {
+  greeting: string;
+  constructor(message: string) {
+    this.greeting = message;
+  }
+  greet() {
+    return "Hello, " + this.greeting;
+  }
+}
+```
+
+Kita dapat mendefinisikan dekorator `@sealed` menggunakan deklarasi fungsi berikut:
+
+```ts
+function sealed(constructor: Function) {
+  Object.seal(constructor);
+  Object.seal(constructor.prototype);
+}
+```
+
+Ketika `@sealed` dijalankan, itu akan menyegel konstruktor dan prototipe-nya.
+
+Selanjutnya kita memiliki contoh bagaimana menimpa konstruktor.
+
+```ts
+function classDecorator<T extends { new (...args: any[]): {} }>(
+  constructor: T
+) {
+  return class extends constructor {
+    newProperty = "new property";
+    hello = "override";
+  };
+}
+
+@classDecorator
+class Greeter {
+  property = "property";
+  hello: string;
+  constructor(m: string) {
+    this.hello = m;
+  }
+}
+
+console.log(new Greeter("world"));
+```
+
+## Method Decorators
+
+_Method Decorator_ dideklarasikan tepat sebelum deklarasi metthod.
+Dekorator diterapkan ke _Property Descriptor_ untuk method, yang dapat digunakan untuk mengamati, memodifikasi, atau mengganti definisi method.
+Method Dekorator tidak dapat digunakan dalam file deklarasi, saat kelebihan beban, atau dalam konteks ambien lainnya (seperti dalam kelas `declare`).
+
+Ekspresi untuk method decorator akan dipanggil sebagai fungsi pada waktu proses, dengan tiga argumen berikut:
+
+1. Bisa memiliki fungsi konstruktor kelas untuk anggota statis, atau prototipe kelas untuk anggota instance.
+2. Nama anggota.
+3. The _Property Descriptor_ untuk anggota.
+
+> CATATAN&emsp; _Property Descriptor_ akan menjadi `undefined` jika target skripmu dibawah `ES5`.
+
+Jika method decorator mengembalikan sebuah nilai, maka akan digunakan sebagai _Property Descriptor_ untuk method.
+
+> CATATAN&emsp; Nilai yang dikembalikan akan dibiarkan, jika target skripmu dibawah `ES5`.
+
+Berikut adalah contoh penerapan method decorator (`@enumerable`) ke method yang ada pada kelas `Greeter`:
+
+```ts
+class Greeter {
+  greeting: string;
+  constructor(message: string) {
+    this.greeting = message;
+  }
+
+  @enumerable(false)
+  greet() {
+    return "Hello, " + this.greeting;
+  }
+}
+```
+
+Kita dapat mendefinisikan dekorator `@enumerable` menggunakan fungsi deklarasi berikut:
+
+```ts
+function enumerable(value: boolean) {
+  return function (
+    target: any,
+    propertyKey: string,
+    descriptor: PropertyDescriptor
+  ) {
+    descriptor.enumerable = value;
+  };
+}
+```
+
+Decorator `@enumerable(false)` disini adalah sebuah [decorator factory](#decorator-factories).
+Ketika decorator `@enumerable(false)` dipanggil, ia akan merubah `enumerable` property dari property descriptor.
+
+## Decorator Aksesor
+
+Sebuah _Accessor Decorator_ dideklarasikan tepat sebelum sebuah deklarasi aksesor.
+Decorator aksesor diterapkan ke _Property Descriptor_ untuk aksesor dan dapat digunakan untuk mengamati, memodifikasi, atau mengganti definisi aksesor.
+Decorator aksesor tidak dapat digunakan dalam deklarasi file, atau dalam konteks ambien lainnya (seperti dalam kelas `declare`).
+
+> CATATAN&emsp; TypeScript melarang penerapan decorator ke aksesor `get` dan `set` untuk single member.
+> Sebaliknya, semua decorator untuk anggota harus diterapkan ke pengakses pertama yang ditentukan dalam urutan dokumen.
+> Ini karena dekorator berlaku untuk _Property Descriptor_, yang menggabungkan aksesor `get` dan`set`, bukan setiap deklarasi secara terpisah.
+
+Ekspresi untuk decorator pengakses akan dipanggil sebagai fungsi pada waktu proses, dengan tiga argumen berikut:
+
+1. Bisa memiliki fungsi konstruktor kelas untuk anggota statis, atau prototipe kelas untuk anggota instance.
+2. Nama anggota.
+3. The _Property Descriptor_ untuk anggota.
+
+> CATATAN&emsp; _Property Descriptor_ akan menjadi `undefined`, jika target skripmu dibawah `ES5`.
+
+Jika aksesor decorator mengembalikan sebuah nilai, ia akan digunakan sebagai _Property Descriptor_ untuk anggota.
+
+> CATATAN&emsp; Nilai yang dikembalikan akan dibiarkan, jika target skripmu dibawah `ES5`.
+
+Berikut ada contoh penerapan aksesor decorator (`@configurable`) ke anggota kelas `Point`:
+
+```ts
+class Point {
+  private _x: number;
+  private _y: number;
+  constructor(x: number, y: number) {
+    this._x = x;
+    this._y = y;
+  }
+
+  @configurable(false)
+  get x() {
+    return this._x;
+  }
+
+  @configurable(false)
+  get y() {
+    return this._y;
+  }
+}
+```
+
+Kita dapat mendefinisikan decorator `@configurable` menggunakan deklarasi fungsi berikut:
+
+```ts
+function configurable(value: boolean) {
+  return function (
+    target: any,
+    propertyKey: string,
+    descriptor: PropertyDescriptor
+  ) {
+    descriptor.configurable = value;
+  };
+}
+```
+
+## Property Decorators
+
+Sebuah _Property Decorator_ dideklarasikan tepat sebelum deklarasi properti.
+_Property Decorator_ tidak dapat digunakan dalam deklarasi file, atau dalam konteks ambien lainnya (seperti dalam kelas `declare`).
+
+Ekspresi untuk property decorator akan dipanggil sebagai fungsi pada waktu proses, dengan dua argumen berikut:
+
+1. Dapat berupa fungsi konstruktor kelas untuk anggota statis, atau prototipe kelas untuk anggota instance.
+2. Nama anggota.
+
+> CATATAN&emsp; _Property Descriptior_ tidak menyediakan sebuah argumen untuk property decorator karena bergantung tentang bagaimana property decorator diinisialisasi pada TypeScript.
+> Ini karena, saat ini tidak ada mekanisme untuk mendeskripsikan sebuah instance property ketika mendefinisikan anggota dari sebuah prototipe, dan tidak ada cara untuk mengamati atau memodifikasi initializer untuk property. Dan nilai kembalian juga akan dibiarkan.
+> Sehingga, sebuah property decorator hanya bisa digunakan untuk mengamati property dengan nama yang spesifik, yang telah dideklarasikan pada sebuah kelas.
+
+Kita dapat menggunakan informasi tersebut untuk memantau property metadata, seperti pada contoh berikut:
+
+```ts
+class Greeter {
+  @format("Hello, %s")
+  greeting: string;
+
+  constructor(message: string) {
+    this.greeting = message;
+  }
+  greet() {
+    let formatString = getFormat(this, "greeting");
+    return formatString.replace("%s", this.greeting);
+  }
+}
+```
+
+Kemudian, kita dapat mendefinisikan decorator `@format` dan fungsi `getFormat` dengan menggunakan deklarasi fungsi berikut:
+
+```ts
+import "reflect-metadata";
+
+const formatMetadataKey = Symbol("format");
+
+function format(formatString: string) {
+  return Reflect.metadata(formatMetadataKey, formatString);
+}
+
+function getFormat(target: any, propertyKey: string) {
+  return Reflect.getMetadata(formatMetadataKey, target, propertyKey);
+}
+```
+
+Decorator `@format("Hello, %s")` disini adalah sebuah [decorator factory](#decorator-factories).
+Ketika `@format("Hello, %s")` dipanggil, ia akan menambahkan property metadata menggunakan fungsi `Reflect.metadata` dari pustaka `reflect-metadata`.
+Ketika `getFormat` dipanggil, ia akan membaca format dari nilai metadata-nya.
+
+> CATATAN&emsp; Contoh ini membutuhkan pustaka `reflect-metadata`.
+> Lihat [Metadata](#metadata) untuk informasi lebih lanjut mengenai pustaka `reflect-metadata`.
+
+## Parameter Decorators
+
+_Parameter Decorator_ dideklarasikan tepat sebelum a parameter dideklarasikan.
+Parameter decorator diterapkan ke fungsi konstruktor pada kelas atau saat deklarasi method.
+Parameter decorator tidak dapat digunakan dalam deklarasi file, overload, atau dalam konteks ambien lainnya (seperti dalam kelas `declare`).
+
+Ekspresi untuk parameter decorator akan dipanggil sebagai fungsi pada waktu proses, dengan tiga argumen berikut:
+
+1. Dapat berupa fungsi konstruktor kelas untuk anggota statis, atau prototipe kelas untuk anggota instance.
+2. Nama anggota.
+3. Indeks ordinal dari parameter dalam daftar parameter fungsi.
+
+> CATATAN&emsp; Sebuah parameter decorator hanya bisa digunakan untuk mengamati sebuah parameter yang telah dideklarasikan pada sebuah method.
+
+Nilai kembalian dari parameter decorator akan dibiarkan.
+
+Berikut adalah contoh penggunaan parameter decorator (`@required`) pada anggota kelas `Greeter`:
+
+```ts
+class Greeter {
+  greeting: string;
+
+  constructor(message: string) {
+    this.greeting = message;
+  }
+
+  @validate
+  greet(@required name: string) {
+    return "Hello " + name + ", " + this.greeting;
+  }
+}
+```
+
+Kemudian, kita dapat mendefinisikan decorator `@required` dan `@validate` menggunakan deklarasi fungsi berikut:
+
+```ts
+import "reflect-metadata";
+
+const requiredMetadataKey = Symbol("required");
+
+function required(
+  target: Object,
+  propertyKey: string | symbol,
+  parameterIndex: number
+) {
+  let existingRequiredParameters: number[] =
+    Reflect.getOwnMetadata(requiredMetadataKey, target, propertyKey) || [];
+  existingRequiredParameters.push(parameterIndex);
+  Reflect.defineMetadata(
+    requiredMetadataKey,
+    existingRequiredParameters,
+    target,
+    propertyKey
+  );
+}
+
+function validate(
+  target: any,
+  propertyName: string,
+  descriptor: TypedPropertyDescriptor<Function>
+) {
+  let method = descriptor.value;
+  descriptor.value = function () {
+    let requiredParameters: number[] = Reflect.getOwnMetadata(
+      requiredMetadataKey,
+      target,
+      propertyName
+    );
+    if (requiredParameters) {
+      for (let parameterIndex of requiredParameters) {
+        if (
+          parameterIndex >= arguments.length ||
+          arguments[parameterIndex] === undefined
+        ) {
+          throw new Error("Missing required argument.");
+        }
+      }
+    }
+
+    return method.apply(this, arguments);
+  };
+}
+```
+
+Decorator `@required` menambahkan entri metadata yang menandakan bahwa parameter tersebut diperlukan.
+Decorator `@validate` kemudian akan memvalidasi semua argumen yang ada, sebelum method-nya dijalankan.
+
+> CATATAN&emsp; Contoh ini memerlukan pustaka `reflect-metadata`
+> Lihat [Metadata](#metadata) untuk informasi lebih lanjut mengenai pustaka `reflect-metadata`.
+
+## Metadata
+
+Beberapa contoh menggunakan pustaka `reflect-metadata` yang menambahkan polyfill untuk [API metadata eksperimental](https://github.com/rbuckton/ReflectDecorators).
+Pustaka ini belum menjadi bagian dari standar ECMAScript (JavaScript).
+Namun, ketika decorator secara resmi diadopsi sebagai bagian dari standar ECMAScript, ekstensi ini akan diusulkan untuk diadopsi.
+
+Anda dapat memasang pustaka ini melalui npm:
+
+```shell
+npm i reflect-metadata --save
+```
+
+TypeScript menyertakan dukungan eksperimental untuk menghadirkan jenis metadata tertentu untuk deklarasi yang memiliki decorator.
+Untuk mengaktifkan dukungan eksperimental ini, Anda harus mengatur opsi compiler `emitDecoratorMetadata` baik pada baris perintah atau di `tsconfig.json` Anda:
+
+**Command Line**:
+
+```shell
+tsc --target ES5 --experimentalDecorators --emitDecoratorMetadata
+```
+
+**tsconfig.json**:
+
+```json tsconfig
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  }
+}
+```
+
+Ketika diaktifkan, selama pustaka `reflect-metadata` di-import, informasi jenis design-time tambahan akan diekspos saat runtime.
+
+Kita dapat melihat action pada contoh berikut:
+
+```ts
+import "reflect-metadata";
+
+class Point {
+  x: number;
+  y: number;
+}
+
+class Line {
+  private _p0: Point;
+  private _p1: Point;
+
+  @validate
+  set p0(value: Point) {
+    this._p0 = value;
+  }
+  get p0() {
+    return this._p0;
+  }
+
+  @validate
+  set p1(value: Point) {
+    this._p1 = value;
+  }
+  get p1() {
+    return this._p1;
+  }
+}
+
+function validate<T>(
+  target: any,
+  propertyKey: string,
+  descriptor: TypedPropertyDescriptor<T>
+) {
+  let set = descriptor.set;
+  descriptor.set = function (value: T) {
+    let type = Reflect.getMetadata("design:type", target, propertyKey);
+    if (!(value instanceof type)) {
+      throw new TypeError("Invalid type.");
+    }
+    set.call(target, value);
+  };
+}
+```
+
+Compiler TypeScript akan memasukkan informasi jenis design-time menggunakan decorator `@Reflect.metadata`.
+Anda dapat menganggapnya setara dengan TypeScript berikut:
+
+```ts
+class Line {
+  private _p0: Point;
+  private _p1: Point;
+
+  @validate
+  @Reflect.metadata("design:type", Point)
+  set p0(value: Point) {
+    this._p0 = value;
+  }
+  get p0() {
+    return this._p0;
+  }
+
+  @validate
+  @Reflect.metadata("design:type", Point)
+  set p1(value: Point) {
+    this._p1 = value;
+  }
+  get p1() {
+    return this._p1;
+  }
+}
+```
+
+> CATATAN&emsp; Decorator metadata adalah fitur experimental dan mungkin dapat menyebabkan gangguan pada rilis di masa mendatang.

--- a/packages/documentation/copy/id/reference/Iterators and Generators.md
+++ b/packages/documentation/copy/id/reference/Iterators and Generators.md
@@ -1,0 +1,90 @@
+---
+title: Iterators and Generators
+layout: docs
+permalink: /id/docs/handbook/iterators-and-generators.html
+oneline: Bagaimana Iterator dan Generator bekerja di TypeScript
+translatable: true
+---
+
+## Iterasi
+
+Sebuah objek dapat dilakukan perulangan jika memiliki poperty [`Symbol.iterator`](Symbols.html#symboliterator).
+Beberapa type bawaan seperti `Array`, `Map`, `Set`, `String`, `Int32Array`, `Uint32Array`, etc. sudah memiliki property `Symbol.iterator`.
+Fungsi `Symbol.iterator` pada sebuah objek, bertanggungjawab untuk mengembalikan list nilai-nilai untuk menjalankan iterasi.
+
+## Pernyataan `for..of`
+
+`for..of` mengulang objek yang dapat diulang dengan cara memanggil properti `Symbol.iterator` pada objek tersebut.
+Berikut ini loop `for..of` sederhana pada sebuah array:
+
+```ts
+let someArray = [1, "string", false];
+
+for (let entry of someArray) {
+  console.log(entry); // 1, "string", false
+}
+```
+
+### Pernyataan `for..of` vs `for..in`
+
+Baik pernyataan `for..of` dan `for..in` akan mengiterasi list; yang membedakan antara keduanya adalah `for..in` akan mengembalikan daftar _keys_ dari objek tersebut, sedangkan `for..of` mengembalikan daftar _values_ property numeric dari objek yang diiterasi.
+
+Berikut adalah contoh implementasi dari perbedaan keduanya:
+
+```ts
+let list = [4, 5, 6];
+
+for (let i in list) {
+  console.log(i); // "0", "1", "2",
+}
+
+for (let i of list) {
+  console.log(i); // "4", "5", "6"
+}
+```
+
+Perbedaan lainnya adalah `for..in` bekerja pada objek apapun; ini berfungsi sebagai cara untuk memeriksa properti pada objek tersebut.
+Di sisi lain, `for..of` tertarik pada nilai dari objek yang dapat diulang. Objek bawaan seperti `Map` dan`Set` mengimplementasikan properti `Symbol.iterator` yang memungkinkan akses ke nilai yang disimpan.
+
+```ts
+let pets = new Set(["Cat", "Dog", "Hamster"]);
+pets["species"] = "mammals";
+
+for (let pet in pets) {
+  console.log(pet); // "species"
+}
+
+for (let pet of pets) {
+  console.log(pet); // "Cat", "Dog", "Hamster"
+}
+```
+
+### Pembuatan kode
+
+#### Menargetkan ES5 dan ES3
+
+Ketika menargetkan ke engine ES5 atau ES3, iterator hanya membolehkan nilai bertipe `Array`.
+Akan terjadi error jika `for..of` melakukan perulangan pada nilai yang bukan Array, bahkan jika nilai non Array tersebut memiliki property `Symbol.iterator`.
+
+Compiler akan menghasilkan perulangan `for` sederhana untuk `for..of`, misalnya:
+
+```ts
+let numbers = [1, 2, 3];
+for (let num of numbers) {
+  console.log(num);
+}
+```
+
+akan menghasilkan:
+
+```js
+var numbers = [1, 2, 3];
+for (var _i = 0; _i < numbers.length; _i++) {
+  var num = numbers[_i];
+  console.log(num);
+}
+```
+
+#### Menargetkan ECMAScript 2015 dan yang lebih tinggi
+
+Ketika menargetkan ke engine ECMAScript 2015, compiler akan membuat perulangan `for..of` untuk menargetkan implementasi iterator bawaan di mesin.

--- a/packages/documentation/copy/id/reference/JSX.md
+++ b/packages/documentation/copy/id/reference/JSX.md
@@ -1,0 +1,442 @@
+---
+title: JSX
+layout: docs
+permalink: /id/docs/handbook/jsx.html
+oneline: Menggunakan JSX dengan TypeScript
+translatable: true
+---
+
+[JSX](https://facebook.github.io/jsx/) adalah sebuah sintaks tertanam, yang seperti XML.
+Ini dimaksudkan untuk diubah menjadi JavaScript yang valid, meskipun semantik dari transformasi itu khusus untuk implementasi.
+JSX menjadi populer dengan kerangka kerja [React](https://reactjs.org/), tetapi sejak itu juga melihat implementasi lain.
+TypeScript mendukung embeding, pemeriksaan type, dan mengkompilasi JSX secara langsung ke JavaScript.
+
+## Dasar Penggunaan
+
+Untuk menggunakan JSX, anda harus melakukan dua hal berikut:
+
+1. Penamaan file dengan ekstensi `.tsx`
+2. Mengaktifkan opsi `jsx`
+
+TypeScript memiliki tiga jenis mode JSX: `preserve`, `react`, dan `react-native`.
+Mode tersebut hanya berlaku untuk stage, sedangkan untuk pemeriksaan type, hal itu tidak berlaku.
+Mode `preserve` akan mempertahankan JSX sebagai bagian dari output untuk selanjutnya digunakan oleh langkah transformasi lain (mis. [Babel](https://babeljs.io/)).
+Selain itu, output-nya akan memiliki ekstensi file `.jsx`.
+Mode `react` akan mengeluarkan`React.createElement`, tidak perlu melalui transformasi JSX sebelum digunakan, dan outputnya akan memiliki ekstensi file `.js`.
+Mode `react-native` sama dengan `pertahankan` yang mempertahankan semua JSX, tetapi hasilnya justru akan memiliki ekstensi file `.js`.
+
+| Mode           | Input     | Output                       | Output File Extension |
+| -------------- | --------- | ---------------------------- | --------------------- |
+| `preserve`     | `<div />` | `<div />`                    | `.jsx`                |
+| `react`        | `<div />` | `React.createElement("div")` | `.js`                 |
+| `react-native` | `<div />` | `<div />`                    | `.js`                 |
+
+Anda dapat menetapkan mode ini menggunakan flag baris perintah `--jsx` atau opsi yang sesuai di file [tsconfig.json](/docs/handbook/tsconfig-json.html) Anda.
+
+> \*Catatan: Anda dapat menentukan fungsi factory JSX yang akan digunakan saat menargetkan react JSX emit dengan opsi `--jsxFactory` (default ke `React.createElement`)
+
+## Opeartor `as`
+
+Ingat bagaimana menulis penegasan type:
+
+```ts
+var foo = <foo>bar;
+```
+
+Ini menegaskan variabel `bar` memiliki type `foo`.
+Sejak TypeScript juga menggunakan kurung siku untuk penegasan type, mengkombinasikannya dengan sintaks JSX akan menimbulkan kesulitan tertentu. Hasilnya, TypeScript tidak membolehkan penggunaan kurung siku untuk penegasan type pada file `.tsx`.
+
+Karena sintaks diatas tidak bisa digunakan pada file `.tsx`, maka alternatif untuk penegasan type dapat menggunakan operator `as`.
+Contohnya dapat dengan mudah ditulis ulang dengan operator `as`.
+
+```ts
+var foo = bar as foo;
+```
+
+Operator `as` tersedia dikedua jenis file, `.ts` dan `.tsx`, dan memiliki perlakuan yang sama seperti penegasan type menggunakan kurung siku.
+
+## Pemeriksaan Type
+
+Urutan yang harus dimengerti mengenai pemeriksaan type di JSX, yaitu pertama anda harus memahami perbedaan antara elemen intrinsik dan elemen berbasiskan nilai. Terdapat sebuah ekspresi `<expr />` dan `expr` yang mungkin mengacu pada suatu hal yang intrinsik pada suatu lingkungan (misalnya `div` atau `span` dalam lingkungan DOM) atau pada komponen custom yang telah Anda buat.
+Ini penting karena dua alasan berikut:
+
+1. Untuk React, elemen intrinsik dianggap sebagai string (`React.createElement("div")`), sedangkan komponen yang Anda buat bukan (`React.createElement(MyComponent)`).
+2. Type dari atribut yang dilewatkan ke elemen JSX seharusnya terlihat berbeda.
+   Atribut elemen intrinsik seharusnya diketahui _secara intrinsik_ sedangkan komponen akan seperti ingin untuk menentukan kumpulan atribut mereka sendiri.
+
+TypeScript menggunakan [beberapa convention yang dengan React](http://facebook.github.io/react/docs/jsx-in-depth.html#html-tags-vs.-react-components) untuk membedakannya.
+Elemen intrinsik selalu dimulai dengan huruf kecil, dan elemen berbasiskan nilai selalu dimulai dengan huruf besar.
+
+## Elemen intrinsik
+
+Elemen intrinsik dicari pada interface khusus, yaitu `JSX.IntrinsicElements`.
+Standarnya, jika interface ini tidak ditentukan, maka apapun yang terjadi dan elemen intrinsik tidak akan diperiksa type-nya.
+Namun, jika interface ini ada, maka nama elemen intrinsik akan dicari sebagai property di interface `JSX.IntrinsicElements`.
+Contohnya:
+
+```ts
+declare namespace JSX {
+  interface IntrinsicElements {
+    foo: any;
+  }
+}
+
+<foo />; // ok
+<bar />; // error
+```
+
+Pada contoh diatas, `<foo />` akan berjalan dengan baik, tapi `<bar />` akan menghasilkan error, karena `<bar />` tidak ditentukan pada interface `JSX.IntrinsicElements`.
+
+> Catatan: Anda juga bisa menentukan indexer untuk mendapatkan seluruh elemen bertipe string didalam `JSX.IntrinsicElements`, seperti berikut:
+
+```ts
+declare namespace JSX {
+  interface IntrinsicElements {
+    [elemName: string]: any;
+  }
+}
+```
+
+## Elemen Berbasiskan Nilai
+
+Elemen berbasiskan nilai akan dicari oleh identifier yang ada pada sebuah scope.
+
+```ts
+import MyComponent from "./myComponent";
+
+<MyComponent />; // ok
+<SomeOtherComponent />; // error
+```
+
+Terdapat dua cara untuk mendefinisikan sebuah elemen berbasiskan nilai, yaitu:
+
+1. Function Component (FC)
+2. Class Component
+
+Karena kedua jenis elemen berbasis nilai ini tidak dapat dibedakan satu sama lain dalam ekspresi JSX, maka pertama TS akan mencoba menyelesaikan ekspresi tersebut sebagai Function Component menggunakan overloading. Jika proses berhasil, maka TS selesai menyelesaikan ekspresi ke deklarasinya. Jika gagal untuk menyelesaikan sebagai Function Component, maka TS kemudian akan mencoba untuk menyelesaikannya sebagai Class Component. Jika gagal, TS akan melaporkan kesalahan.
+
+### Function Component
+
+Seperti namanya, komponen ini didefinisikan menggunakan fungsi JavaScript dimana argumen pertamanya adalah sebuah `props` objek.
+TS memberlakukan bahwa type kembaliannya harus dapat diberikan ke `JSX.Element`.
+
+```ts
+interface FooProp {
+  name: string;
+  X: number;
+  Y: number;
+}
+
+declare function AnotherComponent(prop: {name: string});
+function ComponentFoo(prop: FooProp) {
+  return <AnotherComponent name={prop.name} />;
+}
+
+const Button = (prop: {value: string}, context: { color: string }) => <button>
+```
+
+Karena Function Component adalah fungsi JavaScript, maka fungsi overload dapat digunakan di sini:
+
+```ts
+interface ClickableProps {
+  children: JSX.Element[] | JSX.Element
+}
+
+interface HomeProps extends ClickableProps {
+  home: JSX.Element;
+}
+
+interface SideProps extends ClickableProps {
+  side: JSX.Element | string;
+}
+
+function MainButton(prop: HomeProps): JSX.Element;
+function MainButton(prop: SideProps): JSX.Element {
+  ...
+}
+```
+
+> Catatan: Function Component sebelumnya dikenal sebagai Stateless Function Component (SFC). Karena Function Component tidak dapat lagi dianggap stateless di versi terbaru react, jenis `SFC` dan aliasnya`StatelessComponent` tidak digunakan lagi.
+
+### Class Component
+
+Ini memungkinkan untuk mendefinisikan type dari class component.
+Namun, untuk melakukannya, yang terbaik adalah memahami dua istilah baru berikut: _type class elemen_ dan _type instance elemen_.
+
+Jika terdapat `<Expr />`, maka _type class elemennya_ adalah `Expr`.
+Jadi pada contoh diatas, jika `MyComponent` adalah class ES6, maka type class-nya adalah konstruktor dan static dari class tersebut.
+Jika `MyComponent` adalah factory function, maka type class-nya adalah fungsi itu sendiri.
+
+Setelah type class dibuat, type instance ditentukan oleh gabungan tipe kembalian dari konstruksi type class atau call signature (mana saja yang ada).
+Jadi sekali lagi, dalam kasus kelas ES6, jenis instans adalah jenis instans kelas itu, dan dalam kasus factory function, itu akan menjadi jenis nilai yang dikembalikan dari fungsi tersebut.
+
+```ts
+class MyComponent {
+  render() {}
+}
+
+// menggunakan konstruksi signature
+var myComponent = new MyComponent();
+
+// type class elemen => MyComponent
+// type instance elemen => { render: () => void }
+
+function MyFactoryFunction() {
+  return {
+    render: () => {},
+  };
+}
+
+// menggunakan call signature
+var myComponent = MyFactoryFunction();
+
+// type class elemen => FactoryFunction
+// type instance elemen => { render: () => void }
+```
+
+Type elemen instance itu menarik, karena ini harus dapat di-assign ke `JSX.ElementClass` atau hasilnya akan error.
+Standarnya `JSX.ElementClass` adalah `{}`, tetapi ini bisa ditambah untuk membatasi penggunaan JSX hanya untuk jenis yang sesuai dengan interface yang tepat.
+
+```ts
+declare namespace JSX {
+  interface ElementClass {
+    render: any;
+  }
+}
+
+class MyComponent {
+  render() {}
+}
+function MyFactoryFunction() {
+  return { render: () => {} };
+}
+
+<MyComponent />; // ok
+<MyFactoryFunction />; // ok
+
+class NotAValidComponent {}
+function NotAValidFactoryFunction() {
+  return {};
+}
+
+<NotAValidComponent />; // error
+<NotAValidFactoryFunction />; // error
+```
+
+## Pemeriksaan Type Atribut
+
+Langkah pertama untuk memeriksa type atribut adalah menentukan type atribut elemen.
+Ini sedikit berbeda antara elemen intrinsik dan berbasis nilai.
+
+Untuk elemen intrinsik, ini adalah type dari property pada `JSX.IntrinsicElements`
+
+```ts
+declare namespace JSX {
+  interface IntrinsicElements {
+    foo: { bar?: boolean };
+  }
+}
+
+// type atribut elemen untuk 'foo' is '{bar?: boolean}'
+<foo bar />;
+```
+
+Untuk elemen berbasis nilai, ini sedikit lebih kompleks.
+Ini ditentukan oleh type dari property pada _type elemen instance_ yang telah ditentukan.
+Property mana yang digunakan untuk ditentukan oleh `JSX.ElementAttributesProperty`.
+Ini harus dideklarasikan dengan satu property.
+Nama property itu kemudian digunakan.
+Mulai TypeScript 2.8, jika `JSX.ElementAttributesProperty` tidak disediakan, jenis parameter pertama dari konstruktor elemen kelas atau pemanggilan Function Component akan digunakan sebagai gantinya.
+
+```ts
+declare namespace JSX {
+  interface ElementAttributesProperty {
+    props; // menentukan nama property yang akan digunakan
+  }
+}
+
+class MyComponent {
+  // menentukan property pada type instance elemen
+  props: {
+    foo?: string;
+  };
+}
+
+// type atribut elemen untuk 'MyComponent' adalah '{foo?: string}'
+<MyComponent foo="bar" />;
+```
+
+Type atribut elemen digunakan untuk memeriksa atribut di JSX.
+Properti opsional dan wajib telah didukung.
+
+```ts
+declare namespace JSX {
+  interface IntrinsicElements {
+    foo: { requiredProp: string; optionalProp?: number };
+  }
+}
+
+<foo requiredProp="bar" />; // ok
+<foo requiredProp="bar" optionalProp={0} />; // ok
+<foo />; // error, tidak ada requiredProp
+<foo requiredProp={0} />; // error, requiredProp seharusnya ber-type string
+<foo requiredProp="bar" unknownProp />; // error, unknownProp tidak ada
+<foo requiredProp="bar" some-unknown-prop />; // ok, karena 'some-unknown-prop' bukan identifier yang valid
+```
+
+> Catatan: Jika nama atribut bukan identifier JS yang valid (seperti atribut `data- *`), itu tidak dianggap sebagai kesalahan jika tidak ditemukan dalam type atribut elemen.
+
+Selain itu, antarmuka `JSX.IntrinsicAttributes` dapat digunakan untuk menentukan properti tambahan yang digunakan oleh framework JSX yang umumnya tidak digunakan oleh props atau argumen komponen - misalnya `key` di React. Mengkhususkan lebih lanjut, type generik `JSX.IntrinsicClassAttributes<T>` juga dapat digunakan untuk menetapkan type atribut tambahan yang sama hanya untuk class component (dan bukan function component). Dalam type ini, parameter generik sesuai dengan type instance class. Di React, ini digunakan untuk mengizinkan atribut `ref` dengan type `Ref <T>`. Secara umum, semua properti pada interface ini harus bersifat opsional, kecuali Anda bermaksud agar pengguna framework JSX Anda perlu menyediakan beberapa atribut pada setiap tag.
+
+Spread operator juga bekerja:
+
+```ts
+var props = { requiredProp: "bar" };
+<foo {...props} />; // ok
+
+var badProps = {};
+<foo {...badProps} />; // error
+```
+
+## Pemeriksaan Type Children
+
+Di TypeScript 2.3, TS mengenalkan pemeriksaan type pada _children_. _Children_ adalah property khusus di _type atribut elemen_ dimana child _JSXExpression_ diambil untuk dimasukkan ke atribut.
+Mirip dengan bagaimana menggunakan `JSX.ElementAttributesProperty` untuk menentukan nama dari _props_, TS menggunakan `JSX`.
+`JSX.ElementChildrenAttribute` harus dideklarasikan dengan property tunggal.
+
+```ts
+declare namespace JSX {
+  interface ElementChildrenAttribute {
+    children: {}; // menentukan nama children untuk digunakan
+  }
+}
+```
+
+```ts
+<div>
+  <h1>Hello</h1>
+</div>;
+
+<div>
+  <h1>Hello</h1>
+  World
+</div>;
+
+const CustomComp = (props) => <div>{props.children}</div>
+<CustomComp>
+  <div>Hello World</div>
+  {"This is just a JS expression..." + 1000}
+</CustomComp>
+```
+
+Anda bisa menentukan type dari _children_ seperti atribut lainnya. Ini akan mengganti type standarnya, misalnya [React typings](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react) jika Anda menggunakannya.
+
+```ts
+interface PropsType {
+  children: JSX.Element
+  name: string
+}
+
+class Component extends React.Component<PropsType, {}> {
+  render() {
+    return (
+      <h2>
+        {this.props.children}
+      </h2>
+    )
+  }
+}
+
+// OK
+<Component name="foo">
+  <h1>Hello World</h1>
+</Component>
+
+// Error: children adalah type JSX.Element, bukan array dari JSX.Element.
+<Component name="bar">
+  <h1>Hello World</h1>
+  <h2>Hello World</h2>
+</Component>
+
+// Error: children adalah type JSX.Element, bukan array dari JSX.Element maupun string.
+<Component name="baz">
+  <h1>Hello</h1>
+  World
+</Component>
+```
+
+## Type hasil JSX
+
+Secara standar, hasil dari ekspresi JSX ber-type `any`.
+Anda bisa menyesuaikan type dengan menentukan interface `JSX.Element`.
+Namun, tidak mungkin untuk mengambil informasi type tentang elemen, atribut atau turunan dari JSX dari interface ini.
+Itu adalah black box.
+
+## Menyematkan Ekspresi
+
+JSX memungkinkan Anda untuk menyematkan ekspresi di antara tag dengan mengapit ekspresi dengan kurung kurawal (`{}`).
+
+```ts
+var a = (
+  <div>
+    {["foo", "bar"].map((i) => (
+      <span>{i / 2}</span>
+    ))}
+  </div>
+);
+```
+
+Kode di atas akan menghasilkan kesalahan karena Anda tidak dapat membagi string dengan angka.
+Outputnya, saat menggunakan opsi `preserve`, terlihat seperti:
+
+```ts
+var a = (
+  <div>
+    {["foo", "bar"].map(function (i) {
+      return <span>{i / 2}</span>;
+    })}
+  </div>
+);
+```
+
+## Integrasi React
+
+Untuk menggunakan JSX dengan React, anda harus menggunakan [React typings](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react). Typings ini mendefinisikan namespace `JSX` dengan tepat untuk digunakan dengan React.
+
+```ts
+/// <reference path="react.d.ts" />
+
+interface Props {
+  foo: string;
+}
+
+class MyComponent extends React.Component<Props, {}> {
+  render() {
+    return <span>{this.props.foo}</span>;
+  }
+}
+
+<MyComponent foo="bar" />; // ok
+<MyComponent foo={0} />; // error
+```
+
+## Factory Function
+
+Factory function yang digunakan oleh opsi compiler `jsx: react` dapat dikonfigurasi. Ini dapat disetel menggunakan opsi baris perintah `jsxFactory`, atau komentar `@jsx` sebaris untuk menyetelnya pada basis per file. Misalnya, jika Anda menyetel `jsxFactory` ke `createElement`, `<div />` akan melakukannya sebagai `createElement("div")` bukan `React.createElement("div")`.
+
+Versi pragma komentar dapat digunakan seperti itu (dalam TypeScript 2.8):
+
+```ts
+import preact = require("preact");
+/* @jsx preact.h */
+const x = <div />;
+```
+
+akan menjadi:
+
+```ts
+const preact = require("preact");
+const x = preact.h("div", null);
+```
+
+Factory yang dipilih juga akan mempengaruhi di mana namespace `JSX` dicari (untuk informasi pemeriksaan type) sebelum kembali ke global. Jika factory ditentukan sebagai `React.createElement` (standar), compiler akan memeriksa `React.JSX` sebelum memeriksa `JSX` global. Jika factory ditentukan sebagai `h`, maka ia akan memeriksa `h.JSX` sebelum `JSX` global.

--- a/packages/documentation/copy/id/reference/Mixins.md
+++ b/packages/documentation/copy/id/reference/Mixins.md
@@ -1,0 +1,271 @@
+---
+title: Mixins
+layout: docs
+permalink: /id/docs/handbook/mixins.html
+oneline: Menggunakan pola mixin dengan TypeScript
+translatable: true
+---
+
+Bersamaan dengan hierarki OO tradisional, cara populer lainnya untuk membangun kelas dari komponen yang dapat digunakan kembali adalah membangunnya dengan menggabungkan kelas parsial yang lebih sederhana.
+Anda mungkin sudah familiar dengan ide mixin atau ciri untuk bahasa seperti Scala, dan polanya juga mendapatkan popularitas di komunitas JavaScript.
+
+## Bagaimana Cara Kerja Mixin?
+
+Pola ini bergantung pada penggunaan Generik dengan warisan kelas untuk memperluas kelas dasar.
+Dukungan mixin terbaik TypeScript dilakukan melalui pola ekspresi kelas.
+Anda dapat membaca lebih lanjut mengenai bagaimana pola ini bekerja di [Javscript disini](https://justinfagnani.com/2015/12/21/real-mixins-with-javascript-classes/).
+
+Untuk memulai, kita akan butuh kelas yang akan diterapkan mixin:
+
+```ts twoslash
+class Sprite {
+  name = "";
+  x = 0;
+  y = 0;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+}
+```
+
+Kemudian kamu butuh sebuah type dan sebuah fungsi factory yang mengembalikan sebuah ekspresi kelas untuk meng-extend kelas dasar.
+
+```ts twoslash
+// Untuk memulai, kita membutuhkan tipe yang akan kita gunakan untuk memperluas kelas lain.
+// Tanggung jawab utama adalah mendeklarasikan bahwa tipe yang diteruskan adalah sebuah kelas.
+
+type Constructor = new (...args: any[]) => {};
+
+// Mixin ini menambahkan property scale, dengan getter dan setter
+// untuk mengubahnya dengan properti private yang dienkapsulasi:
+
+function Scale<TBase extends Constructor>(Base: TBase) {
+  return class Scaling extends Base {
+    // Mixin mungkin tidak mendeklarasikan property private/protected
+    // namun, Anda dapat menggunakan field private ES2020
+    _scale = 1;
+
+    setScale(scale: number) {
+      this._scale = scale;
+    }
+
+    get scale(): number {
+      return this._scale;
+    }
+  };
+}
+```
+
+Setelah hal-hal diatas siap, Anda dapat membuat kelas yang mewakili kelas dasar dengan mixin yang diterapkan:
+
+```ts twoslash
+class Sprite {
+  name = "";
+  x = 0;
+  y = 0;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+}
+type Constructor = new (...args: any[]) => {};
+function Scale<TBase extends Constructor>(Base: TBase) {
+  return class Scaling extends Base {
+    // Mixin mungkin tidak mendeklarasikan property private/protected
+    // namun, Anda dapat menggunakan field private ES2020
+    _scale = 1;
+
+    setScale(scale: number) {
+      this._scale = scale;
+    }
+
+    get scale(): number {
+      return this._scale;
+    }
+  };
+}
+// ---potong---
+// Buat kelas baru dari kelas Sprite,
+// dengan Mixin Scale:
+const EightBitSprite = Scale(Sprite);
+
+const flappySprite = new EightBitSprite("Bird");
+flappySprite.setScale(0.8);
+console.log(flappySprite.scale);
+```
+
+## Mixin yang Dibatasi
+
+Dalam bentuk di atas, mixin tidak memiliki pengetahuan yang mendasari kelas yang dapat menyulitkan pembuatan desain yang diinginkan.
+
+Untuk memodelkan ini, kami memodifikasi tipe konstruktor asli untuk menerima argumen generic.
+
+```ts twoslash
+// Ini adalah konstruktor kita sebelumnya:
+type Constructor = new (...args: any[]) => {};
+// Sekarang kami menggunakan versi generik yang dapat menerapkan batasan
+// pada kelas tempat mixin ini diterapkan
+type GConstructor<T = {}> = new (...args: any[]) => T;
+```
+
+Ini memungkinkan untuk membuat kelas yang hanya bekerja dengan kelas dasar yang dibatasi:
+
+```ts twoslash
+type GConstructor<T = {}> = new (...args: any[]) => T;
+class Sprite {
+  name = "";
+  x = 0;
+  y = 0;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+}
+// ---potong---
+type Positionable = GConstructor<{ setPos: (x: number, y: number) => void }>;
+type Spritable = GConstructor<typeof Sprite>;
+type Loggable = GConstructor<{ print: () => void }>;
+```
+
+Kemudian Anda dapat membuat mixin yang hanya berfungsi jika Anda memiliki basis tertentu untuk dibangun:
+
+```ts twoslash
+type GConstructor<T = {}> = new (...args: any[]) => T;
+class Sprite {
+  name = "";
+  x = 0;
+  y = 0;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+}
+type Positionable = GConstructor<{ setPos: (x: number, y: number) => void }>;
+type Spritable = GConstructor<typeof Sprite>;
+type Loggable = GConstructor<{ print: () => void }>;
+// ---potong---
+
+function Jumpable<TBase extends Positionable>(Base: TBase) {
+  return class Jumpable extends Base {
+    jump() {
+      // Mixin ini hanya akan berfungsi jika itu melewati kelas dasar
+      // yang telah ditetapkan setPos
+      // karena kendala Positionable.
+      this.setPos(0, 20);
+    }
+  };
+}
+```
+
+## Pola Alternatif
+
+Versi sebelumnya dari dokumen ini merekomendasikan cara untuk menulis mixin di mana Anda membuat runtime dan hierarki type secara terpisah, lalu menggabungkannya di akhir:
+
+```ts twoslash
+// @strict: false
+// Setiap mixin adalah kelas ES tradisional
+class Jumpable {
+  jump() {}
+}
+
+class Duckable {
+  duck() {}
+}
+
+// Termasuk basisnya
+class Sprite {
+  x = 0;
+  y = 0;
+}
+
+// Kemudian Anda membuat antarmuka yang menggabungkan mixin
+// yang diharapkan dengan nama yang sama sebagai basis Anda
+interface Sprite extends Jumpable, Duckable {}
+// Terapkan mixin ke dalam kelas dasar melalui
+// JS saat runtime
+applyMixins(Sprite, [Jumpable, Duckable]);
+
+let player = new Sprite();
+player.jump();
+console.log(player.x, player.y);
+
+// Ini dapat hidup di mana saja di basis kode Anda:
+function applyMixins(derivedCtor: any, constructors: any[]) {
+  constructors.forEach((baseCtor) => {
+    Object.getOwnPropertyNames(baseCtor.prototype).forEach((name) => {
+      Object.defineProperty(
+        derivedCtor.prototype,
+        name,
+        Object.getOwnPropertyDescriptor(baseCtor.prototype, name)
+      );
+    });
+  });
+}
+```
+
+Pola ini tidak terlalu bergantung pada compiler, dan lebih banyak pada basis kode Anda untuk memastikan runtime dan sistem tipe tetap sinkron dengan benar.
+
+## Kendala
+
+Pola mixin didukung secara native di dalam compiler TypeScript oleh code flow analysis.
+Ada beberapa kasus di mana Anda dapat mencapai tepi dukungan native.
+
+#### Decorator dan Mixin [`#4881`](https://github.com/microsoft/TypeScript/issues/4881)
+
+Anda tidak bisa menggunakan decorator untuk menyediakan mixin melalui code flow analysis:
+
+```ts twoslash
+// @experimentalDecorators
+// @errors: 2339
+// Fungsi dekorator yang mereplikasi pola mixin:
+const Pausable = (target: typeof Player) => {
+  return class Pausable extends target {
+    shouldFreeze = false;
+  };
+};
+
+@Pausable
+class Player {
+  x = 0;
+  y = 0;
+}
+
+// Kelas Player tidak menggabungkan type dekorator:
+const player = new Player();
+player.shouldFreeze;
+
+// Aspek runtime ini dapat direplikasi secara manual
+// melalui komposisi tipe atau penggabungan interface.
+type FreezablePlayer = typeof Player & { shouldFreeze: boolean };
+
+const playerTwo = (new Player() as unknown) as FreezablePlayer;
+playerTwo.shouldFreeze;
+```
+
+#### Static Property Mixins [`#17829`](https://github.com/microsoft/TypeScript/issues/17829)
+
+Pola ekspresi kelas membuat singletons, jadi mereka tidak dapat dipetakan pada sistem type untuk mendukung tipe variabel yang berbeda.
+
+Anda bisa mengatasinya dengan menggunakan fungsi untuk mengembalikan kelas Anda yang berbeda berdasarkan generik:
+
+```ts twoslash
+function base<T>() {
+  class Base {
+    static prop: T;
+  }
+  return Base;
+}
+
+function derived<T>() {
+  class Derived extends base<T>() {
+    static anotherProp: T;
+  }
+  return Derived;
+}
+
+class Spec extends derived<string>() {}
+
+Spec.prop; // string
+Spec.anotherProp; // string
+```

--- a/packages/documentation/copy/id/reference/Symbols.md
+++ b/packages/documentation/copy/id/reference/Symbols.md
@@ -1,0 +1,107 @@
+---
+title: Symbols
+layout: docs
+permalink: /id/docs/handbook/symbols.html
+oneline: Menggunakan Simbol JavaScript primitif di TypeScript
+translatable: true
+---
+
+Mulai dari ECMAScript 2015, `symbol` adalah tipe data primitif, sama seperti `number` dan `string`.
+
+Nilai `simbol` dibuat dengan memanggil konstruktor `Symbol`.
+
+```ts
+let sym1 = Symbol();
+
+let sym2 = Symbol("key"); // kunci string opsional
+```
+
+Simbol tidak dapat diubah, dan unik.
+
+```ts
+let sym2 = Symbol("key");
+let sym3 = Symbol("key");
+
+sym2 === sym3; // false, symbol itu unik
+```
+
+Sama seperti string, simbol dapat digunakan sebagai kunci untuk property objek.
+
+```ts
+const sym = Symbol();
+
+let obj = {
+  [sym]: "value",
+};
+
+console.log(obj[sym]); // "value"
+```
+
+Simbol juga dapat digabungkan dengan deklarasi properti yang dihitung untuk mendeklarasikan properti objek dan anggota kelas.
+
+```ts
+const getClassNameSymbol = Symbol();
+
+class C {
+  [getClassNameSymbol]() {
+    return "C";
+  }
+}
+
+let c = new C();
+let className = c[getClassNameSymbol](); // "C"
+```
+
+## Simbol Terkenal
+
+Selain simbol yang ditentukan pengguna, ada simbol bawaan yang terkenal.
+Simbol bawaan digunakan untuk mewakili perilaku bahasa internal.
+
+Berikut adalah daftar simbol yang terkenal:
+
+## `Symbol.hasInstance`
+
+Sebuah method yang menentukan apakah objek konstruktor mengenali objek sebagai salah satu contoh konstruktor. Dipanggil oleh semantik dari operator instanceof.
+
+## `Symbol.isConcatSpreadable`
+
+Nilai Boolean yang menunjukkan bahwa sebuah objek harus diratakan ke elemen arraynya dengan Array.prototype.concat.
+
+## `Symbol.iterator`
+
+Sebuah method yang mengembalikan iterator standar untuk sebuah objek. Dipanggil oleh semantik pada pernyataan for-of.
+
+## `Symbol.match`
+
+Metode ekspresi reguler yang mencocokkan ekspresi reguler dengan string. Dipanggil dengan method `String.prototype.match`.
+
+## `Symbol.replace`
+
+Method regular expression yang menggantikan substring yang cocok dari sebuah string. Dipanggil dengan method `String.prototype.replace`.
+
+## `Symbol.search`
+
+Method regular expression yang mengembalikan indeks dalam string yang cocok dengan ekspresi reguler. Dipanggil dengan method `String.prototype.search`.
+
+## `Symbol.species`
+
+Properti bernilai fungsi yang merupakan fungsi konstruktor yang digunakan untuk membuat objek turunan.
+
+## `Symbol.split`
+
+Method regular expression yang memisahkan string pada indeks yang cocok dengan ekspresi reguler.
+Dipanggil dengan method `String.prototype.split`.
+
+## `Symbol.toPrimitive`
+
+Method yang mengonversi objek menjadi nilai primitif yang sesuai.
+Dipanggil oleh operasi abstrak `ToPrimitive`.
+
+## `Symbol.toStringTag`
+
+Nilai String yang digunakan dalam pembuatan deskripsi string default dari suatu objek.
+Dipanggil oleh method bawaan `Object.prototype.toString`.
+
+## `Symbol.unscopables`
+
+Objek yang nama propertinya adalah nama properti yang dikecualikan dari environment 'dengan' dari objek terkait.

--- a/packages/documentation/copy/id/tutorials/Babel with TypeScript.md
+++ b/packages/documentation/copy/id/tutorials/Babel with TypeScript.md
@@ -1,0 +1,49 @@
+---
+title: Using Babel with TypeScript
+layout: docs
+permalink: /id/docs/handbook/babel-with-typescript.html
+oneline: Cara membuat proyek hybrid Babel + TypeScript
+translatable: true
+---
+
+## Babel vs `tsc` untuk TypeScript
+
+Ketika membuat proyek JavaScript modern, anda mungkin bertanya pada dirimu sendiri, apa cara yang benar untuk mengkonversi file-file dari TypeScript ke JavaScript.
+
+Sering kali jawabannya adalah _"tergantung"_, atau _"seseorang mungkin telah memutuskan untukmu"_ bergantung pada proyeknya. Jika anda membangun proyekmu dengan framework yang sudah ada, seperti [tsdx](https://tsdx.io), [Angular](https://angular.io/), [NestJS](https://nestjs.com/) atau framework apapun yang disebutkan di [Getting Started](/docs/home).
+
+Namun, heuristic yang berguna bisa jadi:
+
+- Apakah keluaran dari build-mu sebagian besar sama seperti file-file yang di-input-kan? Jika iya, maka gunakan `tsc`
+- Apakah anda butuh build pipeline dengan output yang memiliki beberapa potensi? Jika iya, maka gunakan `babel` untuk transpiling dan `tsc` untuk pemeriksaan type
+
+## Babel untuk transpiling, `tsc` untuk types
+
+Ini adalah pola umum untuk proyek dengan infrastruktur build yang ada, yang mungkin telah ditransfer dari kode JavaScript ke TypeScript.
+
+Teknik ini adalah pendekatan hybrid, menggunakan [preset-typescript](https://babeljs.io/docs/en/babel-preset-typescript) Babel untuk menghasilkan file-file JS mu, dan kemudian menggunakan TypeScript untuk pemeriksaan type dan pembuatan file `.d.ts`
+
+Dengan menggunakan dukungan babel untuk TypeScript, anda mendapatkan kemampuan untuk bekerja pada pipeline build yang sudah ada dan lebih seperti memiliki JS yang lebih cepat, karena Babel tidak melakukan pemeriksaan type pada kodemu
+
+#### Pemeriksaan Type dan menghasilkan file d.ts
+
+Kelemahan menggunakan babel adalah Anda tidak mendapatkan pemeriksaan type selama transisi dari TS ke JS. Ini berarti bahwa kesalahan type yang Anda lewatkan di editor-mu dapat menyusup ke dalam kode saat fase produksi.
+
+Selain itu, Babel tidak dapat membuat file `.d.ts` untuk TypeScript-mu yang dapat mempersulit pengerjaan proyekmu jika itu adalah sebuah pustaka.
+
+Untuk mengatasi hal tersebut, Anda perlu melakukan set up perintah untuk memeriksa type pada proyekmu menggunakan TSC. Ini seperti menduplikasi beberapa konfigurasi babel menjadi sesuai dengan `tsconfig.json`](/tconfig) dan memastikan bahwa flag-flag ini aktif:
+
+```json tsconfig
+"compilerOptions": {
+  // Memastikan bahwa file-file .d.ts dibuat oleh tsc, bukan file .js
+  "declaration": true,
+  "emitDeclarationOnly": true,
+  // Memastikan bahwa Babel secara aman dapat men-transpile file-file di proyek TypeScript
+  "isolatedModules": true
+}
+```
+
+Informasi lebih lanjut mengenai flag-flag tersebut:
+
+- [`isolatedModules`](/tsconfig#isolatedModules)
+- [`declaration`](/tsconfig#declaration), [`emitDeclarationOnly`](/tsconfig#emitDeclarationOnly)

--- a/packages/documentation/copy/id/tutorials/DOM Manipulation.md
+++ b/packages/documentation/copy/id/tutorials/DOM Manipulation.md
@@ -1,0 +1,201 @@
+---
+title: DOM Manipulation
+layout: docs
+permalink: /id/docs/handbook/dom-manipulation.html
+oneline: Menggunakan DOM dengan TypeScript
+translatable: true
+---
+
+## Manipulasi DOM
+
+### _Eksplorasi ke dalam type `HTMLElement`_
+
+Dalam 20+ tahun sejak standarisasi, JavaScript telah berkembang pesat. Meskipun pada tahun 2020, JavaScript dapat digunakan di server, dalam ilmu data, dan bahkan pada perangkat IoT, penting untuk mengingat kasus penggunaannya yang paling populer: web browser.
+
+Situs web terdiri dari dokumen HTML dan/atau XML. Dokumen-dokumen ini statis, tidak berubah. _Document Object Model (DOM)_ adalah antarmuka pemrograman yang diterapkan oleh browser untuk membuat situs web statis berfungsi. API DOM dapat digunakan untuk mengubah struktur dokumen, style, dan konten. API ini sangat kuat sehingga framework frontend yang tak terhitung jumlahnya (jQuery, React, Angular, dll.) telah dikembangkan di sekitarnya untuk membuat situs web dinamis lebih mudah dikembangkan.
+
+TypeScript adalah superset dari JavaScript, dan TypeScript dilengkapi dengan definisi tipe untuk DOM API. Secara standar, definisi ini sudah tersedia dalam proyek TypeScript. Dari 20.000+ baris definisi di _lib.dom.d.ts_, satu yang menonjol di antara yang lain: `HTMLElement`. Jenis ini adalah hal penting untuk manipulasi DOM dengan TypeScript.
+
+> Anda bisa mengeksplor source code [Definisi tipe DOM](https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts)
+
+## Contoh Dasar
+
+Diberikan file _index.html_ yang disederhanakan:
+
+    <!DOCTYPE html>
+    <html lang="en">
+      <head><title>TypeScript Dom Manipulation</title></head>
+      <body>
+        <div id="app"></div>
+        <!-- Assume index.js is the compiled output of index.ts -->
+        <script src="index.js"></script>
+      </body>
+    </html>
+
+Mari kita jelajahi skrip TypeScript yang menambahkan elemen `<p> Hello, World </p>` ke elemen `#app`.
+
+```ts
+// 1. Pilih elemen div menggunakan property id
+const app = document.getElementById("app");
+
+// 2. Buat element <p></p> baru secara terprogram
+const p = document.createElement("p");
+
+// 3. Tambahkan konten teks
+p.textContent = "Hello, World!";
+
+// 4. Tambahkan elemen p ke elemen div
+app?.appendChild(p);
+```
+
+Setelah menyusun dan menjalankan halaman _index.html_, HTML yang dihasilkan adalah:
+
+```html
+<div id="app">
+  <p>Hello, World!</p>
+</div>
+```
+
+## Antarmuka `Document`
+
+Baris pertama kode TypeScript menggunakan variabel global `document`. Memeriksa variabel menunjukkan bahwa ia didefinisikan oleh antarmuka `Dokumen` dari file _lib.dom.d.ts_. Cuplikan kode berisi panggilan ke dua metode, `getElementById` dan `createElement`.
+
+### `Document.getElementById`
+
+Definisi dari metode ini adalah sebagai berikut:
+
+```ts
+getElementById(elementId: string): HTMLElement | null;
+```
+
+Berikan string id elemen dan itu akan mengembalikan `HTMLElement` atau`null`. Metode ini memperkenalkan salah satu jenis terpenting, `HTMLElement`. Ini berfungsi sebagai antarmuka dasar untuk setiap antarmuka elemen lainnya. Misalnya, variabel `p` dalam contoh kode berjenis `HTMLParagraphElement`. Perhatikan juga bahwa metode ini dapat mengembalikan `null`. Ini karena metode tidak dapat memastikan kapan elemen itu tersedia atau apakah elemen tersebut ada atau tidak. Di baris terakhir cuplikan kode, operator _optional chaining_ digunakan untuk memanggil `appendChild`.
+
+### `Document.createElement`
+
+Definisi untuk metode ini adalah (definisi _deprecated_ telah dihilangkan):
+
+```ts
+createElement<K extends keyof HTMLElementTagNameMap>(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K];
+createElement(tagName: string, options?: ElementCreationOptions): HTMLElement;
+```
+
+Ini adalah definisi fungsi yang kelebihan beban. Kelebihan kedua adalah yang paling sederhana dan bekerja sangat mirip dengan method `getElementById`. Berikan setiap `string` dan ia akan mengembalikan standar HTMLElement. Definisi inilah yang memungkinkan developer membuat tag elemen HTML yang unik.
+
+Misalnya `document.createElement('xyz')` mengembalikan elemen `<xyz></xyz>`, jelas bukan elemen yang ditentukan oleh spesifikasi HTML.
+
+> Jika tertarik, Anda dapat berinteraksi dengan elemen tag kustom menggunakan `document.getElementsByTagName`
+
+Untuk definisi pertama dari `createElement`, ini menggunakan beberapa pola umum lanjutan. Paling baik dipahami jika dipecah menjadi beberapa bagian, dimulai dengan ekspresi umum: `<K extends keyof HTMLElementTagNameMap>`. Ekspresi ini mendefinisikan parameter umum `K` yang _constrained_ ke kunci antarmuka`HTMLElementTagNameMap`. Antarmuka peta berisi setiap nama tag HTML yang ditentukan dan antarmuka tipe yang sesuai. Berikut adalah 5 nilai yang dipetakan pertama:
+
+```ts
+interface HTMLElementTagNameMap {
+    "a": HTMLAnchorElement;
+    "abbr": HTMLElement;
+    "address": HTMLElement;
+    "applet": HTMLAppletElement;
+    "area": HTMLAreaElement;
+        ...
+}
+```
+
+Beberapa elemen tidak menunjukkan properti unik sehingga mereka hanya mengembalikan `HTMLElement`, tetapi tipe lain memiliki property dan method unik sehingga mereka mengembalikan antarmuka spesifiknya (yang akan memperluas atau mengimplementasikan `HTMLElement`).
+
+Sekarang, untuk sisa definisi `createElement`:`(tagName: K, options ?: ElementCreationOptions): HTMLElementTagNameMap [K]`. Argumen pertama `tagName` didefinisikan sebagai parameter umum `K`. Interpreter TypeScript cukup pintar untuk _infer_ parameter generik dari argumen ini. Ini berarti bahwa pengembang sebenarnya tidak harus menentukan parameter umum saat menggunakan metode ini; nilai apa pun yang diteruskan ke argumen `tagName` akan disimpulkan sebagai `K` dan karenanya dapat digunakan di seluruh definisi lainnya. Itulah yang sebenarnya terjadi; nilai kembalian `HTMLElementTagNameMap [K]` mengambil argumen `tagName` dan menggunakannya untuk mengembalikan jenis yang sesuai. Definisi ini adalah bagaimana variabel `p` dari kode sebelumnya mendapatkan jenis `HTMLParagraphElement`. Dan jika kodenya adalah `document.createElement ('a')`, maka itu akan menjadi elemen jenis `HTMLAnchorElement`.
+
+## Antarmuka `Node`
+
+Fungsi `document.getElementById` mengembalikan `HTMLElement`. Antarmuka `HTMLElement` memperluas antarmuka `Element`, yang memperluas antarmuka `Node`. Ekstensi prototipe ini memungkinkan semua `HTMLElements` untuk menggunakan subset method standar. Dalam cuplikan kode, kami menggunakan properti yang ditentukan pada antarmuka `Node` untuk menambahkan elemen`p` baru ke situs web.
+
+### `Node.appendChild`
+
+Baris terakhir dari potongan kode adalah `app?.AppendChild (p)`. Bagian sebelumnya, `document.getElementById`, merinci bahwa operator _optional chaining_ digunakan di sini karena `app` berpotensi menjadi null pada waktu proses. Method `appendChild` didefinisikan oleh:
+
+```ts
+appendChild<T extends Node>(newChild: T): T;
+```
+
+Method ini bekerja mirip dengan metode `createElement` karena parameter umum `T` disimpulkan dari argumen `newChild`. `T` adalah _constrained_ ke antarmuka dasar lain`Node`.
+
+## Perbedaan antara `children` dan `childNodes`
+
+Sebelumnya, dokumen ini merinci antarmuka `HTMLElement` yang diperluas dari `Element` yang diturunkan dari `Node`. Di DOM API ada konsep elemen _children_. Misalnya dalam HTML berikut, tag `p` adalah turunan dari elemen `div`
+
+```tsx
+<div>
+  <p>Hello, World</p>
+  <p>TypeScript!</p>
+</div>;
+
+const div = document.getElementsByTagName("div")[0];
+
+div.children;
+// HTMLCollection(2) [p, p]
+
+div.childNodes;
+// NodeList(2) [p, p]
+```
+
+Setelah menangkap elemen `div`, prop `children` akan mengembalikan daftar `HTMLCollection` yang berisi `HTMLParagraphElements`. Property `childNodes` akan mengembalikan daftar node `NodeList` yang serupa. Setiap tag `p` akan tetap berjenis `HTMLParagraphElements`, tetapi `NodeList` dapat berisi _HTML node_ tambahan yang tidak bisa dilakukan oleh list `HTMLCollection`.
+
+Ubah html dengan menghapus salah satu tag `p`, tetapi pertahankan teksnya.
+
+```tsx
+<div>
+  <p>Hello, World</p>
+  TypeScript!
+</div>;
+
+const div = document.getElementsByTagName("div")[0];
+
+div.children;
+// HTMLCollection(1) [p]
+
+div.childNodes;
+// NodeList(2) [p, text]
+```
+
+Lihat bagaimana kedua daftar berubah. `children` sekarang hanya berisi elemen `<p>Hello, World</p>`, dan `childNodes` berisi simpul `teks` daripada dua simpul `p`. Bagian `teks` dari `NodeList` adalah `Node` literal yang berisi teks `TypeScript!`. List `children` tidak berisi `Node`, ini karena tidak dianggap sebagai `HTMLElement`.
+
+## Method `querySelector` dan `querySelectorAll`
+
+Kedua method ini adalah tool yang hebat untuk mendapatkan daftar elemen dom yang sesuai dengan kumpulan constraint yang lebih unik. Mereka didefinisikan di _lib.dom.d.ts_ sebagai:
+
+```ts
+/**
+ * Mengembalikan elemen pertama yang merupakan turunan dari node yang cocok dengan selector.
+ */
+querySelector<K extends keyof HTMLElementTagNameMap>(selectors: K): HTMLElementTagNameMap[K] | null;
+querySelector<K extends keyof SVGElementTagNameMap>(selectors: K): SVGElementTagNameMap[K] | null;
+querySelector<E extends Element = Element>(selectors: string): E | null;
+
+/**
+ * Menampilkan semua turunan elemen node yang cocok dengan selector.
+ */
+querySelectorAll<K extends keyof HTMLElementTagNameMap>(selectors: K): NodeListOf<HTMLElementTagNameMap[K]>;
+querySelectorAll<K extends keyof SVGElementTagNameMap>(selectors: K): NodeListOf<SVGElementTagNameMap[K]>;
+querySelectorAll<E extends Element = Element>(selectors: string): NodeListOf<E>;
+```
+
+Definisi `querySelectorAll` mirip dengan `getElementsByTagName`, kecuali ia mengembalikan tipe baru: `NodeListOf`. Jenis kembalian ini pada dasarnya adalah implementasi khusus dari elemen daftar standar JavaScript. Bisa dibilang, mengganti `NodeListOf<E>` dengan `E[]` akan menghasilkan pengalaman pengguna yang sangat mirip. `NodeListOf` hanya mengimplementasikan property dan method berikut:`length`, `item (index)`,`forEach ((value, key, parent) => void)`, dan numeric indexing. Selain itu, metode ini mengembalikan daftar _elements_, bukan _nodes_, yang dikembalikan oleh `NodeList` dari method `.childNodes`. Meskipun ini mungkin tampak sebagai perbedaan, perhatikan bahwa antarmuka `Element` merupakan turunan dari `Node`.
+
+Untuk melihat method ini beraksi, ubah kode yang ada menjadi:
+
+```tsx
+<ul>
+  <li>First :)</li>
+  <li>Second!</li>
+  <li>Third times a charm.</li>
+</ul>;
+
+const first = document.querySelector("li"); // mengembalikan elemen li pertama
+const all = document.querySelectorAll("li"); // mengembalikan daftar semua elemen li
+```
+
+## Tertarik untuk mempelajari lebih lanjut?
+
+Bagian terbaik tentang definisi type _lib.dom.d.ts_ adalah bahwa definisi tersebut mencerminkan type yang dijelaskan di situs dokumentasi Mozilla Developer Network (MDN). Misalnya, antarmuka `HTMLElement` didokumentasikan oleh [halaman HTMLElement](https://developer.mozilla.org/docs/Web/API/HTMLElement) di MDN. Halaman ini mencantumkan semua property yang tersedia, method, dan terkadang bahkan contoh. Aspek hebat lainnya dari halaman-halaman tersebut adalah mereka menyediakan tautan ke dokumen standar yang sesuai. Berikut ini tautan ke [Rekomendasi W3C untuk HTMLElement](https://www.w3.org/TR/html52/dom.html#htmlelement).
+
+Sumber:
+
+- [ECMA-262 Standard](http://www.ecma-international.org/ecma-262/10.0/index.html)
+- [Introduction to the DOM](https://developer.mozilla.org/docs/Web/API/Document_Object_Model/Introduction)

--- a/packages/documentation/copy/id/tutorials/React.md
+++ b/packages/documentation/copy/id/tutorials/React.md
@@ -1,0 +1,26 @@
+---
+title: React
+layout: docs
+permalink: /id/docs/handbook/react.html
+oneline: Tautan untuk mempelajari tentang TypeScript dan React
+translatable: true
+---
+
+TypeScript mendukung [JSX](/docs/handbook/jsx.html) dan dapat dengan baik memodelkan pola untuk digunakan pada kode React, seperti `useState`.
+
+### Memulai Set Up Dengan Proyek React
+
+Saat ini ada beberapa framework yang mendukung TypeScript:
+
+- [Create React App](https://create-react-app.dev) - [TS docs](https://create-react-app.dev/docs/adding-typescript/)
+- [Next.js](https://nextjs.org) - [TS docs](https://nextjs.org/learn/excel/typescript)
+- [Gatsby](https://www.gatsbyjs.org) - [TS Docs](https://www.gatsbyjs.org/docs/typescript/)
+
+Framework diatas adalah titik awal yang bagus untuk mulai menggunakan TypeScript. Pada situs ini, kami [menggunakan Gatsby](https://www.gatsbyjs.org/blog/2020-01-23-why-typescript-chose-gatsby/#reach-skip-nav) dengan TypeScript. Sehingga dapat digunakan sebagai referensi untuk implementasinya.
+
+### Dokumentasi
+
+Berikut adalah beberapa tempat terbaik untuk menemukan informasi terbaru tentang React dan TypeScript:
+
+- [React TypeScript Cheatsheets](https://react-typescript-cheatsheet.netlify.app)
+- [React & Redux in TypeScript](https://github.com/piotrwitek/react-redux-typescript-guide#react--redux-in-typescript---complete-guide)

--- a/packages/documentation/copy/id/tutorials/TypeScript Tooling in 5 minutes.md
+++ b/packages/documentation/copy/id/tutorials/TypeScript Tooling in 5 minutes.md
@@ -1,0 +1,187 @@
+---
+title: TypeScript Tooling in 5 minutes
+layout: docs
+permalink: /id/docs/handbook/typescript-tooling-in-5-minutes.html
+oneline: Sebuah tutorial untuk memahami cara membuat situs web kecil dengan TypeScript
+translatable: true
+---
+
+Mulai membangun aplikasi web sederhana dengan TypeScript.
+
+## Memasang TypeScript
+
+Berikut adalah 2 cara agar TypeScript ada pada proyekmu:
+
+- Melalui npm (package manager dari Node.js)
+- Dengan memasang plugin Visual Studio TypeScript
+
+Standar dari Visual Studio 2017 dan Visual Studio 2015 Update 3 telah menyertakan TypeScript.
+Jika anda belum memasang TypeScript dengan Visual Studio, anda masih bisa [mengunduhnya disini](/download).
+
+Untuk pengguna npm:
+
+```shell
+> npm install -g typescript
+```
+
+## Membangun file TypeScript pertamamu
+
+Di editormu, ketik kode JavaScript berikut pada file `greeter.ts`:
+
+```ts twoslash
+// @noImplicitAny: false
+function greeter(person) {
+  return "Hello, " + person;
+}
+
+let user = "Jane User";
+
+document.body.textContent = greeter(user);
+```
+
+## Mengkompilasi kodemu
+
+Kita menggunakan ekstensi `.ts`, tapi kode ini hanyalah JavaScript.
+Anda dapat menyalin/menempel ini langsung dari aplikasi JavaScript yang ada.
+
+Di command line, jalankan TypeScript compiler:
+
+```shell
+tsc greeter.ts
+```
+
+Hasilnya akan menjadi file `greeter.js` yang berisi JavaScript yang sama dengan yang anda masukkan.
+Kodenya telah berhasil menjalankannya menggunakan TypeScript di aplikasi JavaScript!
+
+Sekarang kita bisa melangkah lebih jauh tentang tool yang ditawarkan oleh TypeScript.
+Tambahkan sebuah jenis anotasi `: string` ke argumen 'person' pada fungsi `greeter`, seperti berikut:
+
+```ts twoslash
+function greeter(person: string) {
+  return "Hello, " + person;
+}
+
+let user = "Jane User";
+
+document.body.textContent = greeter(user);
+```
+
+## Jenis Anotasi
+
+Jenis anotasi di TypeScript adalah cara yang mudah untuk mengetahui bagaimana fungsi atau variabel tersebut yang dimaksudkan.
+Dalam kasus ini, kami bermaksud agar fungsi greeter dipanggil dengan parameter string tunggal.
+Kita dapat mencoba mengubah pemanggilan fungsi greeter untuk mengirimkan array sebagai gantinya:
+
+```ts twoslash
+// @errors: 2345
+function greeter(person: string) {
+  return "Hello, " + person;
+}
+
+let user = [0, 1, 2];
+
+document.body.textContent = greeter(user);
+```
+
+Compile ulang, dan anda akan melihat error berikut:
+
+```shell
+error TS2345: Argument of type 'number[]' is not assignable to parameter of type 'string'.
+```
+
+Demikian pula, coba hapus semua argumen saat pemanggilan fungsi greeter.
+TypeScript akan memberi tahu Anda bahwa Anda telah memanggil fungsi ini dengan jumlah parameter yang tidak terduga.
+Dalam kedua kasus, TypeScript dapat menawarkan analisis statis berdasarkan struktur kode Anda, dan jenis anotasi yang Anda berikan.
+
+Perhatikan ketika terjadi error, file `greeter.js` tetap dibuat.
+Anda bisa menggunakan TypeScript bahkan jika terjadi error pada kodemu. Tapi pada kasus ini, TypeScript memperingatkan bahwa kodemu akan bekerja tidak sesuai dengan ekspektasi.
+
+## Interfaces
+
+Mari kembangkan sampel kita lebih jauh. Di sini kami menggunakan interface yang mendeskripsikan objek yang memiliki field firstName dan lastName.
+Di TypeScript, dua jenis anotasi akan kompatibel jika struktur internalnya juga kompatibel.
+Ini membolehkan kita untuk mengimplementasikan sebuah interface hanya dengan memiliki bentuk interface yang dibutuhkan, tanpa klausa `implements` yang eksplisit.
+
+```ts twoslash
+interface Person {
+  firstName: string;
+  lastName: string;
+}
+
+function greeter(person: Person) {
+  return "Hello, " + person.firstName + " " + person.lastName;
+}
+
+let user = { firstName: "Jane", lastName: "User" };
+
+document.body.textContent = greeter(user);
+```
+
+## Kelas
+
+Terakhir, mari menambahkan penggunaan kelas pada contoh yang sedang kita kerjakan.
+TypeScript mendukung fitur baru di JavaScript, seperti dukungan untuk kelas berbasiskan pemrograman objek.
+
+Disini kita mulai dengan membuat kelas `Student` dengan konstruktor dan beberapa field publik.
+Perhatikan bahwa kelas dan interface saling bersinergi, sehingga memberikan kebebasan ke programmer untuk memutuskan level abstraksi yang tepat.
+
+Juga perlu perhatikan, pernggunaan `public` pada argumen di konstruktor adalah singkatan yang membolehkan kita untuk secara otomatis membuat property dengan nama tersebut.
+
+```ts twoslash
+class Student {
+  fullName: string;
+  constructor(
+    public firstName: string,
+    public middleInitial: string,
+    public lastName: string
+  ) {
+    this.fullName = firstName + " " + middleInitial + " " + lastName;
+  }
+}
+
+interface Person {
+  firstName: string;
+  lastName: string;
+}
+
+function greeter(person: Person) {
+  return "Hello, " + person.firstName + " " + person.lastName;
+}
+
+let user = new Student("Jane", "M.", "User");
+
+document.body.textContent = greeter(user);
+```
+
+Jalankan ulang perintah `tsc greeter.ts` dan anda akan melihat kode JavaScript-nya.
+Kelas pada TypeScript hanyalah singkatan untuk object-oriented berbasiskan prototipe yang sama, yang sering digunakan di JavaScript.
+
+## Menjalankan aplikasi web TypeScript-mu
+
+Sekarang ketik kode berikut di `greeter.html`:
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>TypeScript Greeter</title>
+  </head>
+  <body>
+    <script src="greeter.js"></script>
+  </body>
+</html>
+```
+
+Buka `greeter.html` di browser untuk menjalankan aplikasi web TypeScript-mu yang pertama!
+
+Opsional: Buka `greeter.ts` di Visual Studio, atau salin kode ke TypeScript playground.
+Anda dapat mengarahkan kursor ke identifier untuk melihat type mereka.
+Perhatikan bahwa dalam beberapa kasus, tipe ini disimpulkan secara otomatis untuk Anda.
+Ketik ulang baris terakhir, dan lihat daftar penyelesaian dan bantuan parameter berdasarkan jenis elemen DOM.
+Letakkan kursor Anda pada referensi ke fungsi greeter, dan tekan F12 untuk masuk ke definisinya.
+Perhatikan juga bahwa Anda dapat mengklik kanan pada simbol dan menggunakan refactoring untuk mengganti namanya.
+
+Jenis informasi yang disediakan bekerja sama dengan tool untuk memudahkan pekerjaan dengan aplikasi JavaScript.
+Untuk informasi lebih lanjut tentang apa yang mungkin kita bisa lakukan dengan TypeScript, anda dapat melihat beberapa sample di situs ini.
+
+![Visual Studio picture](/images/docs/greet_person.png)


### PR DESCRIPTION
**Overview**
Refer to #938 and [this comment](https://github.com/microsoft/TypeScript-Website/issues/938#issuecomment-706573677), I translated the files into Indonesian.

**Changes**
Provides Indonesian translation for the following files:

- [x] Nightly Builds.md
- [x] Creating DTS files From JS.md
- [x] Intro to JS with TS.md
- [x] JSDoc Reference.md
- [x] Configuring Watch.md
- [x] Decorators.md
- [x] Iterators and Generators.md
- [x] JSX.md
- [x] Mixins.md
- [x] Symbols.md
- [x] Babel with TypeScript.md
- [x] DOM Manipulation.md
- [x] React.md
- [x] TypeScript Tooling in 5 minutes.md