### PR TITLE
Translate documentation files (PT-BR): Type Inference / Type Compatibility 

### DIFF
--- a/packages/documentation/copy/pt/reference/Type Compatibility.md
+++ b/packages/documentation/copy/pt/reference/Type Compatibility.md
@@ -1,7 +1,7 @@
 ---
 title: Compatibilidade de Tipos
 layout: docs
-permalink: /docs/handbook/type-compatibility.html
+permalink: /pt/docs/handbook/type-compatibility.html
 oneline: Como checagem de tipos funciona em TypeScript
 translatable: true
 ---

--- a/packages/documentation/copy/pt/reference/Type Compatibility.md
+++ b/packages/documentation/copy/pt/reference/Type Compatibility.md
@@ -32,7 +32,7 @@ Por que o Javascript faz uso amplo de objetos anônimos como funções de expres
 ## Uma nota sobre Solidez
 
 O sistema de tipos TypeScript permite certas operações, que não poderiam ser conhecidas em tempo de compilação, a serem seguras.
-Quando um sistema de tipos tem essa propriedade, fica dito não ser "solido" (_sound_). Os locais onde Typescript permite comportamento não sólido foram considerados cuidadosamente, e ao decorrer desse documento iremos explicar onde eles ocorrem e os cenários motivadores por trás deles. 
+Quando um sistema de tipos tem essa propriedade, fica dito não ser "sólido" (_sound_). Os locais onde Typescript permite comportamento não sólido foram considerados cuidadosamente, e ao decorrer desse documento iremos explicar onde eles ocorrem e os cenários motivadores por trás deles. 
 
 ## Começando
 

--- a/packages/documentation/copy/pt/reference/Type Compatibility.md
+++ b/packages/documentation/copy/pt/reference/Type Compatibility.md
@@ -1,8 +1,8 @@
 ---
-title: Type Compatibility
+title: Compatibilidade de Tipos
 layout: docs
 permalink: /docs/handbook/type-compatibility.html
-oneline: How type-checking works in TypeScript
+oneline: Como checagem de tipos funciona em TypeScript
 translatable: true
 ---
 
@@ -26,13 +26,13 @@ p = new Pessoa();
 ```
 Em linguagens nominalmente tipadas como C# ou Java, o código equivalente seria um erro porque a classe `Pessoa` não se descreve explícitamente como sendo um implementador da interface `Nomeado`.
 
-O sistema de tipagem estrutura do TypeScript foi projetado baseado em como o código Javascript é tipicamente escrito.
+O sistema de tipagem estrutural TypeScript foi projetado baseado em como o código Javascript é tipicamente escrito.
 Por que o Javascript faz uso amplo de objetos anônimos como funções de expressões e literais de objetos, é muito mais natural representar os tipos de relacionamentos encontrados em bibliotecas JavaScript com um sistema de tipo estrutural do que um tipo nominal.
 
-## Uma nota sobre Correção
+## Uma nota sobre Solidez
 
-O sistema de tipos do TypeScript permite certas operações, que não poderiam ser conhecidas em tempo de compilação, serem seguras.
-Quando um sistema de tipos tem essa propriedade, fica dito para não ser "correto". Os locais onde Typescript permite comportamento incorreto foram considerados cuidadosamente, e ao decorrer desse documento iremos explicar onde eles ocorrem e os cenários motivadores por tás deles. 
+O sistema de tipos TypeScript permite certas operações, que não poderiam ser conhecidas em tempo de compilação, a serem seguras.
+Quando um sistema de tipos tem essa propriedade, fica dito não ser "solido" (_sound_). Os locais onde Typescript permite comportamento não sólido foram considerados cuidadosamente, e ao decorrer desse documento iremos explicar onde eles ocorrem e os cenários motivadores por trás deles. 
 
 ## Começando
 
@@ -68,7 +68,7 @@ Esse processo de comparação ocorre recursivamente, explorando o tipo de cada m
 
 ## Comparando duas funções
 
-Enquanto comparar tipos primitivos é relativamente simples, a questão de quais tipos de funções deveriam ser consideradas compatíveis é um pouco mais embaralhado. Vamos começar com um exemplo básico de duas funções que diferem apenas em sua lista de parâmetros:
+Enquanto comparar tipos primitivos é relativamente simples, a questão de quais tipos de funções deveriam ser consideradas compatíveis é um pouco mais difícil. Vamos começar com um exemplo básico de duas funções que diferem apenas em sua lista de parâmetros:
 
 ```ts
 let x = (a: number) => 0;
@@ -115,7 +115,7 @@ O sistema de tipos força que o retorno da função fonte seja um subtipo do tip
 ## Parâmetro de Função Bivariado
 
 Ao comparar os tipos de parâmetros de funções, a atribuição tem sucesso se o parâmetro fonte é atribuível ao parâmetro alvo, ou vice versa.
-Isso é incorreto pois pode ser dada a uma função chamadora uma função que retorna um tipo mais especializado, mas invoca a função com um tipo menos especializado. 
+Isso é não sólido pois pode ser dada a uma função chamadora uma função que retorna um tipo mais especializado, mas invoca a função com um tipo menos especializado. 
 Na pratica, esse tipo de erro é raro, e permitir esse comportamento viabiliza muitos padrões comuns do JavaScript. Um exemplo breve:
 
 ```ts
@@ -139,10 +139,10 @@ function listenEvent(eventType: EventType, handler: (n: Event) => void) {
   /* ... */
 }
 
-// Incorreto, mas útil e comum
+// Não sólido, mas útil e comum
 listenEvent(EventType.Mouse, (e: MouseEvent) => console.log(e.x + "," + e.y));
 
-// Alternativas indesejáveis na presença de correção
+// Alternativas indesejáveis na presença de solidez
 listenEvent(EventType.Mouse, (e: Event) =>
   console.log((e as MouseEvent).x + "," + (e as MouseEvent).y)
 );
@@ -162,7 +162,7 @@ Parâmetros opcionais extras do tipo fonte não são um erro e parâmetros opcio
 
 Quando uma função tem um parâmetro do tipo rest, ela é tratada como se tivesse uma série infinita de parâmetros opcionais.
 
-Isso é incorreto pela perspectiva do sistema de tipos, mas pelo ponto de vista do tempo de execução a ideia de um parâmetro opcional é geralmente reforçada, uma vez que é o equivalente a passar `undefined` naquela posição para a maioria das funções.
+Isso não sólido pela perspectiva do sistema de tipos, mas pelo ponto de vista do tempo de execução a ideia de um parâmetro opcional é geralmente reforçada, uma vez que é o equivalente a passar `undefined` naquela posição para a maioria das funções.
 
 O exemplo motivacional é o padrão comum de uma função que recebe um callback e a chama com alguma previsibilidade (para o programador) mas com numero desconhecido (para o sistema de tipos) de argumentos:
 
@@ -171,7 +171,7 @@ function chamaDepois(args: any[], callback: (...args: any[]) => void) {
   /* ... Chama callback com 'args' ... */
 }
 
-// Incorreto - chamaDepois "poderia" prover qualquer numero de argumentos
+// Não sólido - chamaDepois "poderia" prover qualquer numero de argumentos
 chamaDepois([1, 2], (x, y) => console.log(x + ", " + y));
 
 // Confuso (x e y, na verdade, são requeridos ) e indetectáveis

--- a/packages/documentation/copy/pt/reference/Type Compatibility.md
+++ b/packages/documentation/copy/pt/reference/Type Compatibility.md
@@ -1,0 +1,290 @@
+---
+title: Type Compatibility
+layout: docs
+permalink: /docs/handbook/type-compatibility.html
+oneline: How type-checking works in TypeScript
+translatable: true
+---
+
+Type compatibility in TypeScript is based on structural subtyping.
+Structural typing is a way of relating types based solely on their members.
+This is in contrast with nominal typing.
+Consider the following code:
+
+```ts
+interface Named {
+  name: string;
+}
+
+class Person {
+  name: string;
+}
+
+let p: Named;
+// OK, because of structural typing
+p = new Person();
+```
+
+In nominally-typed languages like C# or Java, the equivalent code would be an error because the `Person` class does not explicitly describe itself as being an implementer of the `Named` interface.
+
+TypeScript's structural type system was designed based on how JavaScript code is typically written.
+Because JavaScript widely uses anonymous objects like function expressions and object literals, it's much more natural to represent the kinds of relationships found in JavaScript libraries with a structural type system instead of a nominal one.
+
+## A Note on Soundness
+
+TypeScript's type system allows certain operations that can't be known at compile-time to be safe. When a type system has this property, it is said to not be "sound". The places where TypeScript allows unsound behavior were carefully considered, and throughout this document we'll explain where these happen and the motivating scenarios behind them.
+
+## Starting out
+
+The basic rule for TypeScript's structural type system is that `x` is compatible with `y` if `y` has at least the same members as `x`. For example:
+
+```ts
+interface Named {
+  name: string;
+}
+
+let x: Named;
+// y's inferred type is { name: string; location: string; }
+let y = { name: "Alice", location: "Seattle" };
+x = y;
+```
+
+To check whether `y` can be assigned to `x`, the compiler checks each property of `x` to find a corresponding compatible property in `y`.
+In this case, `y` must have a member called `name` that is a string. It does, so the assignment is allowed.
+
+The same rule for assignment is used when checking function call arguments:
+
+```ts
+function greet(n: Named) {
+  console.log("Hello, " + n.name);
+}
+greet(y); // OK
+```
+
+Note that `y` has an extra `location` property, but this does not create an error.
+Only members of the target type (`Named` in this case) are considered when checking for compatibility.
+
+This comparison process proceeds recursively, exploring the type of each member and sub-member.
+
+## Comparing two functions
+
+While comparing primitive types and object types is relatively straightforward, the question of what kinds of functions should be considered compatible is a bit more involved.
+Let's start with a basic example of two functions that differ only in their parameter lists:
+
+```ts
+let x = (a: number) => 0;
+let y = (b: number, s: string) => 0;
+
+y = x; // OK
+x = y; // Error
+```
+
+To check if `x` is assignable to `y`, we first look at the parameter list.
+Each parameter in `x` must have a corresponding parameter in `y` with a compatible type.
+Note that the names of the parameters are not considered, only their types.
+In this case, every parameter of `x` has a corresponding compatible parameter in `y`, so the assignment is allowed.
+
+The second assignment is an error, because `y` has a required second parameter that `x` does not have, so the assignment is disallowed.
+
+You may be wondering why we allow 'discarding' parameters like in the example `y = x`.
+The reason for this assignment to be allowed is that ignoring extra function parameters is actually quite common in JavaScript.
+For example, `Array#forEach` provides three parameters to the callback function: the array element, its index, and the containing array.
+Nevertheless, it's very useful to provide a callback that only uses the first parameter:
+
+```ts
+let items = [1, 2, 3];
+
+// Don't force these extra parameters
+items.forEach((item, index, array) => console.log(item));
+
+// Should be OK!
+items.forEach((item) => console.log(item));
+```
+
+Now let's look at how return types are treated, using two functions that differ only by their return type:
+
+```ts
+let x = () => ({ name: "Alice" });
+let y = () => ({ name: "Alice", location: "Seattle" });
+
+x = y; // OK
+y = x; // Error, because x() lacks a location property
+```
+
+The type system enforces that the source function's return type be a subtype of the target type's return type.
+
+## Function Parameter Bivariance
+
+When comparing the types of function parameters, assignment succeeds if either the source parameter is assignable to the target parameter, or vice versa.
+This is unsound because a caller might end up being given a function that takes a more specialized type, but invokes the function with a less specialized type.
+In practice, this sort of error is rare, and allowing this enables many common JavaScript patterns. A brief example:
+
+```ts
+enum EventType {
+  Mouse,
+  Keyboard,
+}
+
+interface Event {
+  timestamp: number;
+}
+interface MouseEvent extends Event {
+  x: number;
+  y: number;
+}
+interface KeyEvent extends Event {
+  keyCode: number;
+}
+
+function listenEvent(eventType: EventType, handler: (n: Event) => void) {
+  /* ... */
+}
+
+// Unsound, but useful and common
+listenEvent(EventType.Mouse, (e: MouseEvent) => console.log(e.x + "," + e.y));
+
+// Undesirable alternatives in presence of soundness
+listenEvent(EventType.Mouse, (e: Event) =>
+  console.log((e as MouseEvent).x + "," + (e as MouseEvent).y)
+);
+listenEvent(EventType.Mouse, ((e: MouseEvent) =>
+  console.log(e.x + "," + e.y)) as (e: Event) => void);
+
+// Still disallowed (clear error). Type safety enforced for wholly incompatible types
+listenEvent(EventType.Mouse, (e: number) => console.log(e));
+```
+
+You can have TypeScript raise errors when this happens via the compiler flag `strictFunctionTypes`.
+
+## Optional Parameters and Rest Parameters
+
+When comparing functions for compatibility, optional and required parameters are interchangeable.
+Extra optional parameters of the source type are not an error, and optional parameters of the target type without corresponding parameters in the source type are not an error.
+
+When a function has a rest parameter, it is treated as if it were an infinite series of optional parameters.
+
+This is unsound from a type system perspective, but from a runtime point of view the idea of an optional parameter is generally not well-enforced since passing `undefined` in that position is equivalent for most functions.
+
+The motivating example is the common pattern of a function that takes a callback and invokes it with some predictable (to the programmer) but unknown (to the type system) number of arguments:
+
+```ts
+function invokeLater(args: any[], callback: (...args: any[]) => void) {
+  /* ... Invoke callback with 'args' ... */
+}
+
+// Unsound - invokeLater "might" provide any number of arguments
+invokeLater([1, 2], (x, y) => console.log(x + ", " + y));
+
+// Confusing (x and y are actually required) and undiscoverable
+invokeLater([1, 2], (x?, y?) => console.log(x + ", " + y));
+```
+
+## Functions with overloads
+
+When a function has overloads, each overload in the source type must be matched by a compatible signature on the target type.
+This ensures that the target function can be called in all the same situations as the source function.
+
+## Enums
+
+Enums are compatible with numbers, and numbers are compatible with enums. Enum values from different enum types are considered incompatible. For example,
+
+```ts
+enum Status {
+  Ready,
+  Waiting,
+}
+enum Color {
+  Red,
+  Blue,
+  Green,
+}
+
+let status = Status.Ready;
+status = Color.Green; // Error
+```
+
+## Classes
+
+Classes work similarly to object literal types and interfaces with one exception: they have both a static and an instance type.
+When comparing two objects of a class type, only members of the instance are compared.
+Static members and constructors do not affect compatibility.
+
+```ts
+class Animal {
+  feet: number;
+  constructor(name: string, numFeet: number) {}
+}
+
+class Size {
+  feet: number;
+  constructor(numFeet: number) {}
+}
+
+let a: Animal;
+let s: Size;
+
+a = s; // OK
+s = a; // OK
+```
+
+## Private and protected members in classes
+
+Private and protected members in a class affect their compatibility.
+When an instance of a class is checked for compatibility, if the target type contains a private member, then the source type must also contain a private member that originated from the same class.
+Likewise, the same applies for an instance with a protected member.
+This allows a class to be assignment compatible with its super class, but _not_ with classes from a different inheritance hierarchy which otherwise have the same shape.
+
+## Generics
+
+Because TypeScript is a structural type system, type parameters only affect the resulting type when consumed as part of the type of a member. For example,
+
+```ts
+interface Empty<T> {}
+let x: Empty<number>;
+let y: Empty<string>;
+
+x = y; // OK, because y matches structure of x
+```
+
+In the above, `x` and `y` are compatible because their structures do not use the type argument in a differentiating way.
+Changing this example by adding a member to `Empty<T>` shows how this works:
+
+```ts
+interface NotEmpty<T> {
+  data: T;
+}
+let x: NotEmpty<number>;
+let y: NotEmpty<string>;
+
+x = y; // Error, because x and y are not compatible
+```
+
+In this way, a generic type that has its type arguments specified acts just like a non-generic type.
+
+For generic types that do not have their type arguments specified, compatibility is checked by specifying `any` in place of all unspecified type arguments.
+The resulting types are then checked for compatibility, just as in the non-generic case.
+
+For example,
+
+```ts
+let identity = function <T>(x: T): T {
+  // ...
+};
+
+let reverse = function <U>(y: U): U {
+  // ...
+};
+
+identity = reverse; // OK, because (x: any) => any matches (y: any) => any
+```
+
+## Advanced Topics
+
+## Subtype vs Assignment
+
+So far, we've used "compatible", which is not a term defined in the language spec.
+In TypeScript, there are two kinds of compatibility: subtype and assignment.
+These differ only in that assignment extends subtype compatibility with rules to allow assignment to and from `any`, and to and from `enum` with corresponding numeric values.
+
+Different places in the language use one of the two compatibility mechanisms, depending on the situation.
+For practical purposes, type compatibility is dictated by assignment compatibility, even in the cases of the `implements` and `extends` clauses.

--- a/packages/documentation/copy/pt/reference/Type Compatibility.md
+++ b/packages/documentation/copy/pt/reference/Type Compatibility.md
@@ -6,118 +6,117 @@ oneline: How type-checking works in TypeScript
 translatable: true
 ---
 
-Type compatibility in TypeScript is based on structural subtyping.
-Structural typing is a way of relating types based solely on their members.
-This is in contrast with nominal typing.
-Consider the following code:
+Compatibilidade de tipos no Typescript é baseado em subtipagem estrutural.
+Tipagem estrutural é um forma de relacionar tipos baseado exclusivamente em seus membros.
+Isso vai de encontro com a tipagem nominal.
+Considere o código a seguir:
 
 ```ts
-interface Named {
-  name: string;
+interface Nomeado {
+  nome: string;
 }
 
-class Person {
-  name: string;
+class Pessoa {
+  nome: string;
 }
 
-let p: Named;
-// OK, because of structural typing
-p = new Person();
+let p: Nomeado;
+// OK, por causa da tipagem estrutural
+p = new Pessoa();
 ```
+Em linguagens nominalmente tipadas como C# ou Java, o código equivalente seria um erro porque a classe `Pessoa` não se descreve explícitamente como sendo um implementador da interface `Nomeado`.
 
-In nominally-typed languages like C# or Java, the equivalent code would be an error because the `Person` class does not explicitly describe itself as being an implementer of the `Named` interface.
+O sistema de tipagem estrutura do TypeScript foi projetado baseado em como o código Javascript é tipicamente escrito.
+Por que o Javascript faz uso amplo de objetos anônimos como funções de expressões e literais de objetos, é muito mais natural representar os tipos de relacionamentos encontrados em bibliotecas JavaScript com um sistema de tipo estrutural do que um tipo nominal.
 
-TypeScript's structural type system was designed based on how JavaScript code is typically written.
-Because JavaScript widely uses anonymous objects like function expressions and object literals, it's much more natural to represent the kinds of relationships found in JavaScript libraries with a structural type system instead of a nominal one.
+## Uma nota sobre Correção
 
-## A Note on Soundness
+O sistema de tipos do TypeScript permite certas operações, que não poderiam ser conhecidas em tempo de compilação, serem seguras.
+Quando um sistema de tipos tem essa propriedade, fica dito para não ser "correto". Os locais onde Typescript permite comportamento incorreto foram considerados cuidadosamente, e ao decorrer desse documento iremos explicar onde eles ocorrem e os cenários motivadores por tás deles. 
 
-TypeScript's type system allows certain operations that can't be known at compile-time to be safe. When a type system has this property, it is said to not be "sound". The places where TypeScript allows unsound behavior were carefully considered, and throughout this document we'll explain where these happen and the motivating scenarios behind them.
+## Começando
 
-## Starting out
-
-The basic rule for TypeScript's structural type system is that `x` is compatible with `y` if `y` has at least the same members as `x`. For example:
+A regra básica para tipagem estrutural do TypeScript é que `x` é compatível com `y` se `y` tem ao menos o mesmo numero de membros de `x`. Por exemplo:
 
 ```ts
-interface Named {
-  name: string;
+interface Nomeado {
+  nome: string;  
 }
 
-let x: Named;
-// y's inferred type is { name: string; location: string; }
-let y = { name: "Alice", location: "Seattle" };
+let x: Nomeado;
+// o tipo inferido de y é { nome: string; localizacao: string; }
+let y = { nome: "Alice", localizacao: "Acre" };
 x = y;
 ```
 
-To check whether `y` can be assigned to `x`, the compiler checks each property of `x` to find a corresponding compatible property in `y`.
-In this case, `y` must have a member called `name` that is a string. It does, so the assignment is allowed.
+Para verificar quando `y` pode ser atribuído a `x`, o compilador checa cada propriedade de `x` para encontrar uma propriedade compatível em  `y`.
+Nesse caso, `y` precisa ter um membro chamado `nome` que é uma string. Tendo feito, então a atribuição é permitida.
 
-The same rule for assignment is used when checking function call arguments:
+A mesma regra para atribuição é usada ao verificar chamadas dos argumentos da função:
 
 ```ts
-function greet(n: Named) {
-  console.log("Hello, " + n.name);
+function cumprimenta(n: Nomeado) {
+  console.log("Olá, " + n.nome);
 }
-greet(y); // OK
+cumprimenta(y); // OK
 ```
 
-Note that `y` has an extra `location` property, but this does not create an error.
-Only members of the target type (`Named` in this case) are considered when checking for compatibility.
+Perceba que `y` tem uma propriedade `localizacao` extra, mas isso não cria um erro.
+Apenas membros do tipo alvo (`Nomeado` nesse caso) são considerados ao checar por compatibilidade.
 
-This comparison process proceeds recursively, exploring the type of each member and sub-member.
+Esse processo de comparação ocorre recursivamente, explorando o tipo de cada membro e sub-membro.
 
-## Comparing two functions
+## Comparando duas funções
 
-While comparing primitive types and object types is relatively straightforward, the question of what kinds of functions should be considered compatible is a bit more involved.
-Let's start with a basic example of two functions that differ only in their parameter lists:
+Enquanto comparar tipos primitivos é relativamente simples, a questão de quais tipos de funções deveriam ser consideradas compatíveis é um pouco mais embaralhado. Vamos começar com um exemplo básico de duas funções que diferem apenas em sua lista de parâmetros:
 
 ```ts
 let x = (a: number) => 0;
 let y = (b: number, s: string) => 0;
 
 y = x; // OK
-x = y; // Error
+x = y; // Erro
 ```
 
-To check if `x` is assignable to `y`, we first look at the parameter list.
-Each parameter in `x` must have a corresponding parameter in `y` with a compatible type.
-Note that the names of the parameters are not considered, only their types.
-In this case, every parameter of `x` has a corresponding compatible parameter in `y`, so the assignment is allowed.
+Para verificar se `x` é atribuível a `y`, primeiro olhamos a lista de parâmetros.
+Cada parâmetro em `x` precisa ter um parâmetro correspondente em `y`com um tipo compatível.
+Perceba que o nome dos parâmetros não são considerados, apenas seus tipos.
+Nesse caso, cada parâmetro de `x` tem um parâmetro correspondente compatível em `y`, então a atribuição é permitida.
 
-The second assignment is an error, because `y` has a required second parameter that `x` does not have, so the assignment is disallowed.
+A segunda atribuição é um erro, porque `y` tem um segundo parâmetro requerido que `x` não tem, então a atribuição não é permitida.
 
-You may be wondering why we allow 'discarding' parameters like in the example `y = x`.
-The reason for this assignment to be allowed is that ignoring extra function parameters is actually quite common in JavaScript.
-For example, `Array#forEach` provides three parameters to the callback function: the array element, its index, and the containing array.
-Nevertheless, it's very useful to provide a callback that only uses the first parameter:
+Você pode estar se perguntando por quê permitimos parâmetros 'descartáveis' como no exemplo `y = x`.
+O motivo para essa atribuição ser permitida é que, ignorar parâmetros extras de funções, na verdade, é bem comum no JavaScript.
+Por exemplo, `Array#forEach` provém tres parâmetros para a função de callback: os elementos do array, seus index e o array.
+Mesmo assim, é muito útil prover um callback que usa apenas o primeiro parâmetro:
 
 ```ts
-let items = [1, 2, 3];
+let itens = [1, 2, 3];
 
-// Don't force these extra parameters
-items.forEach((item, index, array) => console.log(item));
+// Não força esses parâmetros extras
+itens.forEach((item, index, array) => console.log(item));
 
-// Should be OK!
-items.forEach((item) => console.log(item));
+// Deveria ser OK!
+itens.forEach((item) => console.log(item));
 ```
 
-Now let's look at how return types are treated, using two functions that differ only by their return type:
+Agora vamos olhar como os tipos retornados são tratados usando duas funções que diferem apenas em seu tipo retornado:
 
 ```ts
-let x = () => ({ name: "Alice" });
-let y = () => ({ name: "Alice", location: "Seattle" });
+let x = () => ({ nome: "Alice" });
+let y = () => ({ nome: "Alice", localizacao: "Acre" });
 
 x = y; // OK
-y = x; // Error, because x() lacks a location property
+y = x; // Erro, porque falta a propriedade localizacao em x()
 ```
 
-The type system enforces that the source function's return type be a subtype of the target type's return type.
+O sistema de tipos força que o retorno da função fonte seja um subtipo do tipo retornado da função alvo.
 
-## Function Parameter Bivariance
+## Parâmetro de Função Bivariado
 
-When comparing the types of function parameters, assignment succeeds if either the source parameter is assignable to the target parameter, or vice versa.
-This is unsound because a caller might end up being given a function that takes a more specialized type, but invokes the function with a less specialized type.
-In practice, this sort of error is rare, and allowing this enables many common JavaScript patterns. A brief example:
+Ao comparar os tipos de parâmetros de funções, a atribuição tem sucesso se o parâmetro fonte é atribuível ao parâmetro alvo, ou vice versa.
+Isso é incorreto pois pode ser dada a uma função chamadora uma função que retorna um tipo mais especializado, mas invoca a função com um tipo menos especializado. 
+Na pratica, esse tipo de erro é raro, e permitir esse comportamento viabiliza muitos padrões comuns do JavaScript. Um exemplo breve:
 
 ```ts
 enum EventType {
@@ -140,151 +139,151 @@ function listenEvent(eventType: EventType, handler: (n: Event) => void) {
   /* ... */
 }
 
-// Unsound, but useful and common
+// Incorreto, mas útil e comum
 listenEvent(EventType.Mouse, (e: MouseEvent) => console.log(e.x + "," + e.y));
 
-// Undesirable alternatives in presence of soundness
+// Alternativas indesejáveis na presença de correção
 listenEvent(EventType.Mouse, (e: Event) =>
   console.log((e as MouseEvent).x + "," + (e as MouseEvent).y)
 );
 listenEvent(EventType.Mouse, ((e: MouseEvent) =>
   console.log(e.x + "," + e.y)) as (e: Event) => void);
 
-// Still disallowed (clear error). Type safety enforced for wholly incompatible types
+// Ainda não permitido (erro claro). Segurança de tipos forçada para tipos completamente incompatíveis
 listenEvent(EventType.Mouse, (e: number) => console.log(e));
 ```
 
-You can have TypeScript raise errors when this happens via the compiler flag `strictFunctionTypes`.
+Você pode ter o TypeScript lançando erros quando isso acontece pela marcação do compilador `strictFunctionTypes`.
 
-## Optional Parameters and Rest Parameters
+## Parâmetros Opcionais e Parâmetros Rest
 
-When comparing functions for compatibility, optional and required parameters are interchangeable.
-Extra optional parameters of the source type are not an error, and optional parameters of the target type without corresponding parameters in the source type are not an error.
+Ao comparar funções para compatibilidade, parâmetros opcionais e requeridos são intercambiáveis.
+Parâmetros opcionais extras do tipo fonte não são um erro e parâmetros opcionais do tipo alvo, sem parâmetros correspondentes no tipo fonte, não são um erro.
 
-When a function has a rest parameter, it is treated as if it were an infinite series of optional parameters.
+Quando uma função tem um parâmetro do tipo rest, ela é tratada como se tivesse uma série infinita de parâmetros opcionais.
 
-This is unsound from a type system perspective, but from a runtime point of view the idea of an optional parameter is generally not well-enforced since passing `undefined` in that position is equivalent for most functions.
+Isso é incorreto pela perspectiva do sistema de tipos, mas pelo ponto de vista do tempo de execução a ideia de um parâmetro opcional é geralmente reforçada, uma vez que é o equivalente a passar `undefined` naquela posição para a maioria das funções.
 
-The motivating example is the common pattern of a function that takes a callback and invokes it with some predictable (to the programmer) but unknown (to the type system) number of arguments:
+O exemplo motivacional é o padrão comum de uma função que recebe um callback e a chama com alguma previsibilidade (para o programador) mas com numero desconhecido (para o sistema de tipos) de argumentos:
 
 ```ts
-function invokeLater(args: any[], callback: (...args: any[]) => void) {
-  /* ... Invoke callback with 'args' ... */
+function chamaDepois(args: any[], callback: (...args: any[]) => void) {
+  /* ... Chama callback com 'args' ... */
 }
 
-// Unsound - invokeLater "might" provide any number of arguments
-invokeLater([1, 2], (x, y) => console.log(x + ", " + y));
+// Incorreto - chamaDepois "poderia" prover qualquer numero de argumentos
+chamaDepois([1, 2], (x, y) => console.log(x + ", " + y));
 
-// Confusing (x and y are actually required) and undiscoverable
-invokeLater([1, 2], (x?, y?) => console.log(x + ", " + y));
+// Confuso (x e y, na verdade, são requeridos ) e indetectáveis
+chamaDepois([1, 2], (x?, y?) => console.log(x + ", " + y));
 ```
 
-## Functions with overloads
+## Funções com sobrecarga
 
-When a function has overloads, each overload in the source type must be matched by a compatible signature on the target type.
-This ensures that the target function can be called in all the same situations as the source function.
+Quando uma função tem sobrecarga, cada sobrecarga no tipo fonte deve combinar com uma assinatura compatível no tipo alvo.
+Isso assegura que a função alvo pode ser chamada nas mesmas situações da função fonte.
 
 ## Enums
 
-Enums are compatible with numbers, and numbers are compatible with enums. Enum values from different enum types are considered incompatible. For example,
+Enums são compatíveis com números e números são compatíveis com enums. Valores de Enum de tipos de enum diferentes são considerados incompatíveis. Por Exemplo,
 
 ```ts
 enum Status {
-  Ready,
-  Waiting,
+  Pronto,
+  Esperando,
 }
-enum Color {
-  Red,
-  Blue,
-  Green,
+enum Cor {
+  Vermelho,
+  Azul,
+  Verde,
 }
 
-let status = Status.Ready;
-status = Color.Green; // Error
+let status = Status.Pronto;
+status = Cor.Verde; // Erro
 ```
 
 ## Classes
 
-Classes work similarly to object literal types and interfaces with one exception: they have both a static and an instance type.
-When comparing two objects of a class type, only members of the instance are compared.
-Static members and constructors do not affect compatibility.
+Classes funcionam de forma similar a tipos literais de objetos e interfaces, com uma exceção: Ambos tem um tipo estático e de instancia.
+Ao comparar dois objetos de um tipo de classe, apenas membros da instancia são comparados. 
+Membros estáticos e construtores não afetam a compatibilidade.
 
 ```ts
 class Animal {
-  feet: number;
-  constructor(name: string, numFeet: number) {}
+  patas: number;
+  constructor(nome: string, numPatas: number) {}
 }
 
-class Size {
-  feet: number;
-  constructor(numFeet: number) {}
+class Tamanho {
+  patas: number;
+  constructor(numPatas: number) {}
 }
 
 let a: Animal;
-let s: Size;
+let s: Tamanho;
 
 a = s; // OK
 s = a; // OK
 ```
 
-## Private and protected members in classes
+## Membros privados e protegidos em classes
 
-Private and protected members in a class affect their compatibility.
-When an instance of a class is checked for compatibility, if the target type contains a private member, then the source type must also contain a private member that originated from the same class.
-Likewise, the same applies for an instance with a protected member.
-This allows a class to be assignment compatible with its super class, but _not_ with classes from a different inheritance hierarchy which otherwise have the same shape.
+Membros privados e protegidos em uma classe afetam sua compatibilidade.
+Quando a compatibilidade de uma instancia de classe é verificada, se o tipo alvo contem um membro privado, então o tipo fonte também precisa conter um membro privado que se originou da mesma classe. 
+De forma semelhante, o mesmo se aplica para uma instancia com um membro protegido.
+Isso permite manter a compatibilidade de atribuição com a sua classe super, mas _não_ com classes de hierarquias de heranças diferentes que, de outra forma, possuem a mesma estrutura.
 
 ## Generics
 
-Because TypeScript is a structural type system, type parameters only affect the resulting type when consumed as part of the type of a member. For example,
+Porquê TypeScript é um sistema de tipo estrutural, tipo dos parâmetros apenas afetam o tipo resultante quando consumidos como parte do tipo de um membro. Por Exemplo,
 
 ```ts
 interface Empty<T> {}
 let x: Empty<number>;
 let y: Empty<string>;
 
-x = y; // OK, because y matches structure of x
+x = y; // OK, porque y combina com a estrutura de x
 ```
 
-In the above, `x` and `y` are compatible because their structures do not use the type argument in a differentiating way.
-Changing this example by adding a member to `Empty<T>` shows how this works:
+No exemplo acima, `x` e `y` são compatíveis porque suas estruturas não usam o argumento de tipo de forma diferenciativa.
+Modificando esse exemplo adicionando um membro a `Empty<T>` mostra como isso funciona: 
 
 ```ts
-interface NotEmpty<T> {
+interface NaoVazio<T> {
   data: T;
 }
-let x: NotEmpty<number>;
-let y: NotEmpty<string>;
+let x: NaoVazio<number>;
+let y: NaoVazio<string>;
 
-x = y; // Error, because x and y are not compatible
+x = y; // Erro, porque x e y não são compatíveis
 ```
 
-In this way, a generic type that has its type arguments specified acts just like a non-generic type.
+Dessa forma, um tipo genérico que tem os seus tipos de argumentos especificados age como um tipo não genérico.
 
-For generic types that do not have their type arguments specified, compatibility is checked by specifying `any` in place of all unspecified type arguments.
-The resulting types are then checked for compatibility, just as in the non-generic case.
+Para tipos genéricos que nao tem seus tipos de argumentos especificados, a compatibilidade é verificada especificando `any` no lugar de todos os tipos de argumentos não especificados.
+A compatibilidade dos tipos resultantes é então verificada, assim como no caso dos tipos não genéricos.
 
-For example,
+Por exemplo,
 
 ```ts
-let identity = function <T>(x: T): T {
+let identidade = function <T>(x: T): T {
   // ...
 };
 
-let reverse = function <U>(y: U): U {
+let reverter = function <U>(y: U): U {
   // ...
 };
 
-identity = reverse; // OK, because (x: any) => any matches (y: any) => any
+identidade = reverter; // OK, porque (x: any) => any bate com (y: any) => any
 ```
 
-## Advanced Topics
+## Tópicos avançados
 
-## Subtype vs Assignment
+## Subtipos vs Atribuições
 
-So far, we've used "compatible", which is not a term defined in the language spec.
-In TypeScript, there are two kinds of compatibility: subtype and assignment.
-These differ only in that assignment extends subtype compatibility with rules to allow assignment to and from `any`, and to and from `enum` with corresponding numeric values.
+Até aqui, temos usado "compatível", que não é um termo definido nas especificações da linguagem.
+Em TypeScript, existem dois tipos de compatibilidade: subtipos e atribuições.
+Eles diferem apenas no fato de que a atribuição estende a compatibilidade do subtipo com regras para permitir a atribuição de e para `enum` com valores numéricos correspondentes. 
 
-Different places in the language use one of the two compatibility mechanisms, depending on the situation.
-For practical purposes, type compatibility is dictated by assignment compatibility, even in the cases of the `implements` and `extends` clauses.
+Diferentes locais na linguagem usam um dos dois tipos de mecanismos de compatibilidade, dependendo da situação.
+Para fins práticos, compatibilidade de tipos é ditada pela compatibilidade de atribuição, mesmo no casos das clausulas `implements` e `extends`.

--- a/packages/documentation/copy/pt/reference/Type Inference.md
+++ b/packages/documentation/copy/pt/reference/Type Inference.md
@@ -6,125 +6,125 @@ oneline: How code flow analysis works in TypeScript
 translatable: true
 ---
 
-In TypeScript, there are several places where type inference is used to provide type information when there is no explicit type annotation. For example, in this code
+Em TypeScript, existem varios locais onde a inferencia de tipos é usada para prover informacao quando não se tem um tipo explícito de anotação. Por exemplo, esse código
 
 ```ts twoslash
 let x = 3;
 //  ^?
 ```
 
-The type of the `x` variable is inferred to be `number`.
-This kind of inference takes place when initializing variables and members, setting parameter default values, and determining function return types.
+O tipo da variável `x` é inferido como sendo `number`.
+Esse tipo de inferência ocorre ao inicializar variaveis e membros, definir valores padrão de parâmetros e ao determinar o tipo de valor retornado por funções. 
 
-In most cases, type inference is straightforward.
-In the following sections, we'll explore some of the nuances in how types are inferred.
+Na maioria dos casos, inferencia de tipos é fácil de entender.
+Na próxima sessão, iremos explorar algumas das nunancias em como tipos são inferidos.
 
-## Best common type
+## Melhor tipo comum
 
-When a type inference is made from several expressions, the types of those expressions are used to calculate a "best common type". For example,
+Quando uma inferência de tipo é composta por várias expressões, o tipo dessas expressões é usada para calcular o "melhor tipo comum". Por exemplo:
 
 ```ts twoslash
 let x = [0, 1, null];
 //  ^?
 ```
 
-To infer the type of `x` in the example above, we must consider the type of each array element.
-Here we are given two choices for the type of the array: `number` and `null`.
-The best common type algorithm considers each candidate type, and picks the type that is compatible with all the other candidates.
+Para iferir o tipo de `x` no exemplo acima, nós precisamos considerar o tipo de cada elemento do array. 
+Aqui nos foi dada duas escolhas para o tipo do array: `number` e `null`.
+O algorítimo do melhor tipo comum considera o tipo de cada candidato e escolhe o tipo que é compativel com todos os outros candidatos.
 
-Because the best common type has to be chosen from the provided candidate types, there are some cases where types share a common structure, but no one type is the super type of all candidate types. For example:
-
-```ts twoslash
-// @strict: false
-class Animal {}
-class Rhino extends Animal {
-  hasHorn: true;
-}
-class Elephant extends Animal {
-  hasTrunk: true;
-}
-class Snake extends Animal {
-  hasLegs: false;
-}
-// ---cut---
-let zoo = [new Rhino(), new Elephant(), new Snake()];
-//    ^?
-```
-
-Ideally, we may want `zoo` to be inferred as an `Animal[]`, but because there is no object that is strictly of type `Animal` in the array, we make no inference about the array element type.
-To correct this, instead explicitly provide the type when no one type is a super type of all other candidates:
+Porquê o melhor tipo comum tem de ser escolhido a partir dos tipos candidatos providos, existem alguns casos onde tipos compartilham uma estrutura comum, mas nunhum tipo é o super tipo de todos os tipos candidatos. Por Exemplo:
 
 ```ts twoslash
 // @strict: false
 class Animal {}
-class Rhino extends Animal {
-  hasHorn: true;
+class Rinoceronte extends Animal {
+  temChifre: true;
 }
-class Elephant extends Animal {
-  hasTrunk: true;
+class Elefante extends Animal {
+  temTromba: true;
 }
-class Snake extends Animal {
-  hasLegs: false;
+class Cobra extends Animal {
+  temPernas: false;
 }
 // ---cut---
-let zoo: Animal[] = [new Rhino(), new Elephant(), new Snake()];
+let zoo = [new Rinoceronte(), new Elefante(), new Cobra()];
 //    ^?
 ```
 
-When no best common type is found, the resulting inference is the union array type, `(Rhino | Elephant | Snake)[]`.
+De forma ideal, queremos que `zoo` seja inferido como um `Animal[]`, mas como não existe um objeto que seja estritamente do tipo `Animal` no array, nós não fazemos inferências sobre o tipo de elemento do array.
+Para corrigir isso, em troca forneça explicitamente o tipo quando nenhum tipo é um super tipo de todos os outros candidatos:
 
-## Contextual Typing
+```ts twoslash
+// @strict: false
+class Animal {}
+class Rinoceronte extends Animal {
+  temChifre: true;
+}
+class Elefante extends Animal {
+  temTromba: true;
+}
+class Cobra extends Animal {
+  temPernas: false;
+}
+// ---cut---
+let zoo: Animal[] = [new Rinoceronte(), new Elefante(), new Cobra()];
+//    ^?
+```
 
-Type inference also works in "the other direction" in some cases in TypeScript.
-This is known as "contextual typing". Contextual typing occurs when the type of an expression is implied by its location. For example:
+Quando nenhum tipo comum é encontrado, a inferência resultante é a união dos tipos do array, `(Rinoceronte | Elefante | Cobra)[]`.
+
+## Tipagem Contextual
+
+Inferência de tipo também funciona "em direção oposta" em alguns casos no TypeScript.
+Isso é conhecido como "tipagem contextual". Tipagem contextual ocorre quando o tipo de uma expressão é implícito por sua localização. Por exemplo:
 
 ```ts
 window.onmousedown = function (mouseEvent) {
-  console.log(mouseEvent.button); //<- OK
-  console.log(mouseEvent.kangaroo); //<- Error!
+  console.log(mouseEvent.botao); //<- OK
+  console.log(mouseEvent.canguru); //<- Error!
 };
 ```
 
-Here, the TypeScript type checker used the type of the `Window.onmousedown` function to infer the type of the function expression on the right hand side of the assignment.
-When it did so, it was able to infer the [type](https://developer.mozilla.org/docs/Web/API/MouseEvent) of the `mouseEvent` parameter, which does contain a `button` property, but not a `kangaroo` property.
+Aqui, o verificador de tipos do TypeScript usa o tipo da função `Window.onmousedown` para inferir o tipo da expressão função do lado direito da atribuição.
+Ao fazer isso, ele foi capaz de inferir o [tipo](https://developer.mozilla.org/docs/Web/API/MouseEvent) do parâmetro `mouseEvent`, que de fato contém uma propriedade `botao`, mas não uma propriedade `canguru`.
 
-TypeScript is smart enough to infer types in other contexts as well:
+TypeScript é inteligente o suficiente para inferir tipos em outros contextos também:
 
 ```ts
 window.onscroll = function (uiEvent) {
-  console.log(uiEvent.button); //<- Error!
+  console.log(uiEvent.botao); //<- Erro!
 };
 ```
 
-Based on the fact that the above function is being assigned to `Window.onscroll`, TypeScript knows that `uiEvent` is a [UIEvent](https://developer.mozilla.org/docs/Web/API/UIEvent), and not a [MouseEvent](https://developer.mozilla.org/docs/Web/API/MouseEvent) like the previous example. `UIEvent` objects contain no `button` property, and so TypeScript will throw an error.
+Baseado no fato que a função acima foi atribuida a `Window.onscroll`, TypeScript sabe que `uiEvent` é um [UIEvent](https://developer.mozilla.org/docs/Web/API/UIEvent), e não um [MouseEvent](https://developer.mozilla.org/docs/Web/API/MouseEvent) como no exemplo anterior. Objetos `UIEvent` não contém a propriedade `botao`, dessa forma TypeScript irá lançar um erro.
 
-If this function were not in a contextually typed position, the function's argument would implicitly have type `any`, and no error would be issued (unless you are using the `--noImplicitAny` option):
+Se essa função não estivesse digitada em uma posição contextualizada, os argumentos da função teriam implicitamente o tipo `any`, e nenhum erro seria emitido (a não ser que você esteja usando a opção `--noImplicitAny`):
 
 ```ts
 const handler = function (uiEvent) {
-  console.log(uiEvent.button); //<- OK
+  console.log(uiEvent.botao); //<- OK
 };
 ```
 
-We can also explicitly give type information to the function's argument to override any contextual type:
+Nós também podemos fornecer explicitamente informação sobre o tipo para que os argumentos da função sobrescrevam qualquer tipo contextual:
 
 ```ts
 window.onscroll = function (uiEvent: any) {
-  console.log(uiEvent.button); //<- Now, no error is given
+  console.log(uiEvent.botao); //<- Agora, nenhum erro é fornecido
 };
 ```
 
-However, this code will log `undefined`, since `uiEvent` has no property called `button`.
+Entretanto, esse código será exibido no log como `undefined`, uma vez que `uiEvent` não tem nenhuma propriedade `botao`.
 
-Contextual typing applies in many cases.
-Common cases include arguments to function calls, right hand sides of assignments, type assertions, members of object and array literals, and return statements.
-The contextual type also acts as a candidate type in best common type. For example:
+Tipagem contextual se aplica em muitos casos.
+Casos comuns incluem argumentos para chamadas de fuções, lado direito de atribuições, asserções de tipo, membros de objetos, arrays literais, e declarações de retorno.
+O tipo contextual também age como um tipo candidato no melhor tipo comum. Por exemplo: 
 
 ```ts
-function createZoo(): Animal[] {
-  return [new Rhino(), new Elephant(), new Snake()];
+function criaZologico(): Animal[] {
+  return [new Rinoceronte(), new Elefante(), new Cobra()];
 }
 ```
 
-In this example, best common type has a set of four candidates: `Animal`, `Rhino`, `Elephant`, and `Snake`.
-Of these, `Animal` can be chosen by the best common type algorithm.
+Nesse exemplo, o melhor tipo comum tem um grupo de quatro candidatos: `Animal`, `Rinoceronte`, `Elefante`, and `Cobra`.
+Desses, `Animal` pode ser escolhido pelo algorítimo de melhor candidato comum.

--- a/packages/documentation/copy/pt/reference/Type Inference.md
+++ b/packages/documentation/copy/pt/reference/Type Inference.md
@@ -1,7 +1,7 @@
 ---
 title: Inferência de Tipo
 layout: docs
-permalink: /docs/handbook/type-inference.html
+permalink: /pt/docs/handbook/type-inference.html
 oneline: Como a analise do fluxo de código funciona em TypeScript
 translatable: true
 ---

--- a/packages/documentation/copy/pt/reference/Type Inference.md
+++ b/packages/documentation/copy/pt/reference/Type Inference.md
@@ -6,7 +6,7 @@ oneline: How code flow analysis works in TypeScript
 translatable: true
 ---
 
-Em TypeScript, existem varios locais onde a inferencia de tipos é usada para prover informacao quando não se tem um tipo explícito de anotação. Por exemplo, esse código
+Em TypeScript, existem vários locais onde a inferência de tipos é usada para prover informação quando não se tem um tipo explícito de anotação. Por exemplo, nesse código
 
 ```ts twoslash
 let x = 3;
@@ -14,10 +14,10 @@ let x = 3;
 ```
 
 O tipo da variável `x` é inferido como sendo `number`.
-Esse tipo de inferência ocorre ao inicializar variaveis e membros, definir valores padrão de parâmetros e ao determinar o tipo de valor retornado por funções. 
+Esse tipo de inferência ocorre ao inicializar variáveis e membros, definir valores padrão de parâmetros e ao determinar o tipo de valor retornado por funções. 
 
-Na maioria dos casos, inferencia de tipos é fácil de entender.
-Na próxima sessão, iremos explorar algumas das nunancias em como tipos são inferidos.
+Na maioria dos casos, inferência de tipos é fácil de entender.
+Na próxima sessão, iremos explorar algumas das nuances em como tipos são inferidos.
 
 ## Melhor tipo comum
 
@@ -28,11 +28,11 @@ let x = [0, 1, null];
 //  ^?
 ```
 
-Para iferir o tipo de `x` no exemplo acima, nós precisamos considerar o tipo de cada elemento do array. 
+Para inferir o tipo de `x` no exemplo acima, nós precisamos considerar o tipo de cada elemento do array. 
 Aqui nos foi dada duas escolhas para o tipo do array: `number` e `null`.
-O algorítimo do melhor tipo comum considera o tipo de cada candidato e escolhe o tipo que é compativel com todos os outros candidatos.
+O algoritmo do melhor tipo comum considera o tipo de cada candidato e escolhe o tipo que é compatível com todos os outros candidatos.
 
-Porquê o melhor tipo comum tem de ser escolhido a partir dos tipos candidatos providos, existem alguns casos onde tipos compartilham uma estrutura comum, mas nunhum tipo é o super tipo de todos os tipos candidatos. Por Exemplo:
+Porquê o melhor tipo comum tem de ser escolhido a partir dos tipos candidatos providos, existem alguns casos onde tipos compartilham uma estrutura comum, mas nenhum tipo é o supertipo de todos os tipos candidatos. Por Exemplo:
 
 ```ts twoslash
 // @strict: false
@@ -52,7 +52,7 @@ let zoo = [new Rinoceronte(), new Elefante(), new Cobra()];
 ```
 
 De forma ideal, queremos que `zoo` seja inferido como um `Animal[]`, mas como não existe um objeto que seja estritamente do tipo `Animal` no array, nós não fazemos inferências sobre o tipo de elemento do array.
-Para corrigir isso, em troca forneça explicitamente o tipo quando nenhum tipo é um super tipo de todos os outros candidatos:
+Para corrigir isso, em troca forneça explicitamente o tipo quando nenhum outro tipo é um supertipo de todos os outros candidatos:
 
 ```ts twoslash
 // @strict: false
@@ -76,7 +76,7 @@ Quando nenhum tipo comum é encontrado, a inferência resultante é a união dos
 ## Tipagem Contextual
 
 Inferência de tipo também funciona "em direção oposta" em alguns casos no TypeScript.
-Isso é conhecido como "tipagem contextual". Tipagem contextual ocorre quando o tipo de uma expressão é implícito por sua localização. Por exemplo:
+Isso é conhecido como "tipagem contextual". Tipagem contextual ocorre quando o tipo de uma expressão é inferido por sua localização. Por exemplo:
 
 ```ts
 window.onmousedown = function (mouseEvent) {
@@ -117,7 +117,7 @@ window.onscroll = function (uiEvent: any) {
 Entretanto, esse código será exibido no log como `undefined`, uma vez que `uiEvent` não tem nenhuma propriedade `botao`.
 
 Tipagem contextual se aplica em muitos casos.
-Casos comuns incluem argumentos para chamadas de fuções, lado direito de atribuições, asserções de tipo, membros de objetos, arrays literais, e declarações de retorno.
+Casos comuns incluem argumentos para chamadas de funções, lado direito de atribuições, asserções de tipo, membros de objetos, arrays literais, e declarações de retorno.
 O tipo contextual também age como um tipo candidato no melhor tipo comum. Por exemplo: 
 
 ```ts
@@ -126,5 +126,5 @@ function criaZologico(): Animal[] {
 }
 ```
 
-Nesse exemplo, o melhor tipo comum tem um grupo de quatro candidatos: `Animal`, `Rinoceronte`, `Elefante`, and `Cobra`.
+Nesse exemplo, o melhor tipo comum tem um grupo de quatro candidatos: `Animal`, `Rinoceronte`, `Elefante`, e `Cobra`.
 Desses, `Animal` pode ser escolhido pelo algorítimo de melhor candidato comum.

--- a/packages/documentation/copy/pt/reference/Type Inference.md
+++ b/packages/documentation/copy/pt/reference/Type Inference.md
@@ -1,0 +1,130 @@
+---
+title: Type Inference
+layout: docs
+permalink: /docs/handbook/type-inference.html
+oneline: How code flow analysis works in TypeScript
+translatable: true
+---
+
+In TypeScript, there are several places where type inference is used to provide type information when there is no explicit type annotation. For example, in this code
+
+```ts twoslash
+let x = 3;
+//  ^?
+```
+
+The type of the `x` variable is inferred to be `number`.
+This kind of inference takes place when initializing variables and members, setting parameter default values, and determining function return types.
+
+In most cases, type inference is straightforward.
+In the following sections, we'll explore some of the nuances in how types are inferred.
+
+## Best common type
+
+When a type inference is made from several expressions, the types of those expressions are used to calculate a "best common type". For example,
+
+```ts twoslash
+let x = [0, 1, null];
+//  ^?
+```
+
+To infer the type of `x` in the example above, we must consider the type of each array element.
+Here we are given two choices for the type of the array: `number` and `null`.
+The best common type algorithm considers each candidate type, and picks the type that is compatible with all the other candidates.
+
+Because the best common type has to be chosen from the provided candidate types, there are some cases where types share a common structure, but no one type is the super type of all candidate types. For example:
+
+```ts twoslash
+// @strict: false
+class Animal {}
+class Rhino extends Animal {
+  hasHorn: true;
+}
+class Elephant extends Animal {
+  hasTrunk: true;
+}
+class Snake extends Animal {
+  hasLegs: false;
+}
+// ---cut---
+let zoo = [new Rhino(), new Elephant(), new Snake()];
+//    ^?
+```
+
+Ideally, we may want `zoo` to be inferred as an `Animal[]`, but because there is no object that is strictly of type `Animal` in the array, we make no inference about the array element type.
+To correct this, instead explicitly provide the type when no one type is a super type of all other candidates:
+
+```ts twoslash
+// @strict: false
+class Animal {}
+class Rhino extends Animal {
+  hasHorn: true;
+}
+class Elephant extends Animal {
+  hasTrunk: true;
+}
+class Snake extends Animal {
+  hasLegs: false;
+}
+// ---cut---
+let zoo: Animal[] = [new Rhino(), new Elephant(), new Snake()];
+//    ^?
+```
+
+When no best common type is found, the resulting inference is the union array type, `(Rhino | Elephant | Snake)[]`.
+
+## Contextual Typing
+
+Type inference also works in "the other direction" in some cases in TypeScript.
+This is known as "contextual typing". Contextual typing occurs when the type of an expression is implied by its location. For example:
+
+```ts
+window.onmousedown = function (mouseEvent) {
+  console.log(mouseEvent.button); //<- OK
+  console.log(mouseEvent.kangaroo); //<- Error!
+};
+```
+
+Here, the TypeScript type checker used the type of the `Window.onmousedown` function to infer the type of the function expression on the right hand side of the assignment.
+When it did so, it was able to infer the [type](https://developer.mozilla.org/docs/Web/API/MouseEvent) of the `mouseEvent` parameter, which does contain a `button` property, but not a `kangaroo` property.
+
+TypeScript is smart enough to infer types in other contexts as well:
+
+```ts
+window.onscroll = function (uiEvent) {
+  console.log(uiEvent.button); //<- Error!
+};
+```
+
+Based on the fact that the above function is being assigned to `Window.onscroll`, TypeScript knows that `uiEvent` is a [UIEvent](https://developer.mozilla.org/docs/Web/API/UIEvent), and not a [MouseEvent](https://developer.mozilla.org/docs/Web/API/MouseEvent) like the previous example. `UIEvent` objects contain no `button` property, and so TypeScript will throw an error.
+
+If this function were not in a contextually typed position, the function's argument would implicitly have type `any`, and no error would be issued (unless you are using the `--noImplicitAny` option):
+
+```ts
+const handler = function (uiEvent) {
+  console.log(uiEvent.button); //<- OK
+};
+```
+
+We can also explicitly give type information to the function's argument to override any contextual type:
+
+```ts
+window.onscroll = function (uiEvent: any) {
+  console.log(uiEvent.button); //<- Now, no error is given
+};
+```
+
+However, this code will log `undefined`, since `uiEvent` has no property called `button`.
+
+Contextual typing applies in many cases.
+Common cases include arguments to function calls, right hand sides of assignments, type assertions, members of object and array literals, and return statements.
+The contextual type also acts as a candidate type in best common type. For example:
+
+```ts
+function createZoo(): Animal[] {
+  return [new Rhino(), new Elephant(), new Snake()];
+}
+```
+
+In this example, best common type has a set of four candidates: `Animal`, `Rhino`, `Elephant`, and `Snake`.
+Of these, `Animal` can be chosen by the best common type algorithm.

--- a/packages/documentation/copy/pt/reference/Type Inference.md
+++ b/packages/documentation/copy/pt/reference/Type Inference.md
@@ -1,8 +1,8 @@
 ---
-title: Type Inference
+title: Inferência de Tipo
 layout: docs
 permalink: /docs/handbook/type-inference.html
-oneline: How code flow analysis works in TypeScript
+oneline: Como a analise do fluxo de código funciona em TypeScript
 translatable: true
 ---
 


### PR DESCRIPTION
@khaosdoctor  @danilofuchs @orta 

This PR (Ref #233) translates the following files to Brazilian Portuguese:
 - Type Inference
 - Type Compatibility 

During the translation process I found the following title: 

### [A note about Soundness](https://github.com/microsoft/TypeScript-Website/blob/v2/packages/documentation/copy/en/reference/Type%20Compatibility.md#a-note-on-soundness)

Wich introduced the therm `Soundness` into the text. According to Wikipedia Soundness could be interpreted as:

> [In logic, more precisely in deductive reasoning, an argument is sound if it is both valid in form and its premises are true.[1] Soundness also has a related meaning in mathematical logic, wherein logical systems are sound if and only if every formula that can be proved in the system is logically valid with respect to the semantics of the system.](https://en.wikipedia.org/wiki/Soundness)

Soundness is often applied as "sound" and "unsound" throughout the text. I'd had trouble finding a corresponding word to use so I stick with the Wikipedia [Portuguese translation](https://pt.wikipedia.org/wiki/Corre%C3%A7%C3%A3o) and used:
 - Soundness as 'Correção'
 - Sound as 'Correto'
 - Unsound as 'Incorreto'