### PR TITLE
docs(i18n-id): Provide Indonesian translation for documentation

### DIFF
--- a/packages/documentation/copy/id/Nightly Builds.md
+++ b/packages/documentation/copy/id/Nightly Builds.md
@@ -6,7 +6,7 @@ oneline: Cara menggunakan nightly build TypeScript
 translatable: true
 ---
 
-Nightly build dari branch [master TypeScript](https://github.com/Microsoft/TypeScript/tree/master) diterbitkan pada tengah malam, di zona waktu PST ke npm.
+_Nightly build_ dari _branch_ [master TypeScript](https://github.com/Microsoft/TypeScript/tree/master) diterbitkan pada tengah malam, di zona waktu PST ke npm.
 Berikut adalah cara untuk mendapatkan versi ini dan cara menggunakannya.
 
 ## Menggunakan npm
@@ -15,11 +15,11 @@ Berikut adalah cara untuk mendapatkan versi ini dan cara menggunakannya.
 npm install -g typescript@next
 ```
 
-## Memperbarui IDE-mu untuk menggunakan nightly builds
+## Memperbarui IDE-mu untuk menggunakan _nightly builds_
 
-Anda juga dapat memperbarui IDE-mu untuk menggunakan nightly drop.
-Pertama, anda akan perlu untuk memasang package melalui npm.
-Anda juga dapat memasang npm package secara global atau pada folder `node_modules` di dalam proyek-mu.
+Anda juga dapat memperbarui IDE-mu untuk menggunakan _nightly_ drop.
+Pertama, Anda akan perlu untuk memasang package melalui npm.
+Anda juga dapat memasang npm package secara global atau pada direktori `node_modules` di dalam proyekmu.
 
 Pada tahap ini diasumsikan bahwa `typescript@next` sudah di-install.
 
@@ -35,10 +35,10 @@ Informasi lebih lanjut ada di [VSCode documentation](https://code.visualstudio.c
 
 ### Sublime Text
 
-Perbarui file `Settings - User` dengan cara berikut:
+Perbarui berkas `Settings - User` dengan cara berikut:
 
 ```json
-"typescript_tsdk": "<path ke folder-mu>/node_modules/typescript/lib"
+"typescript_tsdk": "<path ke direktorimu>/node_modules/typescript/lib"
 ```
 
 Informasi lebih lanjut ada di [TypeScript Plugin for Sublime Text installation documentation](https://github.com/Microsoft/TypeScript-Sublime-Plugin#installation).
@@ -49,16 +49,16 @@ Informasi lebih lanjut ada di [TypeScript Plugin for Sublime Text installation d
 
 Saat ini, Nightly build tidak menyertakan plugin secara lengkap, tapi kami sedang mengupayakan untuk menerbitkan sebuah installer di nightly.
 
-1. Unduh skrip [VSDevMode.ps1](https://github.com/Microsoft/TypeScript/blob/master/scripts/VSDevMode.ps1) script.
+1. Unduh kode [VSDevMode.ps1](https://github.com/Microsoft/TypeScript/blob/master/scripts/VSDevMode.ps1) kode.
 
-   > Lihat juga halaman wiki kami di [menggunakan custom language service file](https://github.com/Microsoft/TypeScript/wiki/Dev-Mode-in-Visual-Studio#using-a-custom-language-service-file).
+   > Lihat juga halaman wiki kami di [menggunakan berkas custom language service](https://github.com/Microsoft/TypeScript/wiki/Dev-Mode-in-Visual-Studio#using-a-custom-language-service-file).
 
 2. Melalui perintah PowerShell, jalankan:
 
 Untuk VS 2015:
 
 ```posh
-VSDevMode.ps1 14 -tsScript <path ke folder-mu>/node_modules/typescript/lib
+VSDevMode.ps1 14 -tsScript <path ke direktorimu>/node_modules/typescript/lib
 ```
 
 Untuk VS 2013:

--- a/packages/documentation/copy/id/Nightly Builds.md
+++ b/packages/documentation/copy/id/Nightly Builds.md
@@ -19,9 +19,9 @@ npm install -g typescript@next
 
 Anda juga dapat memperbarui IDE-mu untuk menggunakan _nightly_ drop.
 Pertama, Anda akan perlu untuk memasang package melalui npm.
-Anda juga dapat memasang npm package secara global atau pada direktori `node_modules` di dalam proyekmu.
+Anda juga dapat memasang npm _package_ secara global atau pada direktori `node_modules` di dalam proyekmu.
 
-Pada tahap ini diasumsikan bahwa `typescript@next` sudah di-install.
+Pada tahap ini diasumsikan bahwa `typescript@next` sudah dipasang.
 
 ### Visual Studio Code
 
@@ -31,7 +31,7 @@ Perbarui `.vscode/settings.json` dengan cara berikut:
 "typescript.tsdk": "<path ke folder-mu>/node_modules/typescript/lib"
 ```
 
-Informasi lebih lanjut ada di [VSCode documentation](https://code.visualstudio.com/Docs/languages/typescript#_using-newer-typescript-versions).
+Informasi lebih lanjut ada di [Dokumentasi VSCode](https://code.visualstudio.com/Docs/languages/typescript#_using-newer-typescript-versions).
 
 ### Sublime Text
 
@@ -41,13 +41,13 @@ Perbarui berkas `Settings - User` dengan cara berikut:
 "typescript_tsdk": "<path ke direktorimu>/node_modules/typescript/lib"
 ```
 
-Informasi lebih lanjut ada di [TypeScript Plugin for Sublime Text installation documentation](https://github.com/Microsoft/TypeScript-Sublime-Plugin#installation).
+Informasi lebih lanjut ada di [Dokumentasi pemasangan _Plugin_ TypeScript untuk Sublime Text](https://github.com/Microsoft/TypeScript-Sublime-Plugin#installation).
 
 ### Visual Studio 2013 dan 2015
 
-> Catatan: Sebagian besar perubahan tidak mengharuskan anda untuk memasang versi terbaru dari plugin VS TypeScript.
+> Catatan: Sebagian besar perubahan tidak mengharuskan anda untuk memasang versi terbaru dari _plugin_ VS TypeScript.
 
-Saat ini, Nightly build tidak menyertakan plugin secara lengkap, tapi kami sedang mengupayakan untuk menerbitkan sebuah installer di nightly.
+Saat ini, _Nightly build_ tidak menyertakan _plugin_ secara lengkap, tapi kami sedang mengupayakan untuk menerbitkan sebuah _installer_ di _nightly_.
 
 1. Unduh kode [VSDevMode.ps1](https://github.com/Microsoft/TypeScript/blob/master/scripts/VSDevMode.ps1) kode.
 
@@ -71,10 +71,10 @@ VSDevMode.ps1 12 -tsScript <path ke folder-mu>/node_modules/typescript/lib
 
 Masuk ke `Preferences` > `Languages & Frameworks` > `TypeScript`:
 
-> TypeScript Version: Jika anda memasangnya dengan npm, maka akan ada di `/usr/local/lib/node_modules/typescript/lib`
+> Versi TypeScript: Jika anda memasangnya dengan npm, maka akan ada di `/usr/local/lib/node_modules/typescript/lib`
 
 ### IntelliJ IDEA (Windows)
 
 Masuk ke `File` > `Settings` > `Languages & Frameworks` > `TypeScript`:
 
-> TypeScript Version: Jika anda memasangnya dengan npm, maka akan ada di `C:\Users\USERNAME\AppData\Roaming\npm\node_modules\typescript\lib`
+> Versi TypeScript: Jika anda memasangnya dengan npm, maka akan ada di `C:\Users\USERNAME\AppData\Roaming\npm\node_modules\typescript\lib`

--- a/packages/documentation/copy/id/Nightly Builds.md
+++ b/packages/documentation/copy/id/Nightly Builds.md
@@ -1,0 +1,80 @@
+---
+title: Nightly Builds
+layout: docs
+permalink: /id/docs/handbook/nightly-builds.html
+oneline: Cara menggunakan nightly build TypeScript
+translatable: true
+---
+
+Nightly build dari branch [master TypeScript](https://github.com/Microsoft/TypeScript/tree/master) diterbitkan pada tengah malam, di zona waktu PST ke npm.
+Berikut adalah cara untuk mendapatkan versi ini dan cara menggunakannya.
+
+## Menggunakan npm
+
+```shell
+npm install -g typescript@next
+```
+
+## Memperbarui IDE-mu untuk menggunakan nightly builds
+
+Anda juga dapat memperbarui IDE-mu untuk menggunakan nightly drop.
+Pertama, anda akan perlu untuk memasang package melalui npm.
+Anda juga dapat memasang npm package secara global atau pada folder `node_modules` di dalam proyek-mu.
+
+Pada tahap ini diasumsikan bahwa `typescript@next` sudah di-install.
+
+### Visual Studio Code
+
+Perbarui `.vscode/settings.json` dengan cara berikut:
+
+```json
+"typescript.tsdk": "<path ke folder-mu>/node_modules/typescript/lib"
+```
+
+Informasi lebih lanjut ada di [VSCode documentation](https://code.visualstudio.com/Docs/languages/typescript#_using-newer-typescript-versions).
+
+### Sublime Text
+
+Perbarui file `Settings - User` dengan cara berikut:
+
+```json
+"typescript_tsdk": "<path ke folder-mu>/node_modules/typescript/lib"
+```
+
+Informasi lebih lanjut ada di [TypeScript Plugin for Sublime Text installation documentation](https://github.com/Microsoft/TypeScript-Sublime-Plugin#installation).
+
+### Visual Studio 2013 dan 2015
+
+> Catatan: Sebagian besar perubahan tidak mengharuskan anda untuk memasang versi terbaru dari plugin VS TypeScript.
+
+Saat ini, Nightly build tidak menyertakan plugin secara lengkap, tapi kami sedang mengupayakan untuk menerbitkan sebuah installer di nightly.
+
+1. Unduh skrip [VSDevMode.ps1](https://github.com/Microsoft/TypeScript/blob/master/scripts/VSDevMode.ps1) script.
+
+   > Lihat juga halaman wiki kami di [menggunakan custom language service file](https://github.com/Microsoft/TypeScript/wiki/Dev-Mode-in-Visual-Studio#using-a-custom-language-service-file).
+
+2. Melalui perintah PowerShell, jalankan:
+
+Untuk VS 2015:
+
+```posh
+VSDevMode.ps1 14 -tsScript <path ke folder-mu>/node_modules/typescript/lib
+```
+
+Untuk VS 2013:
+
+```posh
+VSDevMode.ps1 12 -tsScript <path ke folder-mu>/node_modules/typescript/lib
+```
+
+### IntelliJ IDEA (Mac)
+
+Masuk ke `Preferences` > `Languages & Frameworks` > `TypeScript`:
+
+> TypeScript Version: Jika anda memasangnya dengan npm, maka akan ada di `/usr/local/lib/node_modules/typescript/lib`
+
+### IntelliJ IDEA (Windows)
+
+Masuk ke `File` > `Settings` > `Languages & Frameworks` > `TypeScript`:
+
+> TypeScript Version: Jika anda memasangnya dengan npm, maka akan ada di `C:\Users\USERNAME\AppData\Roaming\npm\node_modules\typescript\lib`

--- a/packages/documentation/copy/id/javascript/Creating DTS files From JS.md
+++ b/packages/documentation/copy/id/javascript/Creating DTS files From JS.md
@@ -1,0 +1,87 @@
+---
+title: Creating .d.ts Files from .js files
+layout: docs
+permalink: /id/docs/handbook/declaration-files/dts-from-js.html
+oneline: "Bagaimana cara menambahkan hasil d.ts ke proyek JavaScript"
+translatable: true
+---
+
+[Dengan TypeScript 3.7](/docs/handbook/release-notes/typescript-3-7.html#--declaration-and---allowjs), TypeScript menambahkan dukungan untuk menghasilkan file .d.ts dari JavaScript menggunakan sintaks JSDoc.
+
+Pengaturan ini berarti Anda memiliki editor yang mendukung TypeScript tanpa memindahkan proyek anda ke TypeScript, atau harus memelihara file .d.ts di basis kodemu.
+TypeScript mendukung sebagian besar tag JSDoc, Anda bisa menemukannya [di referensi ini](/docs/handbook/type-checking-javascript-files.html#supported-jsdoc).
+
+## Menyiapkan proyekmu untuk menggunakan file .d.ts
+
+Untuk menambahkan pembuatan file .d.ts di proyekmu, Anda perlu melakukan hingga empat langkah:
+
+- Tambahkan TypeScript ke dependensi dev Anda
+- Tambahkan `tsconfig.json` untuk mengkonfigurasi TypeScript
+- Jalankan compiler TypeScript untuk menghasilkan file d.ts yang sesuai untuk file JS
+- (opsional) Edit package.json Anda untuk mereferensikan tipe
+
+### Menambahkan TypeScript
+
+Anda bisa mempelajari cara melakukan ini di [halaman instalasi](/download) kami.
+
+### TSConfig
+
+TSConfig adalah file jsonc yang mengkonfigurasi kedua flag compiler Anda, dan menyatakan di mana mencari file.
+Dalam kasus ini, Anda menginginkan file seperti berikut:
+
+```json5
+{
+  // Change this to match your project
+  include: ["src/**/*"],
+
+  compilerOptions: {
+    // Tells TypeScript to read JS files, as
+    // normally they are ignored as source files
+    allowJs: true,
+    // Generate d.ts files
+    declaration: true,
+    // This compiler run should
+    // only output d.ts files
+    emitDeclarationOnly: true,
+    // Types should go into this directory.
+    // Removing this would place the .d.ts files
+    // next to the .js files
+    outDir: "dist",
+  },
+}
+```
+
+Anda dapat mempelajari lebih lanjut tentang opsi di [referensi tsconfig](/reference).
+Alternatif untuk menggunakan file TSConfig adalah CLI, ini adalah perilaku yang sama seperti perintah CLI.
+
+```sh
+npx typescript src/**/*.js --declaration --allowJs --emitDeclarationOnly --outDir types
+```
+
+## Menjalankan compiler
+
+Anda bisa mempelajari bagaimana melakukan ini di [halaman pemasangan](/download) TypeScript kami.
+Anda perlu memastikan file-file ini disertakan dalam package Anda jika Anda memiliki file dalam `gitignore` proyek Anda.
+
+## Meng-edit file package.json
+
+TypeScript mereplikasi resolusi node untuk modul di `package.json`, dengan langkah tambahan untuk menemukan file .d.ts.
+Secara kasar, resolusi pertama-tama akan memeriksa bidang `"types"` opsional, kemudian bidang `"main"`, dan terakhir akan mencoba `index.d.ts` di root.
+
+| Package.json              | Location of default .d.ts      |
+| :------------------------ | :----------------------------- |
+| No "types" field          | checks "main", then index.d.ts |
+| "types": "main.d.ts"      | main.d.ts                      |
+| "types": "./dist/main.js" | ./main/main.d.ts               |
+
+Jika tidak ada, maka "main" akan digunakan
+
+| Package.json             | Location of default .d.ts |
+| :----------------------- | :------------------------ |
+| No "main" field          | index.d.ts                |
+| "main":"index.js"        | index.d.ts                |
+| "main":"./dist/index.js" | ./dist/index.d.ts         |
+
+## Tips
+
+Jika kamu suka menulis tes untuk file .d.ts, coba [tsd](https://github.com/SamVerschueren/tsd).

--- a/packages/documentation/copy/id/javascript/Creating DTS files From JS.md
+++ b/packages/documentation/copy/id/javascript/Creating DTS files From JS.md
@@ -6,19 +6,19 @@ oneline: "Bagaimana cara menambahkan hasil d.ts ke proyek JavaScript"
 translatable: true
 ---
 
-[Dengan TypeScript 3.7](/docs/handbook/release-notes/typescript-3-7.html#--declaration-and---allowjs), TypeScript menambahkan dukungan untuk menghasilkan file .d.ts dari JavaScript menggunakan sintaks JSDoc.
+[Dengan TypeScript 3.7](/docs/handbook/release-notes/typescript-3-7.html#--declaration-and---allowjs), TypeScript menambahkan dukungan untuk menghasilkan berkas .d.ts dari JavaScript menggunakan sintaks JSDoc.
 
-Pengaturan ini berarti Anda memiliki editor yang mendukung TypeScript tanpa memindahkan proyek anda ke TypeScript, atau harus memelihara file .d.ts di basis kodemu.
+Pengaturan ini berarti Anda memiliki _editor_ yang mendukung TypeScript tanpa memindahkan proyek anda ke TypeScript, atau harus memelihara berkas .d.ts di basis kodemu.
 TypeScript mendukung sebagian besar tag JSDoc, Anda bisa menemukannya [di referensi ini](/docs/handbook/type-checking-javascript-files.html#supported-jsdoc).
 
-## Menyiapkan proyekmu untuk menggunakan file .d.ts
+## Menyiapkan proyekmu untuk menggunakan berkas .d.ts
 
-Untuk menambahkan pembuatan file .d.ts di proyekmu, Anda perlu melakukan hingga empat langkah:
+Untuk menambahkan pembuatan berkas .d.ts di proyekmu, Anda perlu melakukan empat langkah berikut:
 
 - Tambahkan TypeScript ke dependensi _dev_ Anda
 - Tambahkan `tsconfig.json` untuk mengkonfigurasi TypeScript
-- Jalankan kompilator TypeScript untuk menghasilkan file d.ts yang sesuai untuk file JS
-- (opsional) Edit package.json Anda untuk mereferensikan tipe
+- Jalankan kompilator TypeScript untuk menghasilkan berkas d.ts yang sesuai untuk berkas JS
+- (_opsional_) Sunting package.json Anda untuk mereferensikan tipe
 
 ### Menambahkan TypeScript
 
@@ -26,7 +26,7 @@ Anda bisa mempelajari cara melakukan ini di [halaman instalasi](/download) kami.
 
 ### TSConfig
 
-TSConfig adalah file jsonc yang mengkonfigurasi kedua _flag_ kompilator Anda, dan menyatakan di mana mencari file.
+TSConfig adalah berkas jsonc yang mengkonfigurasi kedua _flag_ kompilator Anda, dan menyatakan di mana mencari berkas.
 Dalam kasus ini, Anda menginginkan berkas seperti berikut:
 
 ```json5
@@ -35,8 +35,8 @@ Dalam kasus ini, Anda menginginkan berkas seperti berikut:
   include: ["src/**/*"],
 
   compilerOptions: {
-    // Memberi tahu TypeScript untuk membaca file JS,
-    // karena biasanya file tersebut diabaikan sebagai file sumber
+    // Memberi tahu TypeScript untuk membaca berkas JS,
+    // karena biasanya berkas tersebut diabaikan sebagai berkas sumber
     allowJs: true,
     // Hasilkan berkas d.ts
     declaration: true,
@@ -45,14 +45,14 @@ Dalam kasus ini, Anda menginginkan berkas seperti berikut:
     emitDeclarationOnly: true,
     // Tipe harus masuk ke direktori ini.
     // Menghapus ini akan menempatkan berkas .d.ts
-    // di sebelah file .js
+    // di sebelah berkas .js
     outDir: "dist",
   },
 }
 ```
 
 Anda dapat mempelajari lebih lanjut tentang opsi di [referensi tsconfig](/reference).
-Alternatif untuk menggunakan file TSConfig adalah CLI, ini adalah perilaku yang sama seperti perintah CLI.
+Alternatif untuk menggunakan berkas TSConfig adalah CLI, ini adalah perilaku yang sama seperti perintah CLI.
 
 ```sh
 npx typescript src/**/*.js --declaration --allowJs --emitDeclarationOnly --outDir types
@@ -61,12 +61,12 @@ npx typescript src/**/*.js --declaration --allowJs --emitDeclarationOnly --outDi
 ## Menjalankan kompilator
 
 Anda bisa mempelajari bagaimana melakukan ini di [halaman pemasangan](/download) TypeScript kami.
-Anda perlu memastikan file-file ini disertakan dalam package Anda jika Anda memiliki file dalam `gitignore` proyek Anda.
+Anda perlu memastikan berkas-berkas ini disertakan dalam package Anda jika Anda memiliki berkas dalam `gitignore` proyek Anda.
 
-## Menyunting file package.json
+## Menyunting berkas package.json
 
-TypeScript mereplikasi resolusi node untuk modul di `package.json`, dengan langkah tambahan untuk menemukan file .d.ts.
-Secara garis besar, Pertama-tama resolusi akan memeriksa bagian `"types"` yang opsional, kemudian bidang `"main"`, dan terakhir akan mencoba `index.d.ts` di root.
+TypeScript mereplikasi resolusi _node_ untuk modul di `package.json`, dengan langkah tambahan untuk menemukan berkas .d.ts.
+Secara garis besar, Pertama-tama resolusi akan memeriksa bagian `"types"` yang opsional, kemudian bidang `"main"`, dan terakhir akan mencoba `index.d.ts` di _root_.
 
 | Package.json              | Location of default .d.ts      |
 | :------------------------ | :----------------------------- |
@@ -84,4 +84,4 @@ Jika tidak ada, maka "main" akan digunakan
 
 ## Tips
 
-Jika kamu suka menulis tes untuk file .d.ts, coba [tsd](https://github.com/SamVerschueren/tsd).
+Jika kamu suka menulis tes untuk berkas .d.ts, coba [tsd](https://github.com/SamVerschueren/tsd).

--- a/packages/documentation/copy/id/javascript/Creating DTS files From JS.md
+++ b/packages/documentation/copy/id/javascript/Creating DTS files From JS.md
@@ -1,5 +1,5 @@
 ---
-title: Creating .d.ts Files from .js files
+title: Membuat Berkas .d.ts dari berkas .js
 layout: docs
 permalink: /id/docs/handbook/declaration-files/dts-from-js.html
 oneline: "Bagaimana cara menambahkan hasil d.ts ke proyek JavaScript"
@@ -15,9 +15,9 @@ TypeScript mendukung sebagian besar tag JSDoc, Anda bisa menemukannya [di refere
 
 Untuk menambahkan pembuatan file .d.ts di proyekmu, Anda perlu melakukan hingga empat langkah:
 
-- Tambahkan TypeScript ke dependensi dev Anda
+- Tambahkan TypeScript ke dependensi _dev_ Anda
 - Tambahkan `tsconfig.json` untuk mengkonfigurasi TypeScript
-- Jalankan compiler TypeScript untuk menghasilkan file d.ts yang sesuai untuk file JS
+- Jalankan kompilator TypeScript untuk menghasilkan file d.ts yang sesuai untuk file JS
 - (opsional) Edit package.json Anda untuk mereferensikan tipe
 
 ### Menambahkan TypeScript
@@ -26,26 +26,26 @@ Anda bisa mempelajari cara melakukan ini di [halaman instalasi](/download) kami.
 
 ### TSConfig
 
-TSConfig adalah file jsonc yang mengkonfigurasi kedua flag compiler Anda, dan menyatakan di mana mencari file.
-Dalam kasus ini, Anda menginginkan file seperti berikut:
+TSConfig adalah file jsonc yang mengkonfigurasi kedua _flag_ kompilator Anda, dan menyatakan di mana mencari file.
+Dalam kasus ini, Anda menginginkan berkas seperti berikut:
 
 ```json5
 {
-  // Change this to match your project
+  // Ubah ini agar sesuai dengan proyek Anda
   include: ["src/**/*"],
 
   compilerOptions: {
-    // Tells TypeScript to read JS files, as
-    // normally they are ignored as source files
+    // Memberi tahu TypeScript untuk membaca file JS,
+    // karena biasanya file tersebut diabaikan sebagai file sumber
     allowJs: true,
-    // Generate d.ts files
+    // Hasilkan berkas d.ts
     declaration: true,
-    // This compiler run should
-    // only output d.ts files
+    // Proses kompilator ini seharusnya
+    // hanya mengeluarkan berkas d.ts
     emitDeclarationOnly: true,
-    // Types should go into this directory.
-    // Removing this would place the .d.ts files
-    // next to the .js files
+    // Tipe harus masuk ke direktori ini.
+    // Menghapus ini akan menempatkan berkas .d.ts
+    // di sebelah file .js
     outDir: "dist",
   },
 }
@@ -58,15 +58,15 @@ Alternatif untuk menggunakan file TSConfig adalah CLI, ini adalah perilaku yang 
 npx typescript src/**/*.js --declaration --allowJs --emitDeclarationOnly --outDir types
 ```
 
-## Menjalankan compiler
+## Menjalankan kompilator
 
 Anda bisa mempelajari bagaimana melakukan ini di [halaman pemasangan](/download) TypeScript kami.
 Anda perlu memastikan file-file ini disertakan dalam package Anda jika Anda memiliki file dalam `gitignore` proyek Anda.
 
-## Meng-edit file package.json
+## Menyunting file package.json
 
 TypeScript mereplikasi resolusi node untuk modul di `package.json`, dengan langkah tambahan untuk menemukan file .d.ts.
-Secara kasar, resolusi pertama-tama akan memeriksa bidang `"types"` opsional, kemudian bidang `"main"`, dan terakhir akan mencoba `index.d.ts` di root.
+Secara garis besar, Pertama-tama resolusi akan memeriksa bagian `"types"` yang opsional, kemudian bidang `"main"`, dan terakhir akan mencoba `index.d.ts` di root.
 
 | Package.json              | Location of default .d.ts      |
 | :------------------------ | :----------------------------- |

--- a/packages/documentation/copy/id/javascript/Intro to JS with TS.md
+++ b/packages/documentation/copy/id/javascript/Intro to JS with TS.md
@@ -1,0 +1,70 @@
+---
+title: JS Projects Utilizing TypeScript
+layout: docs
+permalink: /id/docs/handbook/intro-to-js-ts.html
+oneline: Cara menambahkan pemeriksaan type ke file JavaScript menggunakan TypeScript
+translatable: true
+---
+
+Sistem tipe di TypeScript memiliki tingkat keketatan yang berbeda saat bekerja dengan basis kode:
+
+- Sistem tipe yang hanya berdasarkan pada inferensi dengan kode JavaScript
+- Pengetikkan incremental di JavaScript [melalui JSDoc](/docs/handbook/jsdoc-supported-types.html)
+- Menggunakan `// @ts-check` di file JavaScript
+- Kode TypeScript
+- TypeScript dengan [`strict`](/tsconfig#strict) diaktifkan
+
+Setiap langkah mewakili gerakan menuju sistem tipe yang lebih aman, tetapi tidak setiap proyek membutuhkan tingkat verifikasi seperti itu.
+
+## TypeScript dengan JavaScript
+
+Ini ketika editor-mu yang menggunakan TypeScript untuk menyediakan tool, seperti auto-complete, jump to symbil, dan refactoring, misalnya penamaan ulang.
+Di [Homepage](/) tersedia daftar editor yang memiliki plugin TypeScript.
+
+## Menyediakan Type Hints di JS melalui JSDoc
+
+Di file `.js`, type sering kali dapat diketahui. Namun ketika type tidak diketahui, mereka bisa ditentukan menggunakan sintaks JSDoc.
+
+Anotasi JSDoc diletakkan sebelum mendeklarasikan suatu hal. Seperti contoh berikut:
+
+```js twoslash
+/** @type {number} */
+var x;
+
+x = 0; // OK
+x = false; // OK?!
+```
+
+Anda dapat menemukan daftar lengkap mengenai dukungan pola JSDoc [di Tipe-tipe yang didukung JSDoc](/docs/handbook/jsdoc-supported-types.html)
+
+## `@ts-check`
+
+Baris terakhir dari contoh kode sebelumnya akan menimbulkan kesalahan dalam TypeScript, tetapi tidak secara default dalam proyek JS.
+Untuk mengaktifkan error dalam file JavaScript-mu, tambahkan: `// @ ts-check` ke baris pertama dalam file`.js` Anda agar TypeScript dapat memeriksa kesalahan.
+
+```js twoslash
+// @ts-check
+// @errors: 2322
+/** @type {number} */
+var x;
+
+x = 0; // OK
+x = false; // Not OK
+```
+
+Jika anda memiliki banyak file JavaScript yang ingin ditambahkan pemeriksaan error-nya, anda bisa beralhir menggunakan [`jsconfig.json`](/docs/handbook/tsconfig-json.html).
+Dengan begitu, anda tidak perlu menambahkan `// @ts-nocheck` di tiap file-nya.
+
+TypeScript mungkin memberikan error yang kamu tidak sepakati. Pada kasus tersebut, anda bisa membiarkan error itu spesifik dibaris manapun dengan menambahkan `// @ts-ignore` atau `// @ts-expect-error`.
+
+```js twoslash
+// @ts-check
+/** @type {number} */
+var x;
+
+x = 0; // OK
+// @ts-expect-error
+x = false; // Not OK
+```
+
+Untuk mempelajari lebih lanjut bagaimana JavaScript diinterpretasi oleh TypeScript, anda dapat membaca [Bagaimana TS Type Memeriksa JS](/docs/handbook/type-checking-javascript-files.html)

--- a/packages/documentation/copy/id/javascript/Intro to JS with TS.md
+++ b/packages/documentation/copy/id/javascript/Intro to JS with TS.md
@@ -10,7 +10,7 @@ Sistem tipe data di TypeScript memiliki tingkat keketatan yang berbeda saat beke
 
 - Sistem tipe data yang hanya berdasarkan pada inferensi dengan kode JavaScript
 - Pengetikkan secara bertahap di JavaScript [melalui JSDoc](/docs/handbook/jsdoc-supported-types.html)
-- Menggunakan `// @ts-check` di file JavaScript
+- Menggunakan `// @ts-check` di berkas JavaScript
 - Kode TypeScript
 - TypeScript dengan [`strict`](/tsconfig#strict) diaktifkan
 
@@ -18,12 +18,12 @@ Setiap langkah mewakili tahapan sistem tipe yang lebih aman, tetapi tidak setiap
 
 ## TypeScript dengan JavaScript
 
-Ini ketika editor-mu yang menggunakan TypeScript untuk menyediakan tool, seperti auto-complete, jump to symbil, dan refactoring, misalnya penamaan ulang.
-Di [Homepage](/) tersedia daftar editor yang memiliki plugin TypeScript.
+Ini ketika _editor_-mu yang menggunakan TypeScript untuk menyediakan _tool_, seperti _auto-complete_, _jump to symbol_, dan _refactoring_, misalnya penamaan ulang.
+Di [Homepage](/) tersedia daftar _editor_ yang memiliki plugin TypeScript.
 
 ## Menyediakan Type Hints di JS melalui JSDoc
 
-Di file `.js`, tipe sering kali dapat diketahui. Namun ketika tipe tidak diketahui, mereka bisa ditentukan menggunakan sintaks JSDoc.
+Di berkas `.js`, tipe sering kali dapat diketahui. Namun ketika tipe tidak diketahui, mereka bisa ditentukan menggunakan sintaks JSDoc.
 
 Anotasi JSDoc diletakkan sebelum mendeklarasikan suatu hal. Seperti contoh berikut:
 
@@ -40,7 +40,7 @@ Anda dapat menemukan daftar lengkap mengenai dukungan pola JSDoc [di Tipe-tipe y
 ## `@ts-check`
 
 Baris terakhir dari contoh kode sebelumnya akan menimbulkan kesalahan dalam TypeScript, tetapi tidak secara bawaan dalam proyek JS.
-Untuk mengaktifkan galat dalam file JavaScript-mu, tambahkan: `// @ ts-check` ke baris pertama dalam file`.js` Anda agar TypeScript dapat memeriksa kesalahan.
+Untuk mengaktifkan galat dalam berkas JavaScript-mu, tambahkan: `// @ ts-check` ke baris pertama dalam berkas`.js` Anda agar TypeScript dapat memeriksa kesalahan.
 
 ```js twoslash
 // @ts-check
@@ -52,8 +52,8 @@ x = 0; // OK
 x = false; // Not OK
 ```
 
-Jika anda memiliki banyak file JavaScript yang ingin ditambahkan pemeriksaan galatnya, Anda bisa beralhir menggunakan [`jsconfig.json`](/docs/handbook/tsconfig-json.html).
-Dengan begitu, Anda tidak perlu menambahkan `// @ts-nocheck` di tiap file-nya.
+Jika anda memiliki banyak berkas JavaScript yang ingin ditambahkan pemeriksaan galatnya, Anda bisa beralhir menggunakan [`jsconfig.json`](/docs/handbook/tsconfig-json.html).
+Dengan begitu, Anda tidak perlu menambahkan `// @ts-nocheck` di tiap berkasnya.
 
 TypeScript mungkin memberikan galat yang Anda tidak sepakati. Pada kasus tersebut, Anda bisa membiarkan galat itu spesifik dibaris manapun dengan menambahkan `// @ts-ignore` atau `// @ts-expect-error`.
 

--- a/packages/documentation/copy/id/javascript/Intro to JS with TS.md
+++ b/packages/documentation/copy/id/javascript/Intro to JS with TS.md
@@ -1,20 +1,20 @@
 ---
-title: JS Projects Utilizing TypeScript
+title: Memanfaatkan Typescript pada Proyek JS
 layout: docs
 permalink: /id/docs/handbook/intro-to-js-ts.html
-oneline: Cara menambahkan pemeriksaan type ke file JavaScript menggunakan TypeScript
+oneline: Cara menambahkan pemeriksaan tipe data pada berkas JavaScript menggunakan TypeScript
 translatable: true
 ---
 
-Sistem tipe di TypeScript memiliki tingkat keketatan yang berbeda saat bekerja dengan basis kode:
+Sistem tipe data di TypeScript memiliki tingkat keketatan yang berbeda saat bekerja dengan basis kode:
 
-- Sistem tipe yang hanya berdasarkan pada inferensi dengan kode JavaScript
-- Pengetikkan incremental di JavaScript [melalui JSDoc](/docs/handbook/jsdoc-supported-types.html)
+- Sistem tipe data yang hanya berdasarkan pada inferensi dengan kode JavaScript
+- Pengetikkan secara bertahap di JavaScript [melalui JSDoc](/docs/handbook/jsdoc-supported-types.html)
 - Menggunakan `// @ts-check` di file JavaScript
 - Kode TypeScript
 - TypeScript dengan [`strict`](/tsconfig#strict) diaktifkan
 
-Setiap langkah mewakili gerakan menuju sistem tipe yang lebih aman, tetapi tidak setiap proyek membutuhkan tingkat verifikasi seperti itu.
+Setiap langkah mewakili tahapan sistem tipe yang lebih aman, tetapi tidak setiap proyek membutuhkan tingkat verifikasi seperti itu.
 
 ## TypeScript dengan JavaScript
 
@@ -23,7 +23,7 @@ Di [Homepage](/) tersedia daftar editor yang memiliki plugin TypeScript.
 
 ## Menyediakan Type Hints di JS melalui JSDoc
 
-Di file `.js`, type sering kali dapat diketahui. Namun ketika type tidak diketahui, mereka bisa ditentukan menggunakan sintaks JSDoc.
+Di file `.js`, tipe sering kali dapat diketahui. Namun ketika tipe tidak diketahui, mereka bisa ditentukan menggunakan sintaks JSDoc.
 
 Anotasi JSDoc diletakkan sebelum mendeklarasikan suatu hal. Seperti contoh berikut:
 
@@ -39,8 +39,8 @@ Anda dapat menemukan daftar lengkap mengenai dukungan pola JSDoc [di Tipe-tipe y
 
 ## `@ts-check`
 
-Baris terakhir dari contoh kode sebelumnya akan menimbulkan kesalahan dalam TypeScript, tetapi tidak secara default dalam proyek JS.
-Untuk mengaktifkan error dalam file JavaScript-mu, tambahkan: `// @ ts-check` ke baris pertama dalam file`.js` Anda agar TypeScript dapat memeriksa kesalahan.
+Baris terakhir dari contoh kode sebelumnya akan menimbulkan kesalahan dalam TypeScript, tetapi tidak secara bawaan dalam proyek JS.
+Untuk mengaktifkan galat dalam file JavaScript-mu, tambahkan: `// @ ts-check` ke baris pertama dalam file`.js` Anda agar TypeScript dapat memeriksa kesalahan.
 
 ```js twoslash
 // @ts-check
@@ -52,10 +52,10 @@ x = 0; // OK
 x = false; // Not OK
 ```
 
-Jika anda memiliki banyak file JavaScript yang ingin ditambahkan pemeriksaan error-nya, anda bisa beralhir menggunakan [`jsconfig.json`](/docs/handbook/tsconfig-json.html).
-Dengan begitu, anda tidak perlu menambahkan `// @ts-nocheck` di tiap file-nya.
+Jika anda memiliki banyak file JavaScript yang ingin ditambahkan pemeriksaan galatnya, Anda bisa beralhir menggunakan [`jsconfig.json`](/docs/handbook/tsconfig-json.html).
+Dengan begitu, Anda tidak perlu menambahkan `// @ts-nocheck` di tiap file-nya.
 
-TypeScript mungkin memberikan error yang kamu tidak sepakati. Pada kasus tersebut, anda bisa membiarkan error itu spesifik dibaris manapun dengan menambahkan `// @ts-ignore` atau `// @ts-expect-error`.
+TypeScript mungkin memberikan galat yang Anda tidak sepakati. Pada kasus tersebut, Anda bisa membiarkan galat itu spesifik dibaris manapun dengan menambahkan `// @ts-ignore` atau `// @ts-expect-error`.
 
 ```js twoslash
 // @ts-check
@@ -67,4 +67,4 @@ x = 0; // OK
 x = false; // Not OK
 ```
 
-Untuk mempelajari lebih lanjut bagaimana JavaScript diinterpretasi oleh TypeScript, anda dapat membaca [Bagaimana TS Type Memeriksa JS](/docs/handbook/type-checking-javascript-files.html)
+Untuk mempelajari lebih lanjut bagaimana JavaScript diinterpretasi oleh TypeScript, Anda dapat membaca [Bagaimana TS Type Memeriksa JS](/docs/handbook/type-checking-javascript-files.html)

--- a/packages/documentation/copy/id/javascript/JSDoc Reference.md
+++ b/packages/documentation/copy/id/javascript/JSDoc Reference.md
@@ -1,5 +1,5 @@
 ---
-title: JSDoc Reference
+title: Referensi JSDoc
 layout: docs
 permalink: /id/docs/handbook/jsdoc-supported-types.html
 oneline: JSDoc apa yang didukung JavaScript dan TypeScript?
@@ -104,7 +104,7 @@ var stringToNumber;
 var arrayLike;
 ```
 
-Dua jenis sebelumnya sama dengan type TypeScript `{ [x: string]: number }` dan `{ [x: number]: any }`. Compiler memahami kedua sintaks tersebut.
+Dua jenis sebelumnya sama dengan tipe TypeScript `{ [x: string]: number }` dan `{ [x: number]: any }`. Kompilator memahami kedua sintaks tersebut.
 
 Anda dapat menentukan jenis fungsi menggunakan sintaks TypeScript atau Closure:
 
@@ -140,7 +140,7 @@ var question;
 ### Casts
 
 TypeScript meminjam sintaks cast dari Closure.
-Ini memungkinkan Anda mentransmisikan type ke type lain dengan menambahkan tag `@type` sebelum ekspresi dalam tanda kurung.
+Ini memungkinkan Anda mentransmisikan tipe ke tipe lain dengan menambahkan tag `@type` sebelum ekspresi dalam tanda kurung.
 
 ```js twoslash
 /**
@@ -152,7 +152,7 @@ var typeAssertedNumber = /** @type {number} */ (numberOrString);
 
 ### Impor type
 
-Anda bisa juga mengimpor deklarasi dari file lain menggunakan impor type.
+Anda bisa juga mengimpor deklarasi dari file lain menggunakan impor tipe.
 Sintaks ini khusus untuk TypeScript dan berbeda dari standar JSDoc:
 
 ```js twoslash
@@ -170,7 +170,7 @@ function walk(p) {
 }
 ```
 
-mengimpor type juga dapat digunakan di deklarasi type alias:
+mengimpor tipe juga dapat digunakan di deklarasi tipe alias:
 
 ```js twoslash
 // @filename: types.d.ts
@@ -190,7 +190,7 @@ var myPet;
 myPet.name;
 ```
 
-Mengimpor type dapat digunakan untuk mendapatkan type nilai dari module, jika Anda tidak mengetahui jenisnya, atau jika nilai tersebut memiliki type yang besar yang dapat mengganggu untuk diketik:
+Mengimpor tipe dapat digunakan untuk mendapatkan tipe nilai dari modul, jika Anda tidak mengetahui jenisnya, atau jika nilai tersebut memiliki tipe yang besar yang dapat mengganggu untuk diketik:
 
 ```js twoslash
 // @filename: accounts.d.ts
@@ -231,7 +231,7 @@ function stringsStringStrings(p1, p2, p3, p4) {
 }
 ```
 
-Demikian juga, untuk type kembalian suatu fungsi:
+Demikian juga, untuk tipe kembalian suatu fungsi:
 
 ```js twoslash
 /**
@@ -253,11 +253,11 @@ Sintaks yang bekerja dengan `@params`.
 ```js twoslash
 /**
  * @typedef {Object} SpecialType - buat type baru bernama 'SpecialType'
- * @property {string} prop1 - property string dari SpecialType
- * @property {number} prop2 - property number dari SpecialType
- * @property {number=} prop3 - opsional property number dari SpecialType
- * @prop {number} [prop4] - opsional property number dari SpecialType
- * @prop {number} [prop5=42] - opsional property number dari SpecialType dengan nilai standar
+ * @property {string} prop1 - properti string dari SpecialType
+ * @property {number} prop2 - properti number dari SpecialType
+ * @property {number=} prop3 - properti number opsional dari SpecialType
+ * @prop {number} [prop4] - properti number opsional dari SpecialType
+ * @prop {number} [prop5=42] - properti number opsional dari SpecialType dengan nilai standar
  */
 
 /** @type {SpecialType} */
@@ -269,18 +269,18 @@ Anda bisa menggunakan `object` atau `Object` pada baris pertama.
 
 ```js twoslash
 /**
- * @typedef {object} SpecialType1 - buat type baru bernama 'SpecialType'
- * @property {string} prop1 - property string dari SpecialType
- * @property {number} prop2 - property number dari SpecialType
- * @property {number=} prop3 - opsional property number dari SpecialType
+ * @typedef {object} SpecialType1 - buat tipe baru bernama 'SpecialType'
+ * @property {string} prop1 - properti string dari SpecialType
+ * @property {number} prop2 - properti number dari SpecialType
+ * @property {number=} prop3 - opsional properti number dari SpecialType
  */
 
 /** @type {SpecialType1} */
 var specialTypeObject1;
 ```
 
-`@params` memperbolehkan sintaks yang serupa untuk spesifikasi type-nya.
-Perhatikan bahwa nama nested property harus diawali dengan nama parameternya:
+`@params` memperbolehkan sintaks yang serupa untuk spesifikasi tipenya.
+Perhatikan bahwa nama properti _nested_ harus diawali dengan nama parameternya:
 
 ```js twoslash
 /**
@@ -296,7 +296,7 @@ function special(options) {
 }
 ```
 
-`@callback` mirip dengan `@typedef`, tetapi ini menetapkan type fungsi daripada type objek:
+`@callback` mirip dengan `@typedef`, tetapi ini menetapkan tipe fungsi daripada tipe objek:
 
 ```js twoslash
 /**
@@ -324,7 +324,7 @@ Anda dapat mendeklarasikan fungsi generik dengan tag `@template`:
 ```js twoslash
 /**
  * @template T
- * @param {T} x - Parameter umum yang mengalir ke return type
+ * @param {T} x - Parameter umum yang mengalir ke tipe kembalian
  * @return {T}
  */
 function id(x) {
@@ -336,7 +336,7 @@ const b = id(123);
 const c = id({});
 ```
 
-Gunakan koma atau beberapa tag untuk mendeklarasikan beberapa parameter type:
+Gunakan koma atau beberapa tag untuk mendeklarasikan beberapa parameter tipe:
 
 ```js
 /**
@@ -345,8 +345,8 @@ Gunakan koma atau beberapa tag untuk mendeklarasikan beberapa parameter type:
  */
 ```
 
-Anda juga bisa menentukan batasan type sebelum nama parameternya.
-Hanya parameter type pertama dalam sebuah list yang dibatasi.
+Anda juga bisa menentukan batasan tipe sebelum nama parameternya.
+Hanya parameter tipe pertama dalam sebuah list yang dibatasi.
 
 ```js twoslash
 /**
@@ -383,7 +383,7 @@ class C {
     /** @type {number} */
     this.size;
 
-    this.initialize(data); // Seharusnya error, karena initialize mengharapkan string
+    this.initialize(data); // Seharusnya galat, karena inisialisasi mengharapkan string
   }
   /**
    * @param {string} s
@@ -405,7 +405,7 @@ Mereka juga dapat dideklarasikan sebagai fungsi konstruktor, seperti yang dijela
 
 ## `@constructor`
 
-Compiler menyimpulkan fungsi konstruktor berdasarkan penetapan properti ini, tetapi Anda dapat membuat pemeriksaan lebih ketat dan saran lebih baik jika Anda menambahkan tag `@constructor`:
+Kompilator menyimpulkan fungsi konstruktor berdasarkan penetapan properti ini, tetapi Anda dapat membuat pemeriksaan lebih ketat dan saran lebih baik jika Anda menambahkan tag `@constructor`:
 
 ```js twoslash
 // @checkJs
@@ -415,7 +415,7 @@ Compiler menyimpulkan fungsi konstruktor berdasarkan penetapan properti ini, tet
  * @param {number} data
  */
 function C(data) {
-  // type property yang dapat diketahui
+  // tipe properti yang dapat diketahui
   this.name = "foo";
 
   // atau atur secara eksplisit
@@ -441,15 +441,15 @@ c.size;
 var result = C(1);
 ```
 
-> Catatan: Pesan error hanya tampil di basis kode JS dengan [JSConfig](/docs/handbook/tsconfig-json.html) dan [`checkJS`](/tsconfig#checkJs) yang diaktifkan.
+> Catatan: Pesan galat hanya tampil di basis kode JS dengan [JSConfig](/docs/handbook/tsconfig-json.html) dan [`checkJS`](/tsconfig#checkJs) yang diaktifkan.
 
-Dengan `@constructor`, `this` diperiksa didalam fungsi konstruktor `C`, jadi anda akan mendapatkan saran untuk method `initialize` dan sebuah error jika anda memasukkan sebuah angka. Editor-mu mungkin akan menampilkan peringatan jika memanggil `C` daripada mengkonstruksikannya.
+Dengan `@constructor`, `this` diperiksa didalam fungsi konstruktor `C`, jadi anda akan mendapatkan saran untuk method `initialize` dan sebuah galat jika anda memasukkan sebuah angka. Editor-mu mungkin akan menampilkan peringatan jika memanggil `C` daripada mengkonstruksikannya.
 
 Sayangnya, ini berarti bahwa fungsi konstruktor yang juga dapat dipanggil tidak dapat menggunakan `@constructor`.
 
 ## `@this`
 
-Compiler biasanya dapat mengetahui type `this` ketika ia memiliki beberapa konteks untuk dikerjakan. Jika tidak, Anda dapat secara eksplisit menentukan jenis `this` dengan `@this`:
+Kompilator biasanya dapat mengetahui tipe `this` ketika ia memiliki beberapa konteks untuk dikerjakan. Jika tidak, Anda dapat secara eksplisit menentukan jenis `this` dengan `@this`:
 
 ```js twoslash
 /**
@@ -463,7 +463,7 @@ function callbackForLater(e) {
 
 ## `@extends`
 
-Ketika kelas JavaScript memperluas _base class_, tidak ada tempat untuk menentukan seharusnya menggunakan parameter type yang seperti apa. Tag `@extends` menyediakan tempat untuk parameter jenis itu:
+Ketika kelas JavaScript memperluas _base class_, tidak ada tempat untuk menentukan seharusnya menggunakan parameter tipe yang seperti apa. Tag `@extends` menyediakan tempat untuk parameter jenis itu:
 
 ```js twoslash
 /**
@@ -479,7 +479,7 @@ Perhatikan bahwa `@extends` hanya berfungsi dengan kelas. Saat ini, tidak ada ca
 
 ## `@enum`
 
-Tag `@enum` memungkinkan Anda membuat literal objek yang type anggotanya spesifik. Tidak seperti kebanyakan literal objek di JavaScript, ini tidak mengizinkan anggota lain.
+Tag `@enum` memungkinkan Anda membuat literal objek yang tipe anggotanya spesifik. Tidak seperti kebanyakan literal objek di JavaScript, ini tidak mengizinkan anggota lain.
 
 ```js twoslash
 /** @enum {number} */
@@ -512,7 +512,7 @@ class Foo {}
 // ---cut---
 var someObj = {
   /**
-   * @param {string} param1 - Dokumen tentang tugas property
+   * @param {string} param1 - Dokumen tentang tugas properti
    */
   x: function (param1) {},
 };
@@ -563,7 +563,7 @@ function fn9(p1) {
 
 ## Pola yang diketahui TIDAK didukung
 
-Mengacu pada objek di value space sebagai type yang tidak berfungsi, kecuali objek tersebut juga membuat type, seperti fungsi konstruktor.
+Mengacu pada objek di value space sebagai tipe yang tidak berfungsi, kecuali objek tersebut juga membuat tipe, seperti fungsi konstruktor.
 
 ```js twoslash
 function aNormalFunction() {}
@@ -578,7 +578,7 @@ var wrong;
 var right;
 ```
 
-Postfix sama dengan type property dalam type literal objek yang tidak menetapkan properti opsional:
+Postfix sama dengan tipe properti dalam tipe literal objek yang tidak menetapkan properti opsional:
 
 ```js twoslash
 /**
@@ -619,13 +619,13 @@ Type non-nullable tidak memiliki arti dan diperlakukan seperti jenis aslinya:
 ```js twoslash
 /**
  * @type {!number}
- * Hanya ber-type number
+ * Hanya bertipe number
  */
 var normal;
 ```
 
 If it is off, then `number` is nullable.
-Tidak seperti sistem type JSDoc, TypeScript hanya memungkinkan Anda untuk menandai type, apakah mengandung null atau tidak.
+Tidak seperti sistem tipe JSDoc, TypeScript hanya memungkinkan Anda untuk menandai tipe, apakah mengandung null atau tidak.
 Tidak ada non-nullability eksplisit - jika strictNullChecks aktif, `number` tidak dapat dinihilkan.
 Jika tidak aktif, maka `number` adalah nullable.
 
@@ -667,11 +667,11 @@ const c = new Car();
 console.log(c.identifier);
 ```
 
-- `@public` ini berarti property dapat diakses dari mana saja.
+- `@public` ini berarti properti dapat diakses dari mana saja.
 - `@private` berarti bahwa properti hanya dapat digunakan di dalam kelas yang memuatnya.
 - `@protected` berarti bahwa properti hanya dapat digunakan di dalam kelas penampung, dan semua subkelas turunan, tetapi tidak pada instance kelas penampung yang berbeda.
 
-Selanjutnya, kita juga telah menambahkan modifier `@readonly` untuk memastikan bahwa sebuah property hanya dapat di-write selama inisialisasi.
+Selanjutnya, kita juga telah menambahkan modifier `@readonly` untuk memastikan bahwa sebuah properti hanya dapat di-write selama inisialisasi.
 
 ```js twoslash
 // @errors: 2540

--- a/packages/documentation/copy/id/javascript/JSDoc Reference.md
+++ b/packages/documentation/copy/id/javascript/JSDoc Reference.md
@@ -6,7 +6,7 @@ oneline: JSDoc apa yang didukung JavaScript dan TypeScript?
 translatable: true
 ---
 
-Dibawah ini adalah daftar anotasi yang didukung saat menggunakan JSDoc untuk menyediakan informasi di file Javscript.
+Dibawah ini adalah daftar anotasi yang didukung saat menggunakan JSDoc untuk menyediakan informasi di berkas Javscript.
 
 Perhatikan semua tag yang tidak secara eksplisit dicantumkan di bawah (seperti `@ async`) belum didukung.
 
@@ -25,14 +25,14 @@ Perhatikan semua tag yang tidak secara eksplisit dicantumkan di bawah (seperti `
 
 - [Property Modifiers](#jsdoc-property-modifiers) `@public`, `@private`, `@protected`, `@readonly`
 
-Artinya biasanya sama, atau superset, dari arti tag yang diberikan di [jsdoc.app](https://jsdoc.app).
-Kode dibawah mendeskripsikan perbedaan dan beberapa contoh dari setiap tag-nya.
+Artinya biasanya sama, atau _superset_, dari arti _tag_ yang diberikan di [jsdoc.app](https://jsdoc.app).
+Kode dibawah mendeskripsikan perbedaan dan beberapa contoh dari setiap _tag_-nya.
 
-**Catatan:** Anda bisa menggunakan [playground untuk mengeksplor dukungan JSDoc](/play?useJavaScript=truee=4#example/jsdoc-support).
+**Catatan:** Anda bisa menggunakan [_playground_ untuk mengeksplor dukungan JSDoc](/play?useJavaScript=truee=4#example/jsdoc-support).
 
 ## `@type`
 
-Anda dapat menggunakan tag "@type" dan mereferensikan nama jenis (baik primitif, ditentukan dalam deklarasi TypeScript, atau dalam tag "@typedef" JSDoc).
+Anda dapat menggunakan _tag_ "@type" dan mereferensikan nama jenis (baik primitif, ditentukan dalam deklarasi TypeScript, atau dalam _tag_ "@typedef" JSDoc).
 Anda dapat menggunakan sebagian besar jenis JSDoc dan jenis TypeScript apa pun, dari [yang paling dasar seperti `string`](/docs/handbookbasic-types.html) hingga [yang paling canggih, seperti jenis bersyarat](/docs/handbook/advanced-types.html).
 
 ```js twoslash
@@ -53,7 +53,7 @@ var myElement = document.querySelector(selector);
 element.dataset.myData = "";
 ```
 
-`@type` dapat menetapkan tipe gabungan &mdash; misalnya, sesuatu bisa berupa string atau boolean.
+`@type` dapat menetapkan tipe gabungan &mdash; misalnya, sesuatu bisa berupa _string_ atau _boolean_.
 
 ```js twoslash
 /**
@@ -71,7 +71,7 @@ Perhatikan bahwa tanda kurung bersifat opsional untuk tipe gabungan.
 var sb;
 ```
 
-Anda dapat menentukan tipe array menggunakan berbagai sintaks:
+Anda dapat menentukan tipe _array_ menggunakan berbagai sintaks:
 
 ```js twoslash
 /** @type {number[]} */
@@ -82,15 +82,15 @@ var nds;
 var nas;
 ```
 
-Anda juga dapat menentukan tipe literal objek.
-Misalnya, objek dengan properti 'a' (string) dan 'b' (angka) menggunakan sintaks berikut:
+Anda juga dapat menentukan tipe _literal_ objek.
+Misalnya, objek dengan properti 'a' (_string_) dan 'b' (angka) menggunakan sintaks berikut:
 
 ```js twoslash
 /** @type {{ a: string, b: number }} */
 var var9;
 ```
 
-Anda dapat menentukan objek seperti map dan array menggunakan index signature string dan angka, menggunakan sintaks JSDoc standar atau sintaks TypeScript.
+Anda dapat menentukan objek seperti _map_ dan _array_ menggunakan index signature _string_ dan angka, menggunakan sintaks JSDoc standar atau sintaks TypeScript.
 
 ```js twoslash
 /**
@@ -106,7 +106,7 @@ var arrayLike;
 
 Dua jenis sebelumnya sama dengan tipe TypeScript `{ [x: string]: number }` dan `{ [x: number]: any }`. Kompilator memahami kedua sintaks tersebut.
 
-Anda dapat menentukan jenis fungsi menggunakan sintaks TypeScript atau Closure:
+Anda dapat menentukan jenis fungsi menggunakan sintaks TypeScript atau _Closure_:
 
 ```js twoslash
 /** @type {function(string, boolean): number} Closure syntax */
@@ -124,7 +124,7 @@ var fn7;
 var fn6;
 ```
 
-Type lainnya dari Closure juga berfungsi:
+Type lainnya dari _Closure_ juga berfungsi:
 
 ```js twoslash
 /**
@@ -139,7 +139,7 @@ var question;
 
 ### Casts
 
-TypeScript meminjam sintaks cast dari Closure.
+TypeScript meminjam sintaks _cast_ dari _Closure_.
 Ini memungkinkan Anda mentransmisikan tipe ke tipe lain dengan menambahkan tag `@type` sebelum ekspresi dalam tanda kurung.
 
 ```js twoslash
@@ -152,7 +152,7 @@ var typeAssertedNumber = /** @type {number} */ (numberOrString);
 
 ### Impor type
 
-Anda bisa juga mengimpor deklarasi dari file lain menggunakan impor tipe.
+Anda bisa juga mengimpor deklarasi dari berkas lain menggunakan impor tipe.
 Sintaks ini khusus untuk TypeScript dan berbeda dari standar JSDoc:
 
 ```js twoslash
@@ -214,8 +214,8 @@ var x = require("./accounts").userAccount;
 
 ## `@param` and `@returns`
 
-`@param` menggunakan jenis sintaks yang sama dengan `@type`, tapi dengan tambahan sebuah nama parameter.
-Parameter juga dapat dideklarasikan secara opsional dengan membungkus namanya menggunakan kurung siku:
+`@param` menggunakan jenis sintaks yang sama dengan `@type`, tapi dengan tambahan sebuah nama _parameter_.
+_Parameter_ juga dapat dideklarasikan secara opsional dengan membungkus namanya menggunakan kurung siku:
 
 ```js twoslash
 // Parameter dapat dideklarasikan dalam berbagai bentuk sintaksis
@@ -247,7 +247,7 @@ function ab() {}
 
 ## `@typedef`, `@callback`, and `@param`
 
-`@ty[edef` juga dapat digunakan untuk mendefinisikan type yang kompleks.
+`@ty[edef` juga dapat digunakan untuk mendefinisikan tipe yang kompleks.
 Sintaks yang bekerja dengan `@params`.
 
 ```js twoslash
@@ -280,7 +280,7 @@ var specialTypeObject1;
 ```
 
 `@params` memperbolehkan sintaks yang serupa untuk spesifikasi tipenya.
-Perhatikan bahwa nama properti _nested_ harus diawali dengan nama parameternya:
+Perhatikan bahwa nama properti _nested_ harus diawali dengan nama _parameter_-nya:
 
 ```js twoslash
 /**
@@ -336,7 +336,7 @@ const b = id(123);
 const c = id({});
 ```
 
-Gunakan koma atau beberapa tag untuk mendeklarasikan beberapa parameter tipe:
+Gunakan koma atau beberapa _tag_ untuk mendeklarasikan beberapa _parameter_ tipe:
 
 ```js
 /**
@@ -345,8 +345,8 @@ Gunakan koma atau beberapa tag untuk mendeklarasikan beberapa parameter tipe:
  */
 ```
 
-Anda juga bisa menentukan batasan tipe sebelum nama parameternya.
-Hanya parameter tipe pertama dalam sebuah list yang dibatasi.
+Anda juga bisa menentukan batasan tipe sebelum nama _parameter_-nya.
+Hanya _parameter_ tipe pertama dalam sebuah list yang dibatasi.
 
 ```js twoslash
 /**
@@ -360,7 +360,7 @@ function seriousalize(key, object) {
 }
 ```
 
-Mendeklarasikan kelas generik atau type yang tidak didukung.
+Mendeklarasikan kelas generik atau tipe yang tidak didukung.
 
 ## Classes
 
@@ -405,7 +405,7 @@ Mereka juga dapat dideklarasikan sebagai fungsi konstruktor, seperti yang dijela
 
 ## `@constructor`
 
-Kompilator menyimpulkan fungsi konstruktor berdasarkan penetapan properti ini, tetapi Anda dapat membuat pemeriksaan lebih ketat dan saran lebih baik jika Anda menambahkan tag `@constructor`:
+Kompilator menyimpulkan fungsi konstruktor berdasarkan penetapan properti ini, tetapi Anda dapat membuat pemeriksaan lebih ketat dan saran lebih baik jika Anda menambahkan _tag_ `@constructor`:
 
 ```js twoslash
 // @checkJs
@@ -463,7 +463,7 @@ function callbackForLater(e) {
 
 ## `@extends`
 
-Ketika kelas JavaScript memperluas _base class_, tidak ada tempat untuk menentukan seharusnya menggunakan parameter tipe yang seperti apa. Tag `@extends` menyediakan tempat untuk parameter jenis itu:
+Ketika kelas JavaScript memperluas _base class_, tidak ada tempat untuk menentukan seharusnya menggunakan parameter tipe yang seperti apa. _Tag_ `@extends` menyediakan tempat untuk parameter jenis itu:
 
 ```js twoslash
 /**
@@ -479,7 +479,7 @@ Perhatikan bahwa `@extends` hanya berfungsi dengan kelas. Saat ini, tidak ada ca
 
 ## `@enum`
 
-Tag `@enum` memungkinkan Anda membuat literal objek yang tipe anggotanya spesifik. Tidak seperti kebanyakan literal objek di JavaScript, ini tidak mengizinkan anggota lain.
+Tag `@enum` memungkinkan Anda membuat _literal_ objek yang tipe anggotanya spesifik. Tidak seperti kebanyakan _literal_ objek di JavaScript, ini tidak mengizinkan anggota lain.
 
 ```js twoslash
 /** @enum {number} */
@@ -492,7 +492,7 @@ const JSDocState = {
 JSDocState.SawAsterisk;
 ```
 
-Perhatikan bahwa `@enum` sangat berbeda, dan jauh lebih sederhana daripada `enum` TypeScript. Namun, tidak seperti enum TypeScript, `@enum` dapat memiliki tipe apa saja:
+Perhatikan bahwa `@enum` sangat berbeda, dan jauh lebih sederhana daripada `enum` TypeScript. Namun, tidak seperti _enum_ TypeScript, `@enum` dapat memiliki tipe apa saja:
 
 ```js twoslash
 /** @enum {function(number): number} */
@@ -563,7 +563,7 @@ function fn9(p1) {
 
 ## Pola yang diketahui TIDAK didukung
 
-Mengacu pada objek di value space sebagai tipe yang tidak berfungsi, kecuali objek tersebut juga membuat tipe, seperti fungsi konstruktor.
+Mengacu pada objek di _value space_ sebagai tipe yang tidak berfungsi, kecuali objek tersebut juga membuat tipe, seperti fungsi konstruktor.
 
 ```js twoslash
 function aNormalFunction() {}
@@ -578,7 +578,7 @@ var wrong;
 var right;
 ```
 
-Postfix sama dengan tipe properti dalam tipe literal objek yang tidak menetapkan properti opsional:
+_Postfix_ sama dengan tipe properti dalam tipe _literal_ objek yang tidak menetapkan properti opsional:
 
 ```js twoslash
 /**
@@ -592,7 +592,7 @@ var wrong;
 var right;
 ```
 
-Jenis Nullable hanya memiliki arti jika `strictNullChecks` aktif:
+Jenis _Nullable_ hanya memiliki arti jika `strictNullChecks` aktif:
 
 ```js twoslash
 /**
@@ -614,7 +614,7 @@ Anda juga bisa menggunakan tipe gabungan:
 var unionNullable;
 ```
 
-Type non-nullable tidak memiliki arti dan diperlakukan seperti jenis aslinya:
+Tipe _non-nullable_ tidak memiliki arti dan diperlakukan seperti jenis aslinya:
 
 ```js twoslash
 /**
@@ -624,16 +624,15 @@ Type non-nullable tidak memiliki arti dan diperlakukan seperti jenis aslinya:
 var normal;
 ```
 
-If it is off, then `number` is nullable.
 Tidak seperti sistem tipe JSDoc, TypeScript hanya memungkinkan Anda untuk menandai tipe, apakah mengandung null atau tidak.
 Tidak ada non-nullability eksplisit - jika strictNullChecks aktif, `number` tidak dapat dinihilkan.
 Jika tidak aktif, maka `number` adalah nullable.
 
-### Tag yang tidak didukung
+### _Tag_ yang tidak didukung
 
-TypeScript mengabaikan semua tag JSDoc yang tidak didukung.
+TypeScript mengabaikan semua _tag_ JSDoc yang tidak didukung.
 
-Tag berikut memiliki isu terbuka untuk mendukungnya:
+_Tag_ berikut memiliki isu terbuka untuk mendukungnya:
 
 - `@const` ([issue #19672](https://github.com/Microsoft/TypeScript/issues/19672))
 - `@inheritdoc` ([issue #23215](https://github.com/Microsoft/TypeScript/issues/23215))
@@ -643,7 +642,7 @@ Tag berikut memiliki isu terbuka untuk mendukungnya:
 
 ## Extensi kelas JS
 
-### Modifier Property JSDoc
+### _Modifier Property_ JSDoc
 
 Dari TypeScript 3.8 dan seterusnya, Anda dapat menggunakan JSDoc untuk mengubah properti kelas. Pertama adalah pengubah aksesibilitas: `@public`,`@private`, dan `@protected`.
 Tag ini bekerja persis seperti `public`,`private`, dan `protected`, masing-masing berfungsi di TypeScript.
@@ -671,7 +670,7 @@ console.log(c.identifier);
 - `@private` berarti bahwa properti hanya dapat digunakan di dalam kelas yang memuatnya.
 - `@protected` berarti bahwa properti hanya dapat digunakan di dalam kelas penampung, dan semua subkelas turunan, tetapi tidak pada instance kelas penampung yang berbeda.
 
-Selanjutnya, kita juga telah menambahkan modifier `@readonly` untuk memastikan bahwa sebuah properti hanya dapat di-write selama inisialisasi.
+Selanjutnya, kita juga telah menambahkan _modifier_ `@readonly` untuk memastikan bahwa sebuah properti hanya dapat di-_write_ selama inisialisasi.
 
 ```js twoslash
 // @errors: 2540

--- a/packages/documentation/copy/id/javascript/JSDoc Reference.md
+++ b/packages/documentation/copy/id/javascript/JSDoc Reference.md
@@ -1,0 +1,693 @@
+---
+title: JSDoc Reference
+layout: docs
+permalink: /id/docs/handbook/jsdoc-supported-types.html
+oneline: JSDoc apa yang didukung JavaScript dan TypeScript?
+translatable: true
+---
+
+Dibawah ini adalah daftar anotasi yang didukung saat menggunakan JSDoc untuk menyediakan informasi di file Javscript.
+
+Perhatikan semua tag yang tidak secara eksplisit dicantumkan di bawah (seperti `@ async`) belum didukung.
+
+- `@type`
+- `@param` (atau `@arg` atau `@argument`)
+- `@returns` (atau `@return`)
+- `@typedef`
+- `@callback`
+- `@template`
+- `@class` (atau `@constructor`)
+- `@this`
+- `@extends` (atau `@augments`)
+- `@enum`
+
+#### Ekstensi `class`
+
+- [Property Modifiers](#jsdoc-property-modifiers) `@public`, `@private`, `@protected`, `@readonly`
+
+Artinya biasanya sama, atau superset, dari arti tag yang diberikan di [jsdoc.app](https://jsdoc.app).
+Kode dibawah mendeskripsikan perbedaan dan beberapa contoh dari setiap tag-nya.
+
+**Catatan:** Anda bisa menggunakan [playground untuk mengeksplor dukungan JSDoc](/play?useJavaScript=truee=4#example/jsdoc-support).
+
+## `@type`
+
+Anda dapat menggunakan tag "@type" dan mereferensikan nama jenis (baik primitif, ditentukan dalam deklarasi TypeScript, atau dalam tag "@typedef" JSDoc).
+Anda dapat menggunakan sebagian besar jenis JSDoc dan jenis TypeScript apa pun, dari [yang paling dasar seperti `string`](/docs/handbookbasic-types.html) hingga [yang paling canggih, seperti jenis bersyarat](/docs/handbook/advanced-types.html).
+
+```js twoslash
+/**
+ * @type {string}
+ */
+var s;
+
+/** @type {Window} */
+var win;
+
+/** @type {PromiseLike<string>} */
+var promisedString;
+
+// Anda dapat menentukan Elemen HTML dengan properti DOM
+/** @type {HTMLElement} */
+var myElement = document.querySelector(selector);
+element.dataset.myData = "";
+```
+
+`@type` dapat menetapkan tipe gabungan &mdash; misalnya, sesuatu bisa berupa string atau boolean.
+
+```js twoslash
+/**
+ * @type {(string | boolean)}
+ */
+var sb;
+```
+
+Perhatikan bahwa tanda kurung bersifat opsional untuk tipe gabungan.
+
+```js twoslash
+/**
+ * @type {string | boolean}
+ */
+var sb;
+```
+
+Anda dapat menentukan tipe array menggunakan berbagai sintaks:
+
+```js twoslash
+/** @type {number[]} */
+var ns;
+/** @type {Array.<number>} */
+var nds;
+/** @type {Array<number>} */
+var nas;
+```
+
+Anda juga dapat menentukan tipe literal objek.
+Misalnya, objek dengan properti 'a' (string) dan 'b' (angka) menggunakan sintaks berikut:
+
+```js twoslash
+/** @type {{ a: string, b: number }} */
+var var9;
+```
+
+Anda dapat menentukan objek seperti map dan array menggunakan index signature string dan angka, menggunakan sintaks JSDoc standar atau sintaks TypeScript.
+
+```js twoslash
+/**
+ * Objek map yang memetakan kunci string dan nilainya bertipe number.
+ *
+ * @type {Object.<string, number>}
+ */
+var stringToNumber;
+
+/** @type {Object.<number, object>} */
+var arrayLike;
+```
+
+Dua jenis sebelumnya sama dengan type TypeScript `{ [x: string]: number }` dan `{ [x: number]: any }`. Compiler memahami kedua sintaks tersebut.
+
+Anda dapat menentukan jenis fungsi menggunakan sintaks TypeScript atau Closure:
+
+```js twoslash
+/** @type {function(string, boolean): number} Closure syntax */
+var sbn;
+/** @type {(s: string, b: boolean) => number} TypeScript syntax */
+var sbn2;
+```
+
+Atau anda dapat menggunakan type `Function` yang tidak ditentukan:
+
+```js twoslash
+/** @type {Function} */
+var fn7;
+/** @type {function} */
+var fn6;
+```
+
+Type lainnya dari Closure juga berfungsi:
+
+```js twoslash
+/**
+ * @type {*} - can be 'any' type
+ */
+var star;
+/**
+ * @type {?} - unknown type (same as 'any')
+ */
+var question;
+```
+
+### Casts
+
+TypeScript meminjam sintaks cast dari Closure.
+Ini memungkinkan Anda mentransmisikan type ke type lain dengan menambahkan tag `@type` sebelum ekspresi dalam tanda kurung.
+
+```js twoslash
+/**
+ * @type {number | string}
+ */
+var numberOrString = Math.random() < 0.5 ? "hello" : 100;
+var typeAssertedNumber = /** @type {number} */ (numberOrString);
+```
+
+### Impor type
+
+Anda bisa juga mengimpor deklarasi dari file lain menggunakan impor type.
+Sintaks ini khusus untuk TypeScript dan berbeda dari standar JSDoc:
+
+```js twoslash
+// @filename: types.d.ts
+export type Pet = {
+  name: string,
+};
+
+// @filename: main.js
+/**
+ * @param p { import("./types").Pet }
+ */
+function walk(p) {
+  console.log(`Walking ${p.name}...`);
+}
+```
+
+mengimpor type juga dapat digunakan di deklarasi type alias:
+
+```js twoslash
+// @filename: types.d.ts
+export type Pet = {
+  name: string,
+};
+// @filename: main.js
+// ---cut---
+/**
+ * @typedef { import("./types").Pet } Pet
+ */
+
+/**
+ * @type {Pet}
+ */
+var myPet;
+myPet.name;
+```
+
+Mengimpor type dapat digunakan untuk mendapatkan type nilai dari module, jika Anda tidak mengetahui jenisnya, atau jika nilai tersebut memiliki type yang besar yang dapat mengganggu untuk diketik:
+
+```js twoslash
+// @filename: accounts.d.ts
+export const userAccount = {
+  name: "Name",
+  address: "An address",
+  postalCode: "",
+  country: "",
+  planet: "",
+  system: "",
+  galaxy: "",
+  universe: "",
+};
+// @filename: main.js
+// ---cut---
+/**
+ * @type {typeof import("./accounts").userAccount }
+ */
+var x = require("./accounts").userAccount;
+```
+
+## `@param` and `@returns`
+
+`@param` menggunakan jenis sintaks yang sama dengan `@type`, tapi dengan tambahan sebuah nama parameter.
+Parameter juga dapat dideklarasikan secara opsional dengan membungkus namanya menggunakan kurung siku:
+
+```js twoslash
+// Parameter dapat dideklarasikan dalam berbagai bentuk sintaksis
+/**
+ * @param {string}  p1 - Parameter string.
+ * @param {string=} p2 - Opsional param (sintaks Closure)
+ * @param {string} [p3] - Opsional param lainnya (sintaks JSDoc).
+ * @param {string} [p4="test"] - Opsional param dengan nilai standar
+ * @return {string} Ini adalah hasilnya
+ */
+function stringsStringStrings(p1, p2, p3, p4) {
+  // MELAKUKAN
+}
+```
+
+Demikian juga, untuk type kembalian suatu fungsi:
+
+```js twoslash
+/**
+ * @return {PromiseLike<string>}
+ */
+function ps() {}
+
+/**
+ * @returns {{ a: string, b: number }} - Dapat menggunakan '@returns' serta '@return'
+ */
+function ab() {}
+```
+
+## `@typedef`, `@callback`, and `@param`
+
+`@ty[edef` juga dapat digunakan untuk mendefinisikan type yang kompleks.
+Sintaks yang bekerja dengan `@params`.
+
+```js twoslash
+/**
+ * @typedef {Object} SpecialType - buat type baru bernama 'SpecialType'
+ * @property {string} prop1 - property string dari SpecialType
+ * @property {number} prop2 - property number dari SpecialType
+ * @property {number=} prop3 - opsional property number dari SpecialType
+ * @prop {number} [prop4] - opsional property number dari SpecialType
+ * @prop {number} [prop5=42] - opsional property number dari SpecialType dengan nilai standar
+ */
+
+/** @type {SpecialType} */
+var specialTypeObject;
+specialTypeObject.prop3;
+```
+
+Anda bisa menggunakan `object` atau `Object` pada baris pertama.
+
+```js twoslash
+/**
+ * @typedef {object} SpecialType1 - buat type baru bernama 'SpecialType'
+ * @property {string} prop1 - property string dari SpecialType
+ * @property {number} prop2 - property number dari SpecialType
+ * @property {number=} prop3 - opsional property number dari SpecialType
+ */
+
+/** @type {SpecialType1} */
+var specialTypeObject1;
+```
+
+`@params` memperbolehkan sintaks yang serupa untuk spesifikasi type-nya.
+Perhatikan bahwa nama nested property harus diawali dengan nama parameternya:
+
+```js twoslash
+/**
+ * @param {Object} options - Bentuknya sama dengan SpecialType di atas
+ * @param {string} options.prop1
+ * @param {number} options.prop2
+ * @param {number=} options.prop3
+ * @param {number} [options.prop4]
+ * @param {number} [options.prop5=42]
+ */
+function special(options) {
+  return (options.prop4 || 1001) + options.prop5;
+}
+```
+
+`@callback` mirip dengan `@typedef`, tetapi ini menetapkan type fungsi daripada type objek:
+
+```js twoslash
+/**
+ * @callback Predicate
+ * @param {string} data
+ * @param {number} [index]
+ * @returns {boolean}
+ */
+
+/** @type {Predicate} */
+const ok = (s) => !(s.length % 2);
+```
+
+Tentu saja, salah satu dari jenis ini dapat dideklarasikan menggunakan sintaks TypeScript dalam satu baris `@typedef`:
+
+```js
+/** @typedef {{ prop1: string, prop2: string, prop3?: number }} SpecialType */
+/** @typedef {(data: string, index?: number) => boolean} Predicate */
+```
+
+## `@template`
+
+Anda dapat mendeklarasikan fungsi generik dengan tag `@template`:
+
+```js twoslash
+/**
+ * @template T
+ * @param {T} x - Parameter umum yang mengalir ke return type
+ * @return {T}
+ */
+function id(x) {
+  return x;
+}
+
+const a = id("string");
+const b = id(123);
+const c = id({});
+```
+
+Gunakan koma atau beberapa tag untuk mendeklarasikan beberapa parameter type:
+
+```js
+/**
+ * @template T,U,V
+ * @template W,X
+ */
+```
+
+Anda juga bisa menentukan batasan type sebelum nama parameternya.
+Hanya parameter type pertama dalam sebuah list yang dibatasi.
+
+```js twoslash
+/**
+ * @template {string} K - K harus berupa string atau string literal
+ * @template {{ serious(): string }} Seriousalizable - harus memiliki method serious
+ * @param {K} key
+ * @param {Seriousalizable} object
+ */
+function seriousalize(key, object) {
+  // ????
+}
+```
+
+Mendeklarasikan kelas generik atau type yang tidak didukung.
+
+## Classes
+
+Kelas yang dapat dideklarasikan sebagai kelas ES6.
+
+```js twoslash
+class C {
+  /**
+   * @param {number} data
+   */
+  constructor(data) {
+    // tipe properti yang bisa diketahui
+    this.name = "foo";
+
+    // atau mengaturnya secara eksplisit
+    /** @type {string | null} */
+    this.title = null;
+
+    // atau hanya diberi anotasi, jika disetel di tempat lain
+    /** @type {number} */
+    this.size;
+
+    this.initialize(data); // Seharusnya error, karena initialize mengharapkan string
+  }
+  /**
+   * @param {string} s
+   */
+  initialize = function (s) {
+    this.size = s.length;
+  };
+}
+
+var c = new C(0);
+
+// C seharusnya hanya dipanggil dengan yang baru,
+// tetapi karena ini adalah JavaScript, ini
+// diperbolehkan dan dianggap sebagai 'any'.
+var result = C(1);
+```
+
+Mereka juga dapat dideklarasikan sebagai fungsi konstruktor, seperti yang dijelaskan di bagian selanjutnya:
+
+## `@constructor`
+
+Compiler menyimpulkan fungsi konstruktor berdasarkan penetapan properti ini, tetapi Anda dapat membuat pemeriksaan lebih ketat dan saran lebih baik jika Anda menambahkan tag `@constructor`:
+
+```js twoslash
+// @checkJs
+// @errors: 2345 2348
+/**
+ * @constructor
+ * @param {number} data
+ */
+function C(data) {
+  // type property yang dapat diketahui
+  this.name = "foo";
+
+  // atau atur secara eksplisit
+  /** @type {string | null} */
+  this.title = null;
+
+  // atau hanya diberi anotasi, jika disetel di tempat lain
+  /** @type {number} */
+  this.size;
+
+  this.initialize(data);
+}
+/**
+ * @param {string} s
+ */
+C.prototype.initialize = function (s) {
+  this.size = s.length;
+};
+
+var c = new C(0);
+c.size;
+
+var result = C(1);
+```
+
+> Catatan: Pesan error hanya tampil di basis kode JS dengan [JSConfig](/docs/handbook/tsconfig-json.html) dan [`checkJS`](/tsconfig#checkJs) yang diaktifkan.
+
+Dengan `@constructor`, `this` diperiksa didalam fungsi konstruktor `C`, jadi anda akan mendapatkan saran untuk method `initialize` dan sebuah error jika anda memasukkan sebuah angka. Editor-mu mungkin akan menampilkan peringatan jika memanggil `C` daripada mengkonstruksikannya.
+
+Sayangnya, ini berarti bahwa fungsi konstruktor yang juga dapat dipanggil tidak dapat menggunakan `@constructor`.
+
+## `@this`
+
+Compiler biasanya dapat mengetahui type `this` ketika ia memiliki beberapa konteks untuk dikerjakan. Jika tidak, Anda dapat secara eksplisit menentukan jenis `this` dengan `@this`:
+
+```js twoslash
+/**
+ * @this {HTMLElement}
+ * @param {*} e
+ */
+function callbackForLater(e) {
+  this.clientHeight = parseInt(e); // seharusnya baik-baik saja!
+}
+```
+
+## `@extends`
+
+Ketika kelas JavaScript memperluas _base class_, tidak ada tempat untuk menentukan seharusnya menggunakan parameter type yang seperti apa. Tag `@extends` menyediakan tempat untuk parameter jenis itu:
+
+```js twoslash
+/**
+ * @template T
+ * @extends {Set<T>}
+ */
+class SortableSet extends Set {
+  // ...
+}
+```
+
+Perhatikan bahwa `@extends` hanya berfungsi dengan kelas. Saat ini, tidak ada cara untuk fungsi konstruktor memperluas kelas.
+
+## `@enum`
+
+Tag `@enum` memungkinkan Anda membuat literal objek yang type anggotanya spesifik. Tidak seperti kebanyakan literal objek di JavaScript, ini tidak mengizinkan anggota lain.
+
+```js twoslash
+/** @enum {number} */
+const JSDocState = {
+  BeginningOfLine: 0,
+  SawAsterisk: 1,
+  SavingComments: 2,
+};
+
+JSDocState.SawAsterisk;
+```
+
+Perhatikan bahwa `@enum` sangat berbeda, dan jauh lebih sederhana daripada `enum` TypeScript. Namun, tidak seperti enum TypeScript, `@enum` dapat memiliki tipe apa saja:
+
+```js twoslash
+/** @enum {function(number): number} */
+const MathFuncs = {
+  add1: (n) => n + 1,
+  id: (n) => -n,
+  sub1: (n) => n - 1,
+};
+
+MathFuncs.add1;
+```
+
+## Lebih banyak contoh
+
+```js twoslash
+class Foo {}
+// ---cut---
+var someObj = {
+  /**
+   * @param {string} param1 - Dokumen tentang tugas property
+   */
+  x: function (param1) {},
+};
+
+/**
+ * Seperti halnya dokumen tentang tugas variabel
+ * @return {Window}
+ */
+let someFunc = function () {};
+
+/**
+ * Dan method kelas
+ * @param {string} greeting Salam untuk digunakan
+ */
+Foo.prototype.sayHi = (greeting) => console.log("Hi!");
+
+/**
+ * Dan ekspresi arrow function
+ * @param {number} x - Pengganda
+ */
+let myArrow = (x) => x * x;
+
+/**
+ * Artinya, ini juga berfungsi untuk komponen fungsi stateless di JSX
+ * @param {{a: string, b: number}} test - Beberapa param
+ */
+var sfc = (test) => <div>{test.a.charAt(0)}</div>;
+
+/**
+ * Parameter bisa menjadi konstruktor kelas, menggunakan sintaks Closure.
+ *
+ * @param {{new(...args: any[]): object}} C - Kelas untuk mendaftar
+ */
+function registerClass(C) {}
+
+/**
+ * @param {...string} p1 - A 'rest' arg (array) of strings. (treated as 'any')
+ */
+function fn10(p1) {}
+
+/**
+ * @param {...string} p1 - A 'rest' arg (array) of strings. (treated as 'any')
+ */
+function fn9(p1) {
+  return p1.join();
+}
+```
+
+## Pola yang diketahui TIDAK didukung
+
+Mengacu pada objek di value space sebagai type yang tidak berfungsi, kecuali objek tersebut juga membuat type, seperti fungsi konstruktor.
+
+```js twoslash
+function aNormalFunction() {}
+/**
+ * @type {aNormalFunction}
+ */
+var wrong;
+/**
+ * Gunakan 'typeof' sebagai gantinya:
+ * @type {typeof aNormalFunction}
+ */
+var right;
+```
+
+Postfix sama dengan type property dalam type literal objek yang tidak menetapkan properti opsional:
+
+```js twoslash
+/**
+ * @type {{ a: string, b: number= }}
+ */
+var wrong;
+/**
+ * Gunakan postfix question pada nama properti sebagai gantinya:
+ * @type {{ a: string, b?: number }}
+ */
+var right;
+```
+
+Jenis Nullable hanya memiliki arti jika `strictNullChecks` aktif:
+
+```js twoslash
+/**
+ * @type {?number}
+ * With strictNullChecks: true  -- number | null
+ * With strictNullChecks: false -- number
+ */
+var nullable;
+```
+
+Anda juga bisa menggunakan tipe gabungan:
+
+```js twoslash
+/**
+ * @type {number | null}
+ * With strictNullChecks: true  -- number | null
+ * With strictNullChecks: false -- number
+ */
+var unionNullable;
+```
+
+Type non-nullable tidak memiliki arti dan diperlakukan seperti jenis aslinya:
+
+```js twoslash
+/**
+ * @type {!number}
+ * Hanya ber-type number
+ */
+var normal;
+```
+
+If it is off, then `number` is nullable.
+Tidak seperti sistem type JSDoc, TypeScript hanya memungkinkan Anda untuk menandai type, apakah mengandung null atau tidak.
+Tidak ada non-nullability eksplisit - jika strictNullChecks aktif, `number` tidak dapat dinihilkan.
+Jika tidak aktif, maka `number` adalah nullable.
+
+### Tag yang tidak didukung
+
+TypeScript mengabaikan semua tag JSDoc yang tidak didukung.
+
+Tag berikut memiliki isu terbuka untuk mendukungnya:
+
+- `@const` ([issue #19672](https://github.com/Microsoft/TypeScript/issues/19672))
+- `@inheritdoc` ([issue #23215](https://github.com/Microsoft/TypeScript/issues/23215))
+- `@memberof` ([issue #7237](https://github.com/Microsoft/TypeScript/issues/7237))
+- `@yields` ([issue #23857](https://github.com/Microsoft/TypeScript/issues/23857))
+- `{@link …}` ([issue #35524](https://github.com/Microsoft/TypeScript/issues/35524))
+
+## Extensi kelas JS
+
+### Modifier Property JSDoc
+
+Dari TypeScript 3.8 dan seterusnya, Anda dapat menggunakan JSDoc untuk mengubah properti kelas. Pertama adalah pengubah aksesibilitas: `@public`,`@private`, dan `@protected`.
+Tag ini bekerja persis seperti `public`,`private`, dan `protected`, masing-masing berfungsi di TypeScript.
+
+```js twoslash
+// @errors: 2341
+// @ts-check
+
+class Car {
+  constructor() {
+    /** @private */
+    this.identifier = 100;
+  }
+
+  printIdentifier() {
+    console.log(this.identifier);
+  }
+}
+
+const c = new Car();
+console.log(c.identifier);
+```
+
+- `@public` ini berarti property dapat diakses dari mana saja.
+- `@private` berarti bahwa properti hanya dapat digunakan di dalam kelas yang memuatnya.
+- `@protected` berarti bahwa properti hanya dapat digunakan di dalam kelas penampung, dan semua subkelas turunan, tetapi tidak pada instance kelas penampung yang berbeda.
+
+Selanjutnya, kita juga telah menambahkan modifier `@readonly` untuk memastikan bahwa sebuah property hanya dapat di-write selama inisialisasi.
+
+```js twoslash
+// @errors: 2540
+// @ts-check
+
+class Car {
+  constructor() {
+    /** @readonly */
+    this.identifier = 100;
+  }
+
+  printIdentifier() {
+    console.log(this.identifier);
+  }
+}
+
+const c = new Car();
+console.log(c.identifier);
+```

--- a/packages/documentation/copy/id/project-config/Configuring Watch.md
+++ b/packages/documentation/copy/id/project-config/Configuring Watch.md
@@ -6,17 +6,17 @@ oneline: Cara mengkonfigurasi mode watch TypeScript
 translatable: true
 ---
 
-Kompilator mendukung konfigurasi cara mengawasi file dan direktori menggunakan kompilator flags di TypeScript 3.8+, dan variabel environment.
+Kompilator mendukung konfigurasi cara mengawasi berkas dan direktori menggunakan kompilator _flags_ di TypeScript 3.8+, dan variabel _environment_.
 
 ## Latar Belakang
 
-Implementasi `--watch` dari compiter bergantung pada penggunaan `fs.watch` dan `fs.watchFile` yang disediakan oleh node, kedua metode ini memiliki kelebihan dan kekurangan.
+Implementasi `--watch` dari _compiter_ bergantung pada penggunaan `fs.watch` dan `fs.watchFile` yang disediakan oleh _node_, kedua metode ini memiliki kelebihan dan kekurangan.
 
-`fs.watch` menggunakan berkas _system event_ untuk memberi tahu perubahan dalam file/direktori. Tetapi ini bergantung pada OS dan notifikasi tidak sepenuhnya dapat diandalkan dan tidak berfungsi seperti yang diharapkan pada banyak OS. Juga mungkin ada batasan jumlah watch yang dapat dibuat, misalnya linux dan kami dapat melakukannya dengan cukup cepat dengan program yang menyertakan banyak file. Tetapi karena ini menggunakan berkas _system event_, tidak banyak siklus CPU yang terlibat. Kompilator biasanya menggunakan `fs.watch` untuk melihat direktori (misalnya. Direktori sumber disertakan oleh file konfigurasi, direktori di mana resolusi modul gagal, dll.) Ini dapat menangani ketepatan yang hilang dalam memberi tahu tentang perubahan. Tetapi memantau secara rekursif hanya didukung pada Windows dan OSX. Artinya kita membutuhkan sesuatu untuk menggantikan sifat rekursif di OS lain.
+`fs.watch` menggunakan berkas _system event_ untuk memberi tahu perubahan dalam berkas/direktori. Tetapi ini bergantung pada OS dan notifikasi tidak sepenuhnya dapat diandalkan dan tidak berfungsi seperti yang diharapkan pada banyak OS. Juga mungkin ada batasan jumlah _watch_ yang dapat dibuat, misalnya linux dan kami dapat melakukannya dengan cukup cepat dengan program yang menyertakan banyak berkas. Tetapi karena ini menggunakan berkas _system event_, tidak banyak siklus CPU yang terlibat. Kompilator biasanya menggunakan `fs.watch` untuk melihat direktori (misalnya. Direktori sumber disertakan oleh berkas konfigurasi, direktori di mana resolusi modul gagal, dll.) Ini dapat menangani ketepatan yang hilang dalam memberi tahu tentang perubahan. Tetapi memantau secara rekursif hanya didukung pada Windows dan OSX. Artinya kita membutuhkan sesuatu untuk menggantikan sifat rekursif di OS lain.
 
-`fs.watchFile` menggunakan polling dan karenanya melibatkan siklus CPU. Tetapi ini adalah mekanisme yang paling andal untuk mendapatkan pembaruan status file/direktori. Kompilator biasanya menggunakan `fs.watchFile` untuk melihat file sumber, file konfigurasi dan file yang hilang (referensi file hilang) yang berarti penggunaan CPU bergantung pada jumlah file dalam program.
+`fs.watchFile` menggunakan polling dan karenanya melibatkan siklus CPU. Tetapi ini adalah mekanisme yang paling andal untuk mendapatkan pembaruan status berkas/direktori. Kompilator biasanya menggunakan `fs.watchFile` untuk melihat berkas sumber, berkas konfigurasi dan berkas yang hilang (referensi berkas hilang) yang berarti penggunaan CPU bergantung pada jumlah berkas dalam program.
 
-## Konfigurasi file watching menggunakan `tsconfig.json`
+## Konfigurasi berkas _watching_ menggunakan `tsconfig.json`
 
 ```json tsconfig
 {
@@ -27,13 +27,13 @@ Implementasi `--watch` dari compiter bergantung pada penggunaan `fs.watch` dan `
     // ...
   },
 
-  // BARU: Opsi untuk memantau file/direktori
+  // BARU: Opsi untuk memantau berkas/direktori
   "watchOptions": {
-    // Gunakan native file system events untuk file dan direktori
+    // Gunakan native berkas system events untuk berkas dan direktori
     "watchFile": "useFsEvents",
     "watchDirectory": "useFsEvents",
 
-    // Dapatkan pembaruan file
+    // Dapatkan pembaruan berkas
     // ketika terdapat update yang besar.
     "fallbackPolling": "dynamicPriority"
   }
@@ -42,25 +42,25 @@ Implementasi `--watch` dari compiter bergantung pada penggunaan `fs.watch` dan `
 
 Anda dapat membacanya lebih lanjut di [catatan rilis](/docs/handbook/release-notes/typescript-3-8.html#better-directory-watching-on-linux-and-watchoptions).
 
-## Konfigurasi file watching menggunakan variabel environment `TSC_WATCHFILE`
+## Konfigurasi berkas _watching_ menggunakan variabel environment `TSC_WATCHFILE`
 
 <!-- prettier-ignore -->
 Opsi                                         | Deskripsi
 -----------------------------------------------|----------------------------------------------------------------------
-`PriorityPollingInterval`                      | Gunakan `fs.watchFile` tetapi gunakan interval polling yang berbeda untuk file sumber, file konfigurasi, dan file yang hilang
-`DynamicPriorityPolling`                       | Gunakan antrian dinamis di mana dalam file yang sering dimodifikasi akan memiliki interval yang lebih pendek dan file yang tidak diubah akan lebih jarang diperiksa
-`UseFsEvents`                                  | Gunakan `fs.watch` untuk memanfaatkan system event file (tetapi mungkin tidak akurat pada OS yang berbeda) untuk mendapatkan pemberitahuan terhadap perubahan/pembuatan/penghapusan file. Perhatikan bahwa beberapa OS misalnya. linux memiliki batasan jumlah pengamatan dan jika gagal melakukan pengamatan menggunakan `fs.watch`, maka pengamatan akan dilakukan dengan `fs.watchFile`
-`UseFsEventsWithFallbackDynamicPolling`        | Opsi ini mirip dengan `UseFsEvents` kecuali jika gagal memantau menggunakan `fs.watch`, pengawasan dilakukan melalui antrean polling dinamis (seperti dijelaskan dalam `DynamicPriorityPolling`)
-`UseFsEventsOnParentDirectory`                 | Opsi ini mengawasi direktori induk dari file dengan `fs.watch` (menggunakan berkas _system event_) sehingga menjadi rendah pada CPU tetapi dengan keakuratan yang rendah.
-standar (tanpa menspesifikkan nilainya)                   | Jika variabel environment `TSC_NONPOLLING_WATCHER` di-set ke true, maka akan mengawasi direktori induk dari file (seperti `UseFsEventsOnParentDirectory`). Jika tidak, akan menggunakan `fs.watchFile` dengan `250ms` sebagai waktu tunggu untuk file apa pun.
+`PriorityPollingInterval`                      | Gunakan `fs.watchFile` tetapi gunakan _interval polling_ yang berbeda untuk berkas sumber, berkas konfigurasi, dan berkas yang hilang
+`DynamicPriorityPolling`                       | Gunakan antrian dinamis di mana dalam berkas yang sering dimodifikasi akan memiliki _interval_ yang lebih pendek dan berkas yang tidak diubah akan lebih jarang diperiksa
+`UseFsEvents`                                  | Gunakan `fs.watch` untuk memanfaatkan _system event_ berkas (tetapi mungkin tidak akurat pada OS yang berbeda) untuk mendapatkan pemberitahuan terhadap perubahan/pembuatan/penghapusan berkas. Perhatikan bahwa beberapa OS misalnya. linux memiliki batasan jumlah pengamatan dan jika gagal melakukan pengamatan menggunakan `fs.watch`, maka pengamatan akan dilakukan dengan `fs.watchFile`
+`UseFsEventsWithFallbackDynamicPolling`        | Opsi ini mirip dengan `UseFsEvents` kecuali jika gagal memantau menggunakan `fs.watch`, pengawasan dilakukan melalui antrean _polling_ dinamis (seperti dijelaskan dalam `DynamicPriorityPolling`)
+`UseFsEventsOnParentDirectory`                 | Opsi ini mengawasi direktori induk dari berkas dengan `fs.watch` (menggunakan berkas _system event_) sehingga menjadi rendah pada CPU tetapi dengan keakuratan yang rendah.
+standar (tanpa menspesifikkan nilainya)                   | Jika variabel environment `TSC_NONPOLLING_WATCHER` di-set ke true, maka akan mengawasi direktori induk dari berkas (seperti `UseFsEventsOnParentDirectory`). Jika tidak, akan menggunakan `fs.watchFile` dengan `250ms` sebagai waktu tunggu untuk berkas apa pun.
 
-## Mengonfigurasi pengawasan direktori menggunakan variabel environment `TSC_WATCHDIRECTORY`
+## Mengonfigurasi pengawasan direktori menggunakan variabel _environment_ `TSC_WATCHDIRECTORY`
 
-Pemantauan direktori pada platform yang tidak mendukung pemantau direktori rekursif secara native di node, maka akan menggunakan opsi yang berbeda, yang dipilih oleh`TSC_WATCHDIRECTORY`. Perlu dicatat bahwa, platform yang mendukung pemantauan direktori secara rekursif (misalnya Windows), nilai dari variabel environment tersebut akan diabaikan.
+Pemantauan direktori pada platform yang tidak mendukung pemantau direktori rekursif secara _native_ di _node_, maka akan menggunakan opsi yang berbeda, yang dipilih oleh`TSC_WATCHDIRECTORY`. Perlu dicatat bahwa, _platform_ yang mendukung pemantauan direktori secara rekursif (misalnya Windows), nilai dari variabel environment tersebut akan diabaikan.
 
 <!-- prettier-ignore -->
 Opsi                                         | Deskripsi
 -----------------------------------------------|----------------------------------------------------------------------
-`RecursiveDirectoryUsingFsWatchFile`           | Gunakan `fs.watchFile` untuk mengawasi direktori dan direktori anak yang merupakan polling watch (menggunakan siklus CPU)
+`RecursiveDirectoryUsingFsWatchFile`           | Gunakan `fs.watchFile` untuk mengawasi direktori dan direktori anak yang merupakan _polling watch_ (menggunakan siklus CPU)
 `RecursiveDirectoryUsingDynamicPriorityPolling`| Gunakan antrian polling dinamis untuk mengumpulkan perubahan pada direktori dan sub direktori.
-default (tidak ada nilai yang ditentukan)                   | Gunakan `fs.watch` untuk memantau direktoru dan sub direktorinya
+_default_ (tidak ada nilai yang ditentukan)                   | Gunakan `fs.watch` untuk memantau direktoru dan sub direktorinya

--- a/packages/documentation/copy/id/project-config/Configuring Watch.md
+++ b/packages/documentation/copy/id/project-config/Configuring Watch.md
@@ -1,26 +1,26 @@
 ---
-title: Configuring Watch
+title: Mengkonfigurasi Watch
 layout: docs
 permalink: /id/docs/handbook/configuring-watch.html
 oneline: Cara mengkonfigurasi mode watch TypeScript
 translatable: true
 ---
 
-Compiler mendukung konfigurasi cara mengawasi file dan direktori menggunakan compiler flags di TypeScript 3.8+, dan variabel environment.
+Kompilator mendukung konfigurasi cara mengawasi file dan direktori menggunakan kompilator flags di TypeScript 3.8+, dan variabel environment.
 
 ## Latar Belakang
 
 Implementasi `--watch` dari compiter bergantung pada penggunaan `fs.watch` dan `fs.watchFile` yang disediakan oleh node, kedua metode ini memiliki kelebihan dan kekurangan.
 
-`fs.watch` menggunakan system event file untuk memberi tahu perubahan dalam file/direktori. Tetapi ini bergantung pada OS dan notifikasi tidak sepenuhnya dapat diandalkan dan tidak berfungsi seperti yang diharapkan pada banyak OS. Juga mungkin ada batasan jumlah watch yang dapat dibuat, misalnya. linux dan kami dapat melakukannya dengan cukup cepat dengan program yang menyertakan banyak file. Tetapi karena ini menggunakan system event file, tidak banyak siklus CPU yang terlibat. Compiler biasanya menggunakan `fs.watch` untuk melihat direktori (misalnya. Direktori sumber disertakan oleh file konfigurasi, direktori di mana resolusi modul gagal, dll.) Ini dapat menangani ketepatan yang hilang dalam memberi tahu tentang perubahan. Tetapi memantau secara rekursif hanya didukung pada Windows dan OSX. Artinya kita membutuhkan sesuatu untuk menggantikan sifat rekursif di OS lain.
+`fs.watch` menggunakan berkas _system event_ untuk memberi tahu perubahan dalam file/direktori. Tetapi ini bergantung pada OS dan notifikasi tidak sepenuhnya dapat diandalkan dan tidak berfungsi seperti yang diharapkan pada banyak OS. Juga mungkin ada batasan jumlah watch yang dapat dibuat, misalnya linux dan kami dapat melakukannya dengan cukup cepat dengan program yang menyertakan banyak file. Tetapi karena ini menggunakan berkas _system event_, tidak banyak siklus CPU yang terlibat. Kompilator biasanya menggunakan `fs.watch` untuk melihat direktori (misalnya. Direktori sumber disertakan oleh file konfigurasi, direktori di mana resolusi modul gagal, dll.) Ini dapat menangani ketepatan yang hilang dalam memberi tahu tentang perubahan. Tetapi memantau secara rekursif hanya didukung pada Windows dan OSX. Artinya kita membutuhkan sesuatu untuk menggantikan sifat rekursif di OS lain.
 
-`fs.watchFile` menggunakan polling dan karenanya melibatkan siklus CPU. Tetapi ini adalah mekanisme yang paling andal untuk mendapatkan pembaruan status file/direktori. Compiler biasanya menggunakan `fs.watchFile` untuk melihat file sumber, file konfigurasi dan file yang hilang (referensi file hilang) yang berarti penggunaan CPU bergantung pada jumlah file dalam program.
+`fs.watchFile` menggunakan polling dan karenanya melibatkan siklus CPU. Tetapi ini adalah mekanisme yang paling andal untuk mendapatkan pembaruan status file/direktori. Kompilator biasanya menggunakan `fs.watchFile` untuk melihat file sumber, file konfigurasi dan file yang hilang (referensi file hilang) yang berarti penggunaan CPU bergantung pada jumlah file dalam program.
 
 ## Konfigurasi file watching menggunakan `tsconfig.json`
 
 ```json tsconfig
 {
-  // Beberapa opsi compiler umumnya
+  // Beberapa opsi kompilator umumnya
   "compilerOptions": {
     "target": "es2020",
     "moduleResolution": "node"
@@ -51,7 +51,7 @@ Opsi                                         | Deskripsi
 `DynamicPriorityPolling`                       | Gunakan antrian dinamis di mana dalam file yang sering dimodifikasi akan memiliki interval yang lebih pendek dan file yang tidak diubah akan lebih jarang diperiksa
 `UseFsEvents`                                  | Gunakan `fs.watch` untuk memanfaatkan system event file (tetapi mungkin tidak akurat pada OS yang berbeda) untuk mendapatkan pemberitahuan terhadap perubahan/pembuatan/penghapusan file. Perhatikan bahwa beberapa OS misalnya. linux memiliki batasan jumlah pengamatan dan jika gagal melakukan pengamatan menggunakan `fs.watch`, maka pengamatan akan dilakukan dengan `fs.watchFile`
 `UseFsEventsWithFallbackDynamicPolling`        | Opsi ini mirip dengan `UseFsEvents` kecuali jika gagal memantau menggunakan `fs.watch`, pengawasan dilakukan melalui antrean polling dinamis (seperti dijelaskan dalam `DynamicPriorityPolling`)
-`UseFsEventsOnParentDirectory`                 | Opsi ini mengawasi direktori induk dari file dengan `fs.watch` (menggunakan system event file) sehingga menjadi rendah pada CPU tetapi dengan keakuratan yang rendah.
+`UseFsEventsOnParentDirectory`                 | Opsi ini mengawasi direktori induk dari file dengan `fs.watch` (menggunakan berkas _system event_) sehingga menjadi rendah pada CPU tetapi dengan keakuratan yang rendah.
 standar (tanpa menspesifikkan nilainya)                   | Jika variabel environment `TSC_NONPOLLING_WATCHER` di-set ke true, maka akan mengawasi direktori induk dari file (seperti `UseFsEventsOnParentDirectory`). Jika tidak, akan menggunakan `fs.watchFile` dengan `250ms` sebagai waktu tunggu untuk file apa pun.
 
 ## Mengonfigurasi pengawasan direktori menggunakan variabel environment `TSC_WATCHDIRECTORY`
@@ -63,4 +63,4 @@ Opsi                                         | Deskripsi
 -----------------------------------------------|----------------------------------------------------------------------
 `RecursiveDirectoryUsingFsWatchFile`           | Gunakan `fs.watchFile` untuk mengawasi direktori dan direktori anak yang merupakan polling watch (menggunakan siklus CPU)
 `RecursiveDirectoryUsingDynamicPriorityPolling`| Gunakan antrian polling dinamis untuk mengumpulkan perubahan pada direktori dan sub direktori.
-default (no value specified)                   | Gunakan `fs.watch` untuk memantau direktoru dan sub direktorinya
+default (tidak ada nilai yang ditentukan)                   | Gunakan `fs.watch` untuk memantau direktoru dan sub direktorinya

--- a/packages/documentation/copy/id/project-config/Configuring Watch.md
+++ b/packages/documentation/copy/id/project-config/Configuring Watch.md
@@ -1,0 +1,66 @@
+---
+title: Configuring Watch
+layout: docs
+permalink: /id/docs/handbook/configuring-watch.html
+oneline: Cara mengkonfigurasi mode watch TypeScript
+translatable: true
+---
+
+Compiler mendukung konfigurasi cara mengawasi file dan direktori menggunakan compiler flags di TypeScript 3.8+, dan variabel environment.
+
+## Latar Belakang
+
+Implementasi `--watch` dari compiter bergantung pada penggunaan `fs.watch` dan `fs.watchFile` yang disediakan oleh node, kedua metode ini memiliki kelebihan dan kekurangan.
+
+`fs.watch` menggunakan system event file untuk memberi tahu perubahan dalam file/direktori. Tetapi ini bergantung pada OS dan notifikasi tidak sepenuhnya dapat diandalkan dan tidak berfungsi seperti yang diharapkan pada banyak OS. Juga mungkin ada batasan jumlah watch yang dapat dibuat, misalnya. linux dan kami dapat melakukannya dengan cukup cepat dengan program yang menyertakan banyak file. Tetapi karena ini menggunakan system event file, tidak banyak siklus CPU yang terlibat. Compiler biasanya menggunakan `fs.watch` untuk melihat direktori (misalnya. Direktori sumber disertakan oleh file konfigurasi, direktori di mana resolusi modul gagal, dll.) Ini dapat menangani ketepatan yang hilang dalam memberi tahu tentang perubahan. Tetapi memantau secara rekursif hanya didukung pada Windows dan OSX. Artinya kita membutuhkan sesuatu untuk menggantikan sifat rekursif di OS lain.
+
+`fs.watchFile` menggunakan polling dan karenanya melibatkan siklus CPU. Tetapi ini adalah mekanisme yang paling andal untuk mendapatkan pembaruan status file/direktori. Compiler biasanya menggunakan `fs.watchFile` untuk melihat file sumber, file konfigurasi dan file yang hilang (referensi file hilang) yang berarti penggunaan CPU bergantung pada jumlah file dalam program.
+
+## Konfigurasi file watching menggunakan `tsconfig.json`
+
+```json tsconfig
+{
+  // Beberapa opsi compiler umumnya
+  "compilerOptions": {
+    "target": "es2020",
+    "moduleResolution": "node"
+    // ...
+  },
+
+  // BARU: Opsi untuk memantau file/direktori
+  "watchOptions": {
+    // Gunakan native file system events untuk file dan direktori
+    "watchFile": "useFsEvents",
+    "watchDirectory": "useFsEvents",
+
+    // Dapatkan pembaruan file
+    // ketika terdapat update yang besar.
+    "fallbackPolling": "dynamicPriority"
+  }
+}
+```
+
+Anda dapat membacanya lebih lanjut di [catatan rilis](/docs/handbook/release-notes/typescript-3-8.html#better-directory-watching-on-linux-and-watchoptions).
+
+## Konfigurasi file watching menggunakan variabel environment `TSC_WATCHFILE`
+
+<!-- prettier-ignore -->
+Opsi                                         | Deskripsi
+-----------------------------------------------|----------------------------------------------------------------------
+`PriorityPollingInterval`                      | Gunakan `fs.watchFile` tetapi gunakan interval polling yang berbeda untuk file sumber, file konfigurasi, dan file yang hilang
+`DynamicPriorityPolling`                       | Gunakan antrian dinamis di mana dalam file yang sering dimodifikasi akan memiliki interval yang lebih pendek dan file yang tidak diubah akan lebih jarang diperiksa
+`UseFsEvents`                                  | Gunakan `fs.watch` untuk memanfaatkan system event file (tetapi mungkin tidak akurat pada OS yang berbeda) untuk mendapatkan pemberitahuan terhadap perubahan/pembuatan/penghapusan file. Perhatikan bahwa beberapa OS misalnya. linux memiliki batasan jumlah pengamatan dan jika gagal melakukan pengamatan menggunakan `fs.watch`, maka pengamatan akan dilakukan dengan `fs.watchFile`
+`UseFsEventsWithFallbackDynamicPolling`        | Opsi ini mirip dengan `UseFsEvents` kecuali jika gagal memantau menggunakan `fs.watch`, pengawasan dilakukan melalui antrean polling dinamis (seperti dijelaskan dalam `DynamicPriorityPolling`)
+`UseFsEventsOnParentDirectory`                 | Opsi ini mengawasi direktori induk dari file dengan `fs.watch` (menggunakan system event file) sehingga menjadi rendah pada CPU tetapi dengan keakuratan yang rendah.
+standar (tanpa menspesifikkan nilainya)                   | Jika variabel environment `TSC_NONPOLLING_WATCHER` di-set ke true, maka akan mengawasi direktori induk dari file (seperti `UseFsEventsOnParentDirectory`). Jika tidak, akan menggunakan `fs.watchFile` dengan `250ms` sebagai waktu tunggu untuk file apa pun.
+
+## Mengonfigurasi pengawasan direktori menggunakan variabel environment `TSC_WATCHDIRECTORY`
+
+Pemantauan direktori pada platform yang tidak mendukung pemantau direktori rekursif secara native di node, maka akan menggunakan opsi yang berbeda, yang dipilih oleh`TSC_WATCHDIRECTORY`. Perlu dicatat bahwa, platform yang mendukung pemantauan direktori secara rekursif (misalnya Windows), nilai dari variabel environment tersebut akan diabaikan.
+
+<!-- prettier-ignore -->
+Opsi                                         | Deskripsi
+-----------------------------------------------|----------------------------------------------------------------------
+`RecursiveDirectoryUsingFsWatchFile`           | Gunakan `fs.watchFile` untuk mengawasi direktori dan direktori anak yang merupakan polling watch (menggunakan siklus CPU)
+`RecursiveDirectoryUsingDynamicPriorityPolling`| Gunakan antrian polling dinamis untuk mengumpulkan perubahan pada direktori dan sub direktori.
+default (no value specified)                   | Gunakan `fs.watch` untuk memantau direktoru dan sub direktorinya

--- a/packages/documentation/copy/id/reference/Decorators.md
+++ b/packages/documentation/copy/id/reference/Decorators.md
@@ -1,0 +1,573 @@
+---
+title: Decorators
+layout: docs
+permalink: /id/docs/handbook/decorators.html
+oneline: Ringkasan Dekorator TypeScript
+translatable: true
+---
+
+## Pengenalan
+
+Dengan pengenalan Kelas-kelas yang ada di TypeScript dan ES6, sekarang ada skenario tertentu yang memerlukan fitur tambahan untuk mendukung anotasi atau modifikasi kelas dan anggota kelas.
+Decorators menyediakan cara untuk menambahkan anotasi-anotasi dan sebuah sintaks pemrogragaman meta untuk deklarasi kelas dan anggota kelas.
+Decorators ada pada [stage 2 proposal](https://github.com/tc39/proposal-decorators) untuk JavaScript dan juga tersedia pada TypeScript sebagai fitur eksperimental.
+
+> CATATAN&emsp; Decorators adalah fitur eksperimental yang mungkin dapat berubah ketika dirilis nanti.
+
+Untuk mengaktifkan Decorators eksperimental, anda harus menambahkan opsi `experimentalDecorators` ke baris perintah atau ke berkas `tsconfig.json`.
+
+**Command Line**:
+
+```shell
+tsc --target ES5 --experimentalDecorators
+```
+
+**tsconfig.json**:
+
+```json  tsconfig
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "experimentalDecorators": true
+  }
+}
+```
+
+## Decorator
+
+_Decorator_ adalah jenis deklarasi khusus yang dapat dilampirkan ke [deklarasi kelas](#class-decorators), [method](#method-decorators), [accessor](#accessor-decorators), [property](#property-decorators), atau [parameter](#parameter-decorators).
+Decorators menggunakan bentuk `@expression`, dimana `expression` harus mengevaluasi fungsi yang akan dipanggil saat proses dengan informasi tentang deklarasi yang didekorasi.
+
+Sebagai contoh, ada decorator `@sealed` yang mungkin kita akan menuliskan fungsi `sealed` sebagai berikut:
+
+```ts
+function sealed(target) {
+  // lakukan sesuatu dengan 'target' ...
+}
+```
+
+> CATATAN&emsp; Anda dapat melihat contoh lengkapnya di [Decorator Kelas](#class-decorators).
+
+## Decorator Factories
+
+Jika kita ingin menyesuaikan penerapan decorator pada sebuah deklarasi, kita dapat menuliskan sebuah decorator factory. _Decorator Factory_ adalah sebuah fungsi yang mengembalikan ekspresi yang akan dipanggil oleh decorator ketika proses.
+
+Kita dapat menuliskan decorator factory seperti berikut:
+
+```ts
+function color(value: string) {
+  // ini adalah decorator factory
+  return function (target) {
+    // ini adalah decorator
+    // lakukan sesuatu dengan 'target' dan 'value'...
+  };
+}
+```
+
+> CATATAN&emsp; Anda dapat melihat contoh lengkap dari penggunaan decorator factory di [Method Decorators](#method-decorators)
+
+## Komposisi Decorator
+
+Lebih dari satu decorator dapat diterapkan pada sebuah deklarasi, seperti contoh berikut:
+
+- Penerapan dengan satu baris:
+
+  ```ts
+  @f @g x
+  ```
+
+- Penerapan lebih dari satu baris:
+
+  ```ts
+  @f
+  @g
+  x
+  ```
+
+Ketika lebih dari satu decorator diterapkan ke sebuah deklarasi, evaluasi yang dilakukan mirip seperti [fungsi komposisi pada matematika](http://wikipedia.org/wiki/Function_composition). Pada model ini, ketika mengkomposisikan fungsi _f_ dan _g_, maka akan menjadi (_f_ ∘ _g_)(_x_) yang sama dengan _f_(_g_(_x_)).
+
+Dengan demikian, langkah-langkah berikut dilakukan saat mengevaluasi beberapa dekorator pada satu deklarasi di TypeScript:
+
+1. Ekspresi untuk setiap dekorator dievaluasi dari atas ke bawah.
+2. Hasilnya kemudian disebut sebagai fungsi dari bawah ke atas.
+
+If we were to use [decorator factories](#decorator-factories), we can observe this evaluation order with the following example:
+
+JIka kita menggunakan [decorator factories](#decorator-factories), kita dapat mengamati urutan evaluasi ini dengan contoh berikut:
+
+```ts
+function f() {
+  console.log("f(): evaluated");
+  return function (
+    target,
+    propertyKey: string,
+    descriptor: PropertyDescriptor
+  ) {
+    console.log("f(): called");
+  };
+}
+
+function g() {
+  console.log("g(): evaluated");
+  return function (
+    target,
+    propertyKey: string,
+    descriptor: PropertyDescriptor
+  ) {
+    console.log("g(): called");
+  };
+}
+
+class C {
+  @f()
+  @g()
+  method() {}
+}
+```
+
+Yang akan mencetak keluaran ini ke console:
+
+```shell
+f(): evaluated
+g(): evaluated
+g(): called
+f(): called
+```
+
+## Evaluasi Decorator
+
+Ada urutan yang jelas tentang bagaimana decorator diterapkan ke berbagai deklarasi yang ada di dalam kelas:
+
+1. _Parameter Decorators_, diikuti oleh _Method_, _Accessor_, atau _Property Decorators_ diterapkan untuk setiap anggota instance.
+1. _Parameter Decorators_, diikuti oleh _Method_, _Accessor_, atau _Property Decorators_ diterapkan untuk setiap anggota statis.
+1. _Parameter Dekorator_ diterapkan untuk konstruktor.
+1. _Class Decorators_ diterapkan untuk kelas.
+
+## Decorator Kelas
+
+_Class Decorator_ dideklarasikan tepat sebelum deklarasi kelas.
+Dekorator kelas diterapkan ke konstruktor kelas dan dapat digunakan untuk mengamati, memodifikasi, atau mengganti definisi kelas.
+Dekorator kelas tidak dapat digunakan dalam file deklarasi, atau dalam konteks ambien lainnya (seperti pada kelas `deklarasi`).
+
+Ekspresi untuk dekorator kelas akan dipanggil sebagai fungsi pada waktu proses, dengan konstruktor kelas yang didekorasi sebagai satu-satunya argumennya.
+
+Jika dekorator kelas mengembalikan nilai, deklarasi kelas akan diganti dengan fungsi konstruktor yang disediakan.
+
+> CATATAN&nbsp; Jika Anda memilih untuk mengembalikan fungsi konstruktor baru, Anda harus berhati-hati dalam mempertahankan prototipe asli.
+> Logika yang menerapkan dekorator pada waktu proses **tidak akan** melakukannya untukmu.
+
+Berikut ini adalah contoh decorator kelas (`@sealed`) yang diterapkan ke kelas `Greeter`:
+
+```ts
+@sealed
+class Greeter {
+  greeting: string;
+  constructor(message: string) {
+    this.greeting = message;
+  }
+  greet() {
+    return "Hello, " + this.greeting;
+  }
+}
+```
+
+Kita dapat mendefinisikan dekorator `@sealed` menggunakan deklarasi fungsi berikut:
+
+```ts
+function sealed(constructor: Function) {
+  Object.seal(constructor);
+  Object.seal(constructor.prototype);
+}
+```
+
+Ketika `@sealed` dijalankan, itu akan menyegel konstruktor dan prototipe-nya.
+
+Selanjutnya kita memiliki contoh bagaimana menimpa konstruktor.
+
+```ts
+function classDecorator<T extends { new (...args: any[]): {} }>(
+  constructor: T
+) {
+  return class extends constructor {
+    newProperty = "new property";
+    hello = "override";
+  };
+}
+
+@classDecorator
+class Greeter {
+  property = "property";
+  hello: string;
+  constructor(m: string) {
+    this.hello = m;
+  }
+}
+
+console.log(new Greeter("world"));
+```
+
+## Method Decorators
+
+_Method Decorator_ dideklarasikan tepat sebelum deklarasi metthod.
+Dekorator diterapkan ke _Property Descriptor_ untuk method, yang dapat digunakan untuk mengamati, memodifikasi, atau mengganti definisi method.
+Method Dekorator tidak dapat digunakan dalam file deklarasi, saat kelebihan beban, atau dalam konteks ambien lainnya (seperti dalam kelas `declare`).
+
+Ekspresi untuk method decorator akan dipanggil sebagai fungsi pada waktu proses, dengan tiga argumen berikut:
+
+1. Bisa memiliki fungsi konstruktor kelas untuk anggota statis, atau prototipe kelas untuk anggota instance.
+2. Nama anggota.
+3. The _Property Descriptor_ untuk anggota.
+
+> CATATAN&emsp; _Property Descriptor_ akan menjadi `undefined` jika target skripmu dibawah `ES5`.
+
+Jika method decorator mengembalikan sebuah nilai, maka akan digunakan sebagai _Property Descriptor_ untuk method.
+
+> CATATAN&emsp; Nilai yang dikembalikan akan dibiarkan, jika target skripmu dibawah `ES5`.
+
+Berikut adalah contoh penerapan method decorator (`@enumerable`) ke method yang ada pada kelas `Greeter`:
+
+```ts
+class Greeter {
+  greeting: string;
+  constructor(message: string) {
+    this.greeting = message;
+  }
+
+  @enumerable(false)
+  greet() {
+    return "Hello, " + this.greeting;
+  }
+}
+```
+
+Kita dapat mendefinisikan dekorator `@enumerable` menggunakan fungsi deklarasi berikut:
+
+```ts
+function enumerable(value: boolean) {
+  return function (
+    target: any,
+    propertyKey: string,
+    descriptor: PropertyDescriptor
+  ) {
+    descriptor.enumerable = value;
+  };
+}
+```
+
+Decorator `@enumerable(false)` disini adalah sebuah [decorator factory](#decorator-factories).
+Ketika decorator `@enumerable(false)` dipanggil, ia akan merubah `enumerable` property dari property descriptor.
+
+## Decorator Aksesor
+
+Sebuah _Accessor Decorator_ dideklarasikan tepat sebelum sebuah deklarasi aksesor.
+Decorator aksesor diterapkan ke _Property Descriptor_ untuk aksesor dan dapat digunakan untuk mengamati, memodifikasi, atau mengganti definisi aksesor.
+Decorator aksesor tidak dapat digunakan dalam deklarasi file, atau dalam konteks ambien lainnya (seperti dalam kelas `declare`).
+
+> CATATAN&emsp; TypeScript melarang penerapan decorator ke aksesor `get` dan `set` untuk single member.
+> Sebaliknya, semua decorator untuk anggota harus diterapkan ke pengakses pertama yang ditentukan dalam urutan dokumen.
+> Ini karena dekorator berlaku untuk _Property Descriptor_, yang menggabungkan aksesor `get` dan`set`, bukan setiap deklarasi secara terpisah.
+
+Ekspresi untuk decorator pengakses akan dipanggil sebagai fungsi pada waktu proses, dengan tiga argumen berikut:
+
+1. Bisa memiliki fungsi konstruktor kelas untuk anggota statis, atau prototipe kelas untuk anggota instance.
+2. Nama anggota.
+3. The _Property Descriptor_ untuk anggota.
+
+> CATATAN&emsp; _Property Descriptor_ akan menjadi `undefined`, jika target skripmu dibawah `ES5`.
+
+Jika aksesor decorator mengembalikan sebuah nilai, ia akan digunakan sebagai _Property Descriptor_ untuk anggota.
+
+> CATATAN&emsp; Nilai yang dikembalikan akan dibiarkan, jika target skripmu dibawah `ES5`.
+
+Berikut ada contoh penerapan aksesor decorator (`@configurable`) ke anggota kelas `Point`:
+
+```ts
+class Point {
+  private _x: number;
+  private _y: number;
+  constructor(x: number, y: number) {
+    this._x = x;
+    this._y = y;
+  }
+
+  @configurable(false)
+  get x() {
+    return this._x;
+  }
+
+  @configurable(false)
+  get y() {
+    return this._y;
+  }
+}
+```
+
+Kita dapat mendefinisikan decorator `@configurable` menggunakan deklarasi fungsi berikut:
+
+```ts
+function configurable(value: boolean) {
+  return function (
+    target: any,
+    propertyKey: string,
+    descriptor: PropertyDescriptor
+  ) {
+    descriptor.configurable = value;
+  };
+}
+```
+
+## Property Decorators
+
+Sebuah _Property Decorator_ dideklarasikan tepat sebelum deklarasi properti.
+_Property Decorator_ tidak dapat digunakan dalam deklarasi file, atau dalam konteks ambien lainnya (seperti dalam kelas `declare`).
+
+Ekspresi untuk property decorator akan dipanggil sebagai fungsi pada waktu proses, dengan dua argumen berikut:
+
+1. Dapat berupa fungsi konstruktor kelas untuk anggota statis, atau prototipe kelas untuk anggota instance.
+2. Nama anggota.
+
+> CATATAN&emsp; _Property Descriptior_ tidak menyediakan sebuah argumen untuk property decorator karena bergantung tentang bagaimana property decorator diinisialisasi pada TypeScript.
+> Ini karena, saat ini tidak ada mekanisme untuk mendeskripsikan sebuah instance property ketika mendefinisikan anggota dari sebuah prototipe, dan tidak ada cara untuk mengamati atau memodifikasi initializer untuk property. Dan nilai kembalian juga akan dibiarkan.
+> Sehingga, sebuah property decorator hanya bisa digunakan untuk mengamati property dengan nama yang spesifik, yang telah dideklarasikan pada sebuah kelas.
+
+Kita dapat menggunakan informasi tersebut untuk memantau property metadata, seperti pada contoh berikut:
+
+```ts
+class Greeter {
+  @format("Hello, %s")
+  greeting: string;
+
+  constructor(message: string) {
+    this.greeting = message;
+  }
+  greet() {
+    let formatString = getFormat(this, "greeting");
+    return formatString.replace("%s", this.greeting);
+  }
+}
+```
+
+Kemudian, kita dapat mendefinisikan decorator `@format` dan fungsi `getFormat` dengan menggunakan deklarasi fungsi berikut:
+
+```ts
+import "reflect-metadata";
+
+const formatMetadataKey = Symbol("format");
+
+function format(formatString: string) {
+  return Reflect.metadata(formatMetadataKey, formatString);
+}
+
+function getFormat(target: any, propertyKey: string) {
+  return Reflect.getMetadata(formatMetadataKey, target, propertyKey);
+}
+```
+
+Decorator `@format("Hello, %s")` disini adalah sebuah [decorator factory](#decorator-factories).
+Ketika `@format("Hello, %s")` dipanggil, ia akan menambahkan property metadata menggunakan fungsi `Reflect.metadata` dari pustaka `reflect-metadata`.
+Ketika `getFormat` dipanggil, ia akan membaca format dari nilai metadata-nya.
+
+> CATATAN&emsp; Contoh ini membutuhkan pustaka `reflect-metadata`.
+> Lihat [Metadata](#metadata) untuk informasi lebih lanjut mengenai pustaka `reflect-metadata`.
+
+## Parameter Decorators
+
+_Parameter Decorator_ dideklarasikan tepat sebelum a parameter dideklarasikan.
+Parameter decorator diterapkan ke fungsi konstruktor pada kelas atau saat deklarasi method.
+Parameter decorator tidak dapat digunakan dalam deklarasi file, overload, atau dalam konteks ambien lainnya (seperti dalam kelas `declare`).
+
+Ekspresi untuk parameter decorator akan dipanggil sebagai fungsi pada waktu proses, dengan tiga argumen berikut:
+
+1. Dapat berupa fungsi konstruktor kelas untuk anggota statis, atau prototipe kelas untuk anggota instance.
+2. Nama anggota.
+3. Indeks ordinal dari parameter dalam daftar parameter fungsi.
+
+> CATATAN&emsp; Sebuah parameter decorator hanya bisa digunakan untuk mengamati sebuah parameter yang telah dideklarasikan pada sebuah method.
+
+Nilai kembalian dari parameter decorator akan dibiarkan.
+
+Berikut adalah contoh penggunaan parameter decorator (`@required`) pada anggota kelas `Greeter`:
+
+```ts
+class Greeter {
+  greeting: string;
+
+  constructor(message: string) {
+    this.greeting = message;
+  }
+
+  @validate
+  greet(@required name: string) {
+    return "Hello " + name + ", " + this.greeting;
+  }
+}
+```
+
+Kemudian, kita dapat mendefinisikan decorator `@required` dan `@validate` menggunakan deklarasi fungsi berikut:
+
+```ts
+import "reflect-metadata";
+
+const requiredMetadataKey = Symbol("required");
+
+function required(
+  target: Object,
+  propertyKey: string | symbol,
+  parameterIndex: number
+) {
+  let existingRequiredParameters: number[] =
+    Reflect.getOwnMetadata(requiredMetadataKey, target, propertyKey) || [];
+  existingRequiredParameters.push(parameterIndex);
+  Reflect.defineMetadata(
+    requiredMetadataKey,
+    existingRequiredParameters,
+    target,
+    propertyKey
+  );
+}
+
+function validate(
+  target: any,
+  propertyName: string,
+  descriptor: TypedPropertyDescriptor<Function>
+) {
+  let method = descriptor.value;
+  descriptor.value = function () {
+    let requiredParameters: number[] = Reflect.getOwnMetadata(
+      requiredMetadataKey,
+      target,
+      propertyName
+    );
+    if (requiredParameters) {
+      for (let parameterIndex of requiredParameters) {
+        if (
+          parameterIndex >= arguments.length ||
+          arguments[parameterIndex] === undefined
+        ) {
+          throw new Error("Missing required argument.");
+        }
+      }
+    }
+
+    return method.apply(this, arguments);
+  };
+}
+```
+
+Decorator `@required` menambahkan entri metadata yang menandakan bahwa parameter tersebut diperlukan.
+Decorator `@validate` kemudian akan memvalidasi semua argumen yang ada, sebelum method-nya dijalankan.
+
+> CATATAN&emsp; Contoh ini memerlukan pustaka `reflect-metadata`
+> Lihat [Metadata](#metadata) untuk informasi lebih lanjut mengenai pustaka `reflect-metadata`.
+
+## Metadata
+
+Beberapa contoh menggunakan pustaka `reflect-metadata` yang menambahkan polyfill untuk [API metadata eksperimental](https://github.com/rbuckton/ReflectDecorators).
+Pustaka ini belum menjadi bagian dari standar ECMAScript (JavaScript).
+Namun, ketika decorator secara resmi diadopsi sebagai bagian dari standar ECMAScript, ekstensi ini akan diusulkan untuk diadopsi.
+
+Anda dapat memasang pustaka ini melalui npm:
+
+```shell
+npm i reflect-metadata --save
+```
+
+TypeScript menyertakan dukungan eksperimental untuk menghadirkan jenis metadata tertentu untuk deklarasi yang memiliki decorator.
+Untuk mengaktifkan dukungan eksperimental ini, Anda harus mengatur opsi compiler `emitDecoratorMetadata` baik pada baris perintah atau di `tsconfig.json` Anda:
+
+**Command Line**:
+
+```shell
+tsc --target ES5 --experimentalDecorators --emitDecoratorMetadata
+```
+
+**tsconfig.json**:
+
+```json tsconfig
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  }
+}
+```
+
+Ketika diaktifkan, selama pustaka `reflect-metadata` di-import, informasi jenis design-time tambahan akan diekspos saat runtime.
+
+Kita dapat melihat action pada contoh berikut:
+
+```ts
+import "reflect-metadata";
+
+class Point {
+  x: number;
+  y: number;
+}
+
+class Line {
+  private _p0: Point;
+  private _p1: Point;
+
+  @validate
+  set p0(value: Point) {
+    this._p0 = value;
+  }
+  get p0() {
+    return this._p0;
+  }
+
+  @validate
+  set p1(value: Point) {
+    this._p1 = value;
+  }
+  get p1() {
+    return this._p1;
+  }
+}
+
+function validate<T>(
+  target: any,
+  propertyKey: string,
+  descriptor: TypedPropertyDescriptor<T>
+) {
+  let set = descriptor.set;
+  descriptor.set = function (value: T) {
+    let type = Reflect.getMetadata("design:type", target, propertyKey);
+    if (!(value instanceof type)) {
+      throw new TypeError("Invalid type.");
+    }
+    set.call(target, value);
+  };
+}
+```
+
+Compiler TypeScript akan memasukkan informasi jenis design-time menggunakan decorator `@Reflect.metadata`.
+Anda dapat menganggapnya setara dengan TypeScript berikut:
+
+```ts
+class Line {
+  private _p0: Point;
+  private _p1: Point;
+
+  @validate
+  @Reflect.metadata("design:type", Point)
+  set p0(value: Point) {
+    this._p0 = value;
+  }
+  get p0() {
+    return this._p0;
+  }
+
+  @validate
+  @Reflect.metadata("design:type", Point)
+  set p1(value: Point) {
+    this._p1 = value;
+  }
+  get p1() {
+    return this._p1;
+  }
+}
+```
+
+> CATATAN&emsp; Decorator metadata adalah fitur experimental dan mungkin dapat menyebabkan gangguan pada rilis di masa mendatang.

--- a/packages/documentation/copy/id/reference/Decorators.md
+++ b/packages/documentation/copy/id/reference/Decorators.md
@@ -9,14 +9,14 @@ translatable: true
 ## Pengenalan
 
 Dengan pengenalan Kelas-kelas yang ada di TypeScript dan ES6, sekarang ada skenario tertentu yang memerlukan fitur tambahan untuk mendukung anotasi atau modifikasi kelas dan anggota kelas.
-Decorators menyediakan cara untuk menambahkan anotasi-anotasi dan sebuah sintaks pemrogragaman meta untuk deklarasi kelas dan anggota kelas.
-Decorators ada pada [stage 2 proposal](https://github.com/tc39/proposal-decorators) untuk JavaScript dan juga tersedia pada TypeScript sebagai fitur eksperimental.
+_Decorators_ menyediakan cara untuk menambahkan anotasi-anotasi dan sebuah sintaks pemrogragaman meta untuk deklarasi kelas dan anggota kelas.
+_Decorators_ ada pada [stage 2 proposal](https://github.com/tc39/proposal-decorators) untuk JavaScript dan juga tersedia pada TypeScript sebagai fitur eksperimental.
 
-> CATATAN&emsp; Decorators adalah fitur eksperimental yang mungkin dapat berubah ketika dirilis nanti.
+> CATATAN&emsp; _Decorators_ adalah fitur eksperimental yang mungkin dapat berubah ketika dirilis nanti.
 
-Untuk mengaktifkan Decorators eksperimental, anda harus menambahkan opsi `experimentalDecorators` ke baris perintah atau ke berkas `tsconfig.json`.
+Untuk mengaktifkan _Decorators_ eksperimental, anda harus menambahkan opsi `experimentalDecorators` ke baris perintah atau ke berkas `tsconfig.json`.
 
-**Command Line**:
+**_Command Line_**:
 
 ```shell
 tsc --target ES5 --experimentalDecorators
@@ -33,10 +33,10 @@ tsc --target ES5 --experimentalDecorators
 }
 ```
 
-## Decorator
+## _Decorator_
 
 _Decorator_ adalah jenis deklarasi khusus yang dapat dilampirkan ke [deklarasi kelas](#class-decorators), [method](#method-decorators), [accessor](#accessor-decorators), [property](#property-decorators), atau [parameter](#parameter-decorators).
-Decorators menggunakan bentuk `@expression`, dimana `expression` harus mengevaluasi fungsi yang akan dipanggil saat proses dengan informasi tentang deklarasi yang didekorasi.
+_Decorators_ menggunakan bentuk `@expression`, dimana `expression` harus mengevaluasi fungsi yang akan dipanggil saat proses dengan informasi tentang deklarasi yang didekorasi.
 
 Sebagai contoh, ada decorator `@sealed` yang mungkin kita akan menuliskan fungsi `sealed` sebagai berikut:
 
@@ -48,11 +48,11 @@ function sealed(target) {
 
 > CATATAN&emsp; Anda dapat melihat contoh lengkapnya di [Decorator Kelas](#class-decorators).
 
-## Decorator Factories
+## _Decorator Factories_
 
-Jika kita ingin menyesuaikan penerapan decorator pada sebuah deklarasi, kita dapat menuliskan sebuah decorator factory. _Decorator Factory_ adalah sebuah fungsi yang mengembalikan ekspresi yang akan dipanggil oleh decorator ketika proses.
+Jika kita ingin menyesuaikan penerapan _decorator_ pada sebuah deklarasi, kita dapat menuliskan sebuah _decorator factory_. _Decorator Factory_ adalah sebuah fungsi yang mengembalikan ekspresi yang akan dipanggil oleh _decorator_ ketika proses.
 
-Kita dapat menuliskan decorator factory seperti berikut:
+Kita dapat menuliskan _decorator factory_ seperti berikut:
 
 ```ts
 function color(value: string) {
@@ -64,11 +64,11 @@ function color(value: string) {
 }
 ```
 
-> CATATAN&emsp; Anda dapat melihat contoh lengkap dari penggunaan decorator factory di [Method Decorators](#method-decorators)
+> CATATAN&emsp; Anda dapat melihat contoh lengkap dari penggunaan _decorator factory_ di [_Method Decorators_](#method-decorators)
 
-## Komposisi Decorator
+## Komposisi _Decorator_
 
-Lebih dari satu decorator dapat diterapkan pada sebuah deklarasi, seperti contoh berikut:
+Lebih dari satu _decorator_ dapat diterapkan pada sebuah deklarasi, seperti contoh berikut:
 
 - Penerapan dengan satu baris:
 
@@ -84,16 +84,14 @@ Lebih dari satu decorator dapat diterapkan pada sebuah deklarasi, seperti contoh
   x
   ```
 
-Ketika lebih dari satu decorator diterapkan ke sebuah deklarasi, evaluasi yang dilakukan mirip seperti [fungsi komposisi pada matematika](http://wikipedia.org/wiki/Function_composition). Pada model ini, ketika mengkomposisikan fungsi _f_ dan _g_, maka akan menjadi (_f_ ∘ _g_)(_x_) yang sama dengan _f_(_g_(_x_)).
+Ketika lebih dari satu _decorator_ diterapkan ke sebuah deklarasi, evaluasi yang dilakukan mirip seperti [fungsi komposisi pada matematika](http://wikipedia.org/wiki/Function_composition). Pada model ini, ketika mengkomposisikan fungsi _f_ dan _g_, maka akan menjadi (_f_ ∘ _g_)(_x_) yang sama dengan _f_(_g_(_x_)).
 
-Dengan demikian, langkah-langkah berikut dilakukan saat mengevaluasi beberapa dekorator pada satu deklarasi di TypeScript:
+Dengan demikian, langkah-langkah berikut dilakukan saat mengevaluasi beberapa _decorator_ pada satu deklarasi di TypeScript:
 
-1. Ekspresi untuk setiap dekorator dievaluasi dari atas ke bawah.
+1. Ekspresi untuk setiap _decorator_ dievaluasi dari atas ke bawah.
 2. Hasilnya kemudian disebut sebagai fungsi dari bawah ke atas.
 
-If we were to use [decorator factories](#decorator-factories), we can observe this evaluation order with the following example:
-
-JIka kita menggunakan [decorator factories](#decorator-factories), kita dapat mengamati urutan evaluasi ini dengan contoh berikut:
+JIka kita menggunakan [_decorator factories_](#decorator-factories), kita dapat mengamati urutan evaluasi ini dengan contoh berikut:
 
 ```ts
 function f() {
@@ -125,7 +123,7 @@ class C {
 }
 ```
 
-Yang akan mencetak keluaran ini ke console:
+Yang akan mencetak keluaran ini ke _console_:
 
 ```shell
 f(): evaluated
@@ -134,29 +132,29 @@ g(): called
 f(): called
 ```
 
-## Evaluasi Decorator
+## Evaluasi _Decorator_
 
-Ada urutan yang jelas tentang bagaimana decorator diterapkan ke berbagai deklarasi yang ada di dalam kelas:
+Ada urutan yang jelas tentang bagaimana _decorator_ diterapkan ke berbagai deklarasi yang ada di dalam kelas:
 
 1. _Parameter Decorators_, diikuti oleh _Method_, _Accessor_, atau _Property Decorators_ diterapkan untuk setiap anggota instance.
 1. _Parameter Decorators_, diikuti oleh _Method_, _Accessor_, atau _Property Decorators_ diterapkan untuk setiap anggota statis.
 1. _Parameter Dekorator_ diterapkan untuk konstruktor.
 1. _Class Decorators_ diterapkan untuk kelas.
 
-## Decorator Kelas
+## _Decorator_ Kelas
 
 _Class Decorator_ dideklarasikan tepat sebelum deklarasi kelas.
-Dekorator kelas diterapkan ke konstruktor kelas dan dapat digunakan untuk mengamati, memodifikasi, atau mengganti definisi kelas.
-Dekorator kelas tidak dapat digunakan dalam file deklarasi, atau dalam konteks ambien lainnya (seperti pada kelas `deklarasi`).
+_Decorator_ kelas diterapkan ke konstruktor kelas dan dapat digunakan untuk mengamati, memodifikasi, atau mengganti definisi kelas.
+_Decorator_ kelas tidak dapat digunakan dalam berkas deklarasi, atau dalam konteks ambien lainnya (seperti pada kelas `deklarasi`).
 
-Ekspresi untuk dekorator kelas akan dipanggil sebagai fungsi pada waktu proses, dengan konstruktor kelas yang didekorasi sebagai satu-satunya argumennya.
+Ekspresi untuk _decorator_ kelas akan dipanggil sebagai fungsi pada waktu proses, dengan konstruktor kelas yang didekorasi sebagai satu-satunya argumennya.
 
-Jika dekorator kelas mengembalikan nilai, deklarasi kelas akan diganti dengan fungsi konstruktor yang disediakan.
+Jika _decorator_ kelas mengembalikan nilai, deklarasi kelas akan diganti dengan fungsi konstruktor yang disediakan.
 
 > CATATAN&nbsp; Jika Anda memilih untuk mengembalikan fungsi konstruktor baru, Anda harus berhati-hati dalam mempertahankan prototipe asli.
 > Logika yang menerapkan dekorator pada waktu proses **tidak akan** melakukannya untukmu.
 
-Berikut ini adalah contoh decorator kelas (`@sealed`) yang diterapkan ke kelas `Greeter`:
+Berikut ini adalah contoh _decorator_ kelas (`@sealed`) yang diterapkan ke kelas _`Greeter`_:
 
 ```ts
 @sealed
@@ -171,7 +169,7 @@ class Greeter {
 }
 ```
 
-Kita dapat mendefinisikan dekorator `@sealed` menggunakan deklarasi fungsi berikut:
+Kita dapat mendefinisikan _decorator_ `@sealed` menggunakan deklarasi fungsi berikut:
 
 ```ts
 function sealed(constructor: Function) {
@@ -180,7 +178,7 @@ function sealed(constructor: Function) {
 }
 ```
 
-Ketika `@sealed` dijalankan, itu akan menyegel konstruktor dan prototipe-nya.
+Ketika `@sealed` dijalankan, itu akan menyegel konstruktor dan prototipenya.
 
 Selanjutnya kita memiliki contoh bagaimana menimpa konstruktor.
 
@@ -208,23 +206,23 @@ console.log(new Greeter("world"));
 
 ## Method Decorators
 
-_Method Decorator_ dideklarasikan tepat sebelum deklarasi metthod.
-Dekorator diterapkan ke _Property Descriptor_ untuk method, yang dapat digunakan untuk mengamati, memodifikasi, atau mengganti definisi method.
-Method Dekorator tidak dapat digunakan dalam file deklarasi, saat kelebihan beban, atau dalam konteks ambien lainnya (seperti dalam kelas `declare`).
+_Method Decorator_ dideklarasikan tepat sebelum deklarasi _method_.
+Dekorator diterapkan ke _Property Descriptor_ untuk method, yang dapat digunakan untuk mengamati, memodifikasi, atau mengganti definisi _method_.
+_Method Decorator_ tidak dapat digunakan dalam berkas deklarasi, saat kelebihan beban, atau dalam konteks ambien lainnya (seperti dalam kelas `declare`).
 
-Ekspresi untuk method decorator akan dipanggil sebagai fungsi pada waktu proses, dengan tiga argumen berikut:
+Ekspresi untuk _method decorator_ akan dipanggil sebagai fungsi pada waktu proses, dengan tiga argumen berikut:
 
-1. Bisa memiliki fungsi konstruktor kelas untuk anggota statis, atau prototipe kelas untuk anggota instance.
+1. Bisa memiliki fungsi konstruktor kelas untuk anggota statis, atau prototipe kelas untuk anggota _instance_.
 2. Nama anggota.
 3. The _Property Descriptor_ untuk anggota.
 
 > CATATAN&emsp; _Property Descriptor_ akan menjadi `undefined` jika target skripmu dibawah `ES5`.
 
-Jika method decorator mengembalikan sebuah nilai, maka akan digunakan sebagai _Property Descriptor_ untuk method.
+Jika _method decorator_ mengembalikan sebuah nilai, maka akan digunakan sebagai _Property Descriptor_ untuk method.
 
-> CATATAN&emsp; Nilai yang dikembalikan akan dibiarkan, jika target skripmu dibawah `ES5`.
+> CATATAN&emsp; Nilai yang dikembalikan akan dibiarkan, jika target kodemu dibawah `ES5`.
 
-Berikut adalah contoh penerapan method decorator (`@enumerable`) ke method yang ada pada kelas `Greeter`:
+Berikut adalah contoh penerapan _method decorator_ (`@enumerable`) ke method yang ada pada kelas _`Greeter`_:
 
 ```ts
 class Greeter {
@@ -240,7 +238,7 @@ class Greeter {
 }
 ```
 
-Kita dapat mendefinisikan dekorator `@enumerable` menggunakan fungsi deklarasi berikut:
+Kita dapat mendefinisikan _decorator_ `@enumerable` menggunakan fungsi deklarasi berikut:
 
 ```ts
 function enumerable(value: boolean) {
@@ -254,32 +252,32 @@ function enumerable(value: boolean) {
 }
 ```
 
-Decorator `@enumerable(false)` disini adalah sebuah [decorator factory](#decorator-factories).
-Ketika decorator `@enumerable(false)` dipanggil, ia akan merubah `enumerable` properti dari properti descriptor.
+_Decorator_ `@enumerable(false)` disini adalah sebuah [_decorator factory_](#decorator-factories).
+Ketika _decorator_ `@enumerable(false)` dipanggil, ia akan merubah _`enumerable`_ properti dari properti _descriptor_.
 
-## Decorator Aksesor
+## _Decorator_ Aksesor
 
 Sebuah _Accessor Decorator_ dideklarasikan tepat sebelum sebuah deklarasi aksesor.
-Decorator aksesor diterapkan ke _Property Descriptor_ untuk aksesor dan dapat digunakan untuk mengamati, memodifikasi, atau mengganti definisi aksesor.
-Decorator aksesor tidak dapat digunakan dalam deklarasi file, atau dalam konteks ambien lainnya (seperti dalam kelas `declare`).
+_Decorator_ aksesor diterapkan ke _Property Descriptor_ untuk aksesor dan dapat digunakan untuk mengamati, memodifikasi, atau mengganti definisi aksesor.
+_Decorator_ aksesor tidak dapat digunakan dalam deklarasi berkas, atau dalam konteks ambien lainnya (seperti dalam kelas `declare`).
 
-> CATATAN&emsp; TypeScript melarang penerapan decorator ke aksesor `get` dan `set` untuk single member.
-> Sebaliknya, semua decorator untuk anggota harus diterapkan ke pengakses pertama yang ditentukan dalam urutan dokumen.
-> Ini karena dekorator berlaku untuk _Property Descriptor_, yang menggabungkan aksesor `get` dan`set`, bukan setiap deklarasi secara terpisah.
+> CATATAN&emsp; TypeScript melarang penerapan _decorator_ ke aksesor `get` dan `set` untuk _single_ member.
+> Sebaliknya, semua _decorator_ untuk anggota harus diterapkan ke pengakses pertama yang ditentukan dalam urutan dokumen.
+> Ini karena _decorator_ berlaku untuk _Property Descriptor_, yang menggabungkan aksesor `get` dan `set`, bukan setiap deklarasi secara terpisah.
 
-Ekspresi untuk decorator pengakses akan dipanggil sebagai fungsi pada waktu proses, dengan tiga argumen berikut:
+Ekspresi untuk _decorator_ pengakses akan dipanggil sebagai fungsi pada waktu proses, dengan tiga argumen berikut:
 
-1. Bisa memiliki fungsi konstruktor kelas untuk anggota statis, atau prototipe kelas untuk anggota instance.
+1. Bisa memiliki fungsi konstruktor kelas untuk anggota statis, atau prototipe kelas untuk anggota _instance_.
 2. Nama anggota.
 3. The _Property Descriptor_ untuk anggota.
 
 > CATATAN&emsp; _Property Descriptor_ akan menjadi `undefined`, jika target skripmu dibawah `ES5`.
 
-Jika aksesor decorator mengembalikan sebuah nilai, ia akan digunakan sebagai _Property Descriptor_ untuk anggota.
+Jika aksesor _decorator_ mengembalikan sebuah nilai, ia akan digunakan sebagai _Property Descriptor_ untuk anggota.
 
 > CATATAN&emsp; Nilai yang dikembalikan akan dibiarkan, jika target skripmu dibawah `ES5`.
 
-Berikut ada contoh penerapan aksesor decorator (`@configurable`) ke anggota kelas `Point`:
+Berikut ada contoh penerapan aksesor _decorator_ (`@configurable`) ke anggota kelas _`Point`_:
 
 ```ts
 class Point {
@@ -302,7 +300,7 @@ class Point {
 }
 ```
 
-Kita dapat mendefinisikan decorator `@configurable` menggunakan deklarasi fungsi berikut:
+Kita dapat mendefinisikan _decorator_ `@configurable` menggunakan deklarasi fungsi berikut:
 
 ```ts
 function configurable(value: boolean) {
@@ -316,19 +314,19 @@ function configurable(value: boolean) {
 }
 ```
 
-## Property Decorators
+## _Property Decorators_
 
 Sebuah _Property Decorator_ dideklarasikan tepat sebelum deklarasi properti.
-_Property Decorator_ tidak dapat digunakan dalam deklarasi file, atau dalam konteks ambien lainnya (seperti dalam kelas `declare`).
+_Property Decorator_ tidak dapat digunakan dalam deklarasi berkas, atau dalam konteks ambien lainnya (seperti dalam kelas `declare`).
 
 Ekspresi untuk properti decorator akan dipanggil sebagai fungsi pada waktu proses, dengan dua argumen berikut:
 
-1. Dapat berupa fungsi konstruktor kelas untuk anggota statis, atau prototipe kelas untuk anggota instance.
+1. Dapat berupa fungsi konstruktor kelas untuk anggota statis, atau prototipe kelas untuk anggota _instance_.
 2. Nama anggota.
 
-> CATATAN&emsp; _Property Descriptior_ tidak menyediakan sebuah argumen untuk properti decorator karena bergantung tentang bagaimana properti decorator diinisialisasi pada TypeScript.
-> Ini karena, saat ini tidak ada mekanisme untuk mendeskripsikan sebuah instance properti ketika mendefinisikan anggota dari sebuah prototipe, dan tidak ada cara untuk mengamati atau memodifikasi initializer untuk properti. Dan nilai kembalian juga akan dibiarkan.
-> Sehingga, sebuah properti decorator hanya bisa digunakan untuk mengamati properti dengan nama yang spesifik, yang telah dideklarasikan pada sebuah kelas.
+> CATATAN&emsp; _Property Descriptior_ tidak menyediakan sebuah argumen untuk properti _decorator_ karena bergantung tentang bagaimana properti _decorator_ diinisialisasi pada TypeScript.
+> Ini karena, saat ini tidak ada mekanisme untuk mendeskripsikan sebuah _instance_ properti ketika mendefinisikan anggota dari sebuah prototipe, dan tidak ada cara untuk mengamati atau memodifikasi _initializer_ untuk properti. Dan nilai kembalian juga akan dibiarkan.
+> Sehingga, sebuah properti _decorator_ hanya bisa digunakan untuk mengamati properti dengan nama yang spesifik, yang telah dideklarasikan pada sebuah kelas.
 
 Kita dapat menggunakan informasi tersebut untuk memantau properti metadata, seperti pada contoh berikut:
 
@@ -347,7 +345,7 @@ class Greeter {
 }
 ```
 
-Kemudian, kita dapat mendefinisikan decorator `@format` dan fungsi `getFormat` dengan menggunakan deklarasi fungsi berikut:
+Kemudian, kita dapat mendefinisikan _decorator_ `@format` dan fungsi `getFormat` dengan menggunakan deklarasi fungsi berikut:
 
 ```ts
 import "reflect-metadata";
@@ -363,30 +361,30 @@ function getFormat(target: any, propertyKey: string) {
 }
 ```
 
-Decorator `@format("Hello, %s")` disini adalah sebuah [decorator factory](#decorator-factories).
+_Decorator_ `@format("Hello, %s")` disini adalah sebuah [decorator factory](#decorator-factories).
 Ketika `@format("Hello, %s")` dipanggil, ia akan menambahkan properti metadata menggunakan fungsi `Reflect.metadata` dari pustaka `reflect-metadata`.
-Ketika `getFormat` dipanggil, ia akan membaca format dari nilai metadata-nya.
+Ketika `getFormat` dipanggil, ia akan membaca format dari nilai _metadata_-nya.
 
 > CATATAN&emsp; Contoh ini membutuhkan pustaka `reflect-metadata`.
 > Lihat [Metadata](#metadata) untuk informasi lebih lanjut mengenai pustaka `reflect-metadata`.
 
-## Parameter Decorators
+## _Parameter Decorators_
 
 _Parameter Decorator_ dideklarasikan tepat sebelum a parameter dideklarasikan.
-Parameter decorator diterapkan ke fungsi konstruktor pada kelas atau saat deklarasi method.
-Parameter decorator tidak dapat digunakan dalam deklarasi file, overload, atau dalam konteks ambien lainnya (seperti dalam kelas `declare`).
+_Parameter decorator_ diterapkan ke fungsi konstruktor pada kelas atau saat deklarasi _method_.
+_Parameter decorator_ tidak dapat digunakan dalam deklarasi berkas, overload, atau dalam konteks ambien lainnya (seperti dalam kelas `declare`).
 
-Ekspresi untuk parameter decorator akan dipanggil sebagai fungsi pada waktu proses, dengan tiga argumen berikut:
+Ekspresi untuk _parameter decorator_ akan dipanggil sebagai fungsi pada waktu proses, dengan tiga argumen berikut:
 
-1. Dapat berupa fungsi konstruktor kelas untuk anggota statis, atau prototipe kelas untuk anggota instance.
+1. Dapat berupa fungsi konstruktor kelas untuk anggota statis, atau prototipe kelas untuk anggota _instance_.
 2. Nama anggota.
 3. Indeks ordinal dari parameter dalam daftar parameter fungsi.
 
-> CATATAN&emsp; Sebuah parameter decorator hanya bisa digunakan untuk mengamati sebuah parameter yang telah dideklarasikan pada sebuah method.
+> CATATAN&emsp; Sebuah _parameter decorator_ hanya bisa digunakan untuk mengamati sebuah parameter yang telah dideklarasikan pada sebuah method.
 
-Nilai kembalian dari parameter decorator akan dibiarkan.
+Nilai kembalian dari _parameter decorator_ akan dibiarkan.
 
-Berikut adalah contoh penggunaan parameter decorator (`@required`) pada anggota kelas `Greeter`:
+Berikut adalah contoh penggunaan _parameter decorator_ (`@required`) pada anggota kelas `Greeter`:
 
 ```ts
 class Greeter {
@@ -403,7 +401,7 @@ class Greeter {
 }
 ```
 
-Kemudian, kita dapat mendefinisikan decorator `@required` dan `@validate` menggunakan deklarasi fungsi berikut:
+Kemudian, kita dapat mendefinisikan _decorator_ `@required` dan `@validate` menggunakan deklarasi fungsi berikut:
 
 ```ts
 import "reflect-metadata";
@@ -454,15 +452,15 @@ function validate(
 }
 ```
 
-Decorator `@required` menambahkan entri metadata yang menandakan bahwa parameter tersebut diperlukan.
-Decorator `@validate` kemudian akan memvalidasi semua argumen yang ada, sebelum method-nya dijalankan.
+_Decorator_ `@required` menambahkan entri metadata yang menandakan bahwa parameter tersebut diperlukan.
+_Decorator_ `@validate` kemudian akan memvalidasi semua argumen yang ada, sebelum _method_-nya dijalankan.
 
 > CATATAN&emsp; Contoh ini memerlukan pustaka `reflect-metadata`
 > Lihat [Metadata](#metadata) untuk informasi lebih lanjut mengenai pustaka `reflect-metadata`.
 
-## Metadata
+## _Metadata_
 
-Beberapa contoh menggunakan pustaka `reflect-metadata` yang menambahkan polyfill untuk [API metadata eksperimental](https://github.com/rbuckton/ReflectDecorators).
+Beberapa contoh menggunakan pustaka `reflect-metadata` yang menambahkan _polyfill_ untuk [API metadata eksperimental](https://github.com/rbuckton/ReflectDecorators).
 Pustaka ini belum menjadi bagian dari standar ECMAScript (JavaScript).
 Namun, ketika decorator secara resmi diadopsi sebagai bagian dari standar ECMAScript, ekstensi ini akan diusulkan untuk diadopsi.
 
@@ -472,10 +470,10 @@ Anda dapat memasang pustaka ini melalui npm:
 npm i reflect-metadata --save
 ```
 
-TypeScript menyertakan dukungan eksperimental untuk menghadirkan jenis metadata tertentu untuk deklarasi yang memiliki decorator.
+TypeScript menyertakan dukungan eksperimental untuk menghadirkan jenis _metadata_ tertentu untuk deklarasi yang memiliki _decorator_.
 Untuk mengaktifkan dukungan eksperimental ini, Anda harus mengatur opsi kompilator `emitDecoratorMetadata` baik pada baris perintah atau di `tsconfig.json` Anda:
 
-**Command Line**:
+**_Command Line_**:
 
 ```shell
 tsc --target ES5 --experimentalDecorators --emitDecoratorMetadata
@@ -493,7 +491,7 @@ tsc --target ES5 --experimentalDecorators --emitDecoratorMetadata
 }
 ```
 
-Ketika diaktifkan, selama pustaka `reflect-metadata` di-import, informasi jenis design-time tambahan akan diekspos saat runtime.
+Ketika diaktifkan, selama pustaka `reflect-metadata` di-_import_, informasi jenis _design-time_ tambahan akan diekspos saat _runtime_.
 
 Kita dapat melihat action pada contoh berikut:
 
@@ -542,7 +540,7 @@ function validate<T>(
 }
 ```
 
-Kompilator TypeScript akan memasukkan informasi jenis design-time menggunakan decorator `@Reflect.metadata`.
+Kompilator TypeScript akan memasukkan informasi jenis _design-time_ menggunakan _decorator_ `@Reflect.metadata`.
 Anda dapat menganggapnya setara dengan TypeScript berikut:
 
 ```ts
@@ -570,4 +568,4 @@ class Line {
 }
 ```
 
-> CATATAN&emsp; Decorator metadata adalah fitur experimental dan mungkin dapat menyebabkan gangguan pada rilis di masa mendatang.
+> CATATAN&emsp; _Decorator_ metadata adalah fitur _experimental_ dan mungkin dapat menyebabkan gangguan pada rilis di masa mendatang.

--- a/packages/documentation/copy/id/reference/Decorators.md
+++ b/packages/documentation/copy/id/reference/Decorators.md
@@ -24,7 +24,7 @@ tsc --target ES5 --experimentalDecorators
 
 **tsconfig.json**:
 
-```json  tsconfig
+```json tsconfig
 {
   "compilerOptions": {
     "target": "ES5",
@@ -255,7 +255,7 @@ function enumerable(value: boolean) {
 ```
 
 Decorator `@enumerable(false)` disini adalah sebuah [decorator factory](#decorator-factories).
-Ketika decorator `@enumerable(false)` dipanggil, ia akan merubah `enumerable` property dari property descriptor.
+Ketika decorator `@enumerable(false)` dipanggil, ia akan merubah `enumerable` properti dari properti descriptor.
 
 ## Decorator Aksesor
 
@@ -321,16 +321,16 @@ function configurable(value: boolean) {
 Sebuah _Property Decorator_ dideklarasikan tepat sebelum deklarasi properti.
 _Property Decorator_ tidak dapat digunakan dalam deklarasi file, atau dalam konteks ambien lainnya (seperti dalam kelas `declare`).
 
-Ekspresi untuk property decorator akan dipanggil sebagai fungsi pada waktu proses, dengan dua argumen berikut:
+Ekspresi untuk properti decorator akan dipanggil sebagai fungsi pada waktu proses, dengan dua argumen berikut:
 
 1. Dapat berupa fungsi konstruktor kelas untuk anggota statis, atau prototipe kelas untuk anggota instance.
 2. Nama anggota.
 
-> CATATAN&emsp; _Property Descriptior_ tidak menyediakan sebuah argumen untuk property decorator karena bergantung tentang bagaimana property decorator diinisialisasi pada TypeScript.
-> Ini karena, saat ini tidak ada mekanisme untuk mendeskripsikan sebuah instance property ketika mendefinisikan anggota dari sebuah prototipe, dan tidak ada cara untuk mengamati atau memodifikasi initializer untuk property. Dan nilai kembalian juga akan dibiarkan.
-> Sehingga, sebuah property decorator hanya bisa digunakan untuk mengamati property dengan nama yang spesifik, yang telah dideklarasikan pada sebuah kelas.
+> CATATAN&emsp; _Property Descriptior_ tidak menyediakan sebuah argumen untuk properti decorator karena bergantung tentang bagaimana properti decorator diinisialisasi pada TypeScript.
+> Ini karena, saat ini tidak ada mekanisme untuk mendeskripsikan sebuah instance properti ketika mendefinisikan anggota dari sebuah prototipe, dan tidak ada cara untuk mengamati atau memodifikasi initializer untuk properti. Dan nilai kembalian juga akan dibiarkan.
+> Sehingga, sebuah properti decorator hanya bisa digunakan untuk mengamati properti dengan nama yang spesifik, yang telah dideklarasikan pada sebuah kelas.
 
-Kita dapat menggunakan informasi tersebut untuk memantau property metadata, seperti pada contoh berikut:
+Kita dapat menggunakan informasi tersebut untuk memantau properti metadata, seperti pada contoh berikut:
 
 ```ts
 class Greeter {
@@ -364,7 +364,7 @@ function getFormat(target: any, propertyKey: string) {
 ```
 
 Decorator `@format("Hello, %s")` disini adalah sebuah [decorator factory](#decorator-factories).
-Ketika `@format("Hello, %s")` dipanggil, ia akan menambahkan property metadata menggunakan fungsi `Reflect.metadata` dari pustaka `reflect-metadata`.
+Ketika `@format("Hello, %s")` dipanggil, ia akan menambahkan properti metadata menggunakan fungsi `Reflect.metadata` dari pustaka `reflect-metadata`.
 Ketika `getFormat` dipanggil, ia akan membaca format dari nilai metadata-nya.
 
 > CATATAN&emsp; Contoh ini membutuhkan pustaka `reflect-metadata`.
@@ -473,7 +473,7 @@ npm i reflect-metadata --save
 ```
 
 TypeScript menyertakan dukungan eksperimental untuk menghadirkan jenis metadata tertentu untuk deklarasi yang memiliki decorator.
-Untuk mengaktifkan dukungan eksperimental ini, Anda harus mengatur opsi compiler `emitDecoratorMetadata` baik pada baris perintah atau di `tsconfig.json` Anda:
+Untuk mengaktifkan dukungan eksperimental ini, Anda harus mengatur opsi kompilator `emitDecoratorMetadata` baik pada baris perintah atau di `tsconfig.json` Anda:
 
 **Command Line**:
 
@@ -542,7 +542,7 @@ function validate<T>(
 }
 ```
 
-Compiler TypeScript akan memasukkan informasi jenis design-time menggunakan decorator `@Reflect.metadata`.
+Kompilator TypeScript akan memasukkan informasi jenis design-time menggunakan decorator `@Reflect.metadata`.
 Anda dapat menganggapnya setara dengan TypeScript berikut:
 
 ```ts

--- a/packages/documentation/copy/id/reference/Iterators and Generators.md
+++ b/packages/documentation/copy/id/reference/Iterators and Generators.md
@@ -1,5 +1,5 @@
 ---
-title: Iterators and Generators
+title: Iterators dan Generators
 layout: docs
 permalink: /id/docs/handbook/iterators-and-generators.html
 oneline: Bagaimana Iterator dan Generator bekerja di TypeScript
@@ -9,7 +9,7 @@ translatable: true
 ## Iterasi
 
 Sebuah objek dapat dilakukan perulangan jika memiliki poperty [`Symbol.iterator`](Symbols.html#symboliterator).
-Beberapa type bawaan seperti `Array`, `Map`, `Set`, `String`, `Int32Array`, `Uint32Array`, etc. sudah memiliki property `Symbol.iterator`.
+Beberapa tipe bawaan seperti `Array`, `Map`, `Set`, `String`, `Int32Array`, `Uint32Array`, etc. sudah memiliki properti `Symbol.iterator`.
 Fungsi `Symbol.iterator` pada sebuah objek, bertanggungjawab untuk mengembalikan list nilai-nilai untuk menjalankan iterasi.
 
 ## Pernyataan `for..of`
@@ -27,7 +27,7 @@ for (let entry of someArray) {
 
 ### Pernyataan `for..of` vs `for..in`
 
-Baik pernyataan `for..of` dan `for..in` akan mengiterasi list; yang membedakan antara keduanya adalah `for..in` akan mengembalikan daftar _keys_ dari objek tersebut, sedangkan `for..of` mengembalikan daftar _values_ property numeric dari objek yang diiterasi.
+Baik pernyataan `for..of` dan `for..in` akan mengiterasi list; yang membedakan antara keduanya adalah `for..in` akan mengembalikan daftar _keys_ dari objek tersebut, sedangkan `for..of` mengembalikan daftar _values_ properti numeric dari objek yang diiterasi.
 
 Berikut adalah contoh implementasi dari perbedaan keduanya:
 
@@ -64,9 +64,9 @@ for (let pet of pets) {
 #### Menargetkan ES5 dan ES3
 
 Ketika menargetkan ke engine ES5 atau ES3, iterator hanya membolehkan nilai bertipe `Array`.
-Akan terjadi error jika `for..of` melakukan perulangan pada nilai yang bukan Array, bahkan jika nilai non Array tersebut memiliki property `Symbol.iterator`.
+Akan terjadi galat jika `for..of` melakukan perulangan pada nilai yang bukan Array, bahkan jika nilai non Array tersebut memiliki properti `Symbol.iterator`.
 
-Compiler akan menghasilkan perulangan `for` sederhana untuk `for..of`, misalnya:
+Kompilator akan menghasilkan perulangan `for` sederhana untuk `for..of`, misalnya:
 
 ```ts
 let numbers = [1, 2, 3];
@@ -87,4 +87,4 @@ for (var _i = 0; _i < numbers.length; _i++) {
 
 #### Menargetkan ECMAScript 2015 dan yang lebih tinggi
 
-Ketika menargetkan ke engine ECMAScript 2015, compiler akan membuat perulangan `for..of` untuk menargetkan implementasi iterator bawaan di mesin.
+Ketika menargetkan ke engine ECMAScript 2015, kompilator akan membuat perulangan `for..of` untuk menargetkan implementasi iterator bawaan di mesin.

--- a/packages/documentation/copy/id/reference/Iterators and Generators.md
+++ b/packages/documentation/copy/id/reference/Iterators and Generators.md
@@ -8,14 +8,14 @@ translatable: true
 
 ## Iterasi
 
-Sebuah objek dapat dilakukan perulangan jika memiliki poperty [`Symbol.iterator`](Symbols.html#symboliterator).
+Sebuah objek dapat dilakukan perulangan jika memiliki properti [`Symbol.iterator`](Symbols.html#symboliterator).
 Beberapa tipe bawaan seperti `Array`, `Map`, `Set`, `String`, `Int32Array`, `Uint32Array`, etc. sudah memiliki properti `Symbol.iterator`.
-Fungsi `Symbol.iterator` pada sebuah objek, bertanggungjawab untuk mengembalikan list nilai-nilai untuk menjalankan iterasi.
+Fungsi `Symbol.iterator` pada sebuah objek, bertanggungjawab untuk mengembalikan _list_ nilai-nilai untuk menjalankan iterasi.
 
 ## Pernyataan `for..of`
 
 `for..of` mengulang objek yang dapat diulang dengan cara memanggil properti `Symbol.iterator` pada objek tersebut.
-Berikut ini loop `for..of` sederhana pada sebuah array:
+Berikut ini _loop_ `for..of` sederhana pada sebuah _array_:
 
 ```ts
 let someArray = [1, "string", false];
@@ -27,7 +27,7 @@ for (let entry of someArray) {
 
 ### Pernyataan `for..of` vs `for..in`
 
-Baik pernyataan `for..of` dan `for..in` akan mengiterasi list; yang membedakan antara keduanya adalah `for..in` akan mengembalikan daftar _keys_ dari objek tersebut, sedangkan `for..of` mengembalikan daftar _values_ properti numeric dari objek yang diiterasi.
+Baik pernyataan `for..of` dan `for..in` akan mengiterasi _list_; yang membedakan antara keduanya adalah `for..in` akan mengembalikan daftar _keys_ dari objek tersebut, sedangkan `for..of` mengembalikan daftar _values_ properti numeric dari objek yang diiterasi.
 
 Berikut adalah contoh implementasi dari perbedaan keduanya:
 
@@ -63,8 +63,8 @@ for (let pet of pets) {
 
 #### Menargetkan ES5 dan ES3
 
-Ketika menargetkan ke engine ES5 atau ES3, iterator hanya membolehkan nilai bertipe `Array`.
-Akan terjadi galat jika `for..of` melakukan perulangan pada nilai yang bukan Array, bahkan jika nilai non Array tersebut memiliki properti `Symbol.iterator`.
+Ketika menargetkan ke engine ES5 atau ES3, _iterator_ hanya membolehkan nilai bertipe `Array`.
+Akan terjadi galat jika `for..of` melakukan perulangan pada nilai yang bukan Array, bahkan jika nilai non _Array_ tersebut memiliki properti `Symbol.iterator`.
 
 Kompilator akan menghasilkan perulangan `for` sederhana untuk `for..of`, misalnya:
 
@@ -87,4 +87,4 @@ for (var _i = 0; _i < numbers.length; _i++) {
 
 #### Menargetkan ECMAScript 2015 dan yang lebih tinggi
 
-Ketika menargetkan ke engine ECMAScript 2015, kompilator akan membuat perulangan `for..of` untuk menargetkan implementasi iterator bawaan di mesin.
+Ketika menargetkan ke _engine_ ECMAScript 2015, kompilator akan membuat perulangan `for..of` untuk menargetkan implementasi _iterator_ bawaan di mesin.

--- a/packages/documentation/copy/id/reference/Iterators and Generators.md
+++ b/packages/documentation/copy/id/reference/Iterators and Generators.md
@@ -1,0 +1,90 @@
+---
+title: Iterators and Generators
+layout: docs
+permalink: /id/docs/handbook/iterators-and-generators.html
+oneline: Bagaimana Iterator dan Generator bekerja di TypeScript
+translatable: true
+---
+
+## Iterasi
+
+Sebuah objek dapat dilakukan perulangan jika memiliki poperty [`Symbol.iterator`](Symbols.html#symboliterator).
+Beberapa type bawaan seperti `Array`, `Map`, `Set`, `String`, `Int32Array`, `Uint32Array`, etc. sudah memiliki property `Symbol.iterator`.
+Fungsi `Symbol.iterator` pada sebuah objek, bertanggungjawab untuk mengembalikan list nilai-nilai untuk menjalankan iterasi.
+
+## Pernyataan `for..of`
+
+`for..of` mengulang objek yang dapat diulang dengan cara memanggil properti `Symbol.iterator` pada objek tersebut.
+Berikut ini loop `for..of` sederhana pada sebuah array:
+
+```ts
+let someArray = [1, "string", false];
+
+for (let entry of someArray) {
+  console.log(entry); // 1, "string", false
+}
+```
+
+### Pernyataan `for..of` vs `for..in`
+
+Baik pernyataan `for..of` dan `for..in` akan mengiterasi list; yang membedakan antara keduanya adalah `for..in` akan mengembalikan daftar _keys_ dari objek tersebut, sedangkan `for..of` mengembalikan daftar _values_ property numeric dari objek yang diiterasi.
+
+Berikut adalah contoh implementasi dari perbedaan keduanya:
+
+```ts
+let list = [4, 5, 6];
+
+for (let i in list) {
+  console.log(i); // "0", "1", "2",
+}
+
+for (let i of list) {
+  console.log(i); // "4", "5", "6"
+}
+```
+
+Perbedaan lainnya adalah `for..in` bekerja pada objek apapun; ini berfungsi sebagai cara untuk memeriksa properti pada objek tersebut.
+Di sisi lain, `for..of` tertarik pada nilai dari objek yang dapat diulang. Objek bawaan seperti `Map` dan`Set` mengimplementasikan properti `Symbol.iterator` yang memungkinkan akses ke nilai yang disimpan.
+
+```ts
+let pets = new Set(["Cat", "Dog", "Hamster"]);
+pets["species"] = "mammals";
+
+for (let pet in pets) {
+  console.log(pet); // "species"
+}
+
+for (let pet of pets) {
+  console.log(pet); // "Cat", "Dog", "Hamster"
+}
+```
+
+### Pembuatan kode
+
+#### Menargetkan ES5 dan ES3
+
+Ketika menargetkan ke engine ES5 atau ES3, iterator hanya membolehkan nilai bertipe `Array`.
+Akan terjadi error jika `for..of` melakukan perulangan pada nilai yang bukan Array, bahkan jika nilai non Array tersebut memiliki property `Symbol.iterator`.
+
+Compiler akan menghasilkan perulangan `for` sederhana untuk `for..of`, misalnya:
+
+```ts
+let numbers = [1, 2, 3];
+for (let num of numbers) {
+  console.log(num);
+}
+```
+
+akan menghasilkan:
+
+```js
+var numbers = [1, 2, 3];
+for (var _i = 0; _i < numbers.length; _i++) {
+  var num = numbers[_i];
+  console.log(num);
+}
+```
+
+#### Menargetkan ECMAScript 2015 dan yang lebih tinggi
+
+Ketika menargetkan ke engine ECMAScript 2015, compiler akan membuat perulangan `for..of` untuk menargetkan implementasi iterator bawaan di mesin.

--- a/packages/documentation/copy/id/reference/JSX.md
+++ b/packages/documentation/copy/id/reference/JSX.md
@@ -9,17 +9,17 @@ translatable: true
 [JSX](https://facebook.github.io/jsx/) adalah sebuah sintaks tertanam, yang seperti XML.
 Ini dimaksudkan untuk diubah menjadi JavaScript yang valid, meskipun semantik dari transformasi itu khusus untuk implementasi.
 JSX menjadi populer dengan kerangka kerja [React](https://reactjs.org/), tetapi sejak itu juga melihat implementasi lain.
-TypeScript mendukung embeding, pemeriksaan type, dan mengkompilasi JSX secara langsung ke JavaScript.
+TypeScript mendukung embeding, pemeriksaan tipe, dan mengkompilasi JSX secara langsung ke JavaScript.
 
 ## Dasar Penggunaan
 
-Untuk menggunakan JSX, anda harus melakukan dua hal berikut:
+Untuk menggunakan JSX, Anda harus melakukan dua hal berikut:
 
 1. Penamaan file dengan ekstensi `.tsx`
 2. Mengaktifkan opsi `jsx`
 
 TypeScript memiliki tiga jenis mode JSX: `preserve`, `react`, dan `react-native`.
-Mode tersebut hanya berlaku untuk stage, sedangkan untuk pemeriksaan type, hal itu tidak berlaku.
+Mode tersebut hanya berlaku untuk stage, sedangkan untuk pemeriksaan tipe, hal itu tidak berlaku.
 Mode `preserve` akan mempertahankan JSX sebagai bagian dari output untuk selanjutnya digunakan oleh langkah transformasi lain (mis. [Babel](https://babeljs.io/)).
 Selain itu, output-nya akan memiliki ekstensi file `.jsx`.
 Mode `react` akan mengeluarkan`React.createElement`, tidak perlu melalui transformasi JSX sebelum digunakan, dan outputnya akan memiliki ekstensi file `.js`.
@@ -33,31 +33,31 @@ Mode `react-native` sama dengan `pertahankan` yang mempertahankan semua JSX, tet
 
 Anda dapat menetapkan mode ini menggunakan flag baris perintah `--jsx` atau opsi yang sesuai di file [tsconfig.json](/docs/handbook/tsconfig-json.html) Anda.
 
-> \*Catatan: Anda dapat menentukan fungsi factory JSX yang akan digunakan saat menargetkan react JSX emit dengan opsi `--jsxFactory` (default ke `React.createElement`)
+> \*Catatan: Anda dapat menentukan fungsi factory JSX yang akan digunakan saat menargetkan react JSX emit dengan opsi `--jsxFactory` (nilai bawaan ke `React.createElement`)
 
 ## Opeartor `as`
 
-Ingat bagaimana menulis penegasan type:
+Ingat bagaimana menulis penegasan tipe:
 
 ```ts
 var foo = <foo>bar;
 ```
 
-Ini menegaskan variabel `bar` memiliki type `foo`.
-Sejak TypeScript juga menggunakan kurung siku untuk penegasan type, mengkombinasikannya dengan sintaks JSX akan menimbulkan kesulitan tertentu. Hasilnya, TypeScript tidak membolehkan penggunaan kurung siku untuk penegasan type pada file `.tsx`.
+Ini menegaskan variabel `bar` memiliki tipe `foo`.
+Sejak TypeScript juga menggunakan kurung siku untuk penegasan tipe, mengkombinasikannya dengan sintaks JSX akan menimbulkan kesulitan tertentu. Hasilnya, TypeScript tidak membolehkan penggunaan kurung siku untuk penegasan tipe pada file `.tsx`.
 
-Karena sintaks diatas tidak bisa digunakan pada file `.tsx`, maka alternatif untuk penegasan type dapat menggunakan operator `as`.
+Karena sintaks diatas tidak bisa digunakan pada file `.tsx`, maka alternatif untuk penegasan tipe dapat menggunakan operator `as`.
 Contohnya dapat dengan mudah ditulis ulang dengan operator `as`.
 
 ```ts
 var foo = bar as foo;
 ```
 
-Operator `as` tersedia dikedua jenis file, `.ts` dan `.tsx`, dan memiliki perlakuan yang sama seperti penegasan type menggunakan kurung siku.
+Operator `as` tersedia dikedua jenis file, `.ts` dan `.tsx`, dan memiliki perlakuan yang sama seperti penegasan tipe menggunakan kurung siku.
 
-## Pemeriksaan Type
+## Pemeriksaan Tipe
 
-Urutan yang harus dimengerti mengenai pemeriksaan type di JSX, yaitu pertama anda harus memahami perbedaan antara elemen intrinsik dan elemen berbasiskan nilai. Terdapat sebuah ekspresi `<expr />` dan `expr` yang mungkin mengacu pada suatu hal yang intrinsik pada suatu lingkungan (misalnya `div` atau `span` dalam lingkungan DOM) atau pada komponen custom yang telah Anda buat.
+Urutan yang harus dimengerti mengenai pemeriksaan tipe di JSX, yaitu pertama Anda harus memahami perbedaan antara elemen intrinsik dan elemen berbasiskan nilai. Terdapat sebuah ekspresi `<expr />` dan `expr` yang mungkin mengacu pada suatu hal yang intrinsik pada suatu lingkungan (misalnya `div` atau `span` dalam lingkungan DOM) atau pada komponen custom yang telah Anda buat.
 Ini penting karena dua alasan berikut:
 
 1. Untuk React, elemen intrinsik dianggap sebagai string (`React.createElement("div")`), sedangkan komponen yang Anda buat bukan (`React.createElement(MyComponent)`).
@@ -70,8 +70,8 @@ Elemen intrinsik selalu dimulai dengan huruf kecil, dan elemen berbasiskan nilai
 ## Elemen intrinsik
 
 Elemen intrinsik dicari pada interface khusus, yaitu `JSX.IntrinsicElements`.
-Standarnya, jika interface ini tidak ditentukan, maka apapun yang terjadi dan elemen intrinsik tidak akan diperiksa type-nya.
-Namun, jika interface ini ada, maka nama elemen intrinsik akan dicari sebagai property di interface `JSX.IntrinsicElements`.
+Standarnya, jika interface ini tidak ditentukan, maka apapun yang terjadi dan elemen intrinsik tidak akan diperiksa tipenya.
+Namun, jika interface ini ada, maka nama elemen intrinsik akan dicari sebagai properti di interface `JSX.IntrinsicElements`.
 Contohnya:
 
 ```ts
@@ -82,10 +82,10 @@ declare namespace JSX {
 }
 
 <foo />; // ok
-<bar />; // error
+<bar />; // galat
 ```
 
-Pada contoh diatas, `<foo />` akan berjalan dengan baik, tapi `<bar />` akan menghasilkan error, karena `<bar />` tidak ditentukan pada interface `JSX.IntrinsicElements`.
+Pada contoh diatas, `<foo />` akan berjalan dengan baik, tapi `<bar />` akan menghasilkan galat, karena `<bar />` tidak ditentukan pada interface `JSX.IntrinsicElements`.
 
 > Catatan: Anda juga bisa menentukan indexer untuk mendapatkan seluruh elemen bertipe string didalam `JSX.IntrinsicElements`, seperti berikut:
 
@@ -105,7 +105,7 @@ Elemen berbasiskan nilai akan dicari oleh identifier yang ada pada sebuah scope.
 import MyComponent from "./myComponent";
 
 <MyComponent />; // ok
-<SomeOtherComponent />; // error
+<SomeOtherComponent />; // galat
 ```
 
 Terdapat dua cara untuk mendefinisikan sebuah elemen berbasiskan nilai, yaitu:
@@ -118,7 +118,7 @@ Karena kedua jenis elemen berbasis nilai ini tidak dapat dibedakan satu sama lai
 ### Function Component
 
 Seperti namanya, komponen ini didefinisikan menggunakan fungsi JavaScript dimana argumen pertamanya adalah sebuah `props` objek.
-TS memberlakukan bahwa type kembaliannya harus dapat diberikan ke `JSX.Element`.
+TS memberlakukan bahwa tipe kembaliannya harus dapat diberikan ke `JSX.Element`.
 
 ```ts
 interface FooProp {
@@ -160,14 +160,14 @@ function MainButton(prop: SideProps): JSX.Element {
 
 ### Class Component
 
-Ini memungkinkan untuk mendefinisikan type dari class component.
+Ini memungkinkan untuk mendefinisikan tipe dari class component.
 Namun, untuk melakukannya, yang terbaik adalah memahami dua istilah baru berikut: _type class elemen_ dan _type instance elemen_.
 
 Jika terdapat `<Expr />`, maka _type class elemennya_ adalah `Expr`.
-Jadi pada contoh diatas, jika `MyComponent` adalah class ES6, maka type class-nya adalah konstruktor dan static dari class tersebut.
-Jika `MyComponent` adalah factory function, maka type class-nya adalah fungsi itu sendiri.
+Jadi pada contoh diatas, jika `MyComponent` adalah class ES6, maka tipe class-nya adalah konstruktor dan static dari class tersebut.
+Jika `MyComponent` adalah factory function, maka tipe class-nya adalah fungsi itu sendiri.
 
-Setelah type class dibuat, type instance ditentukan oleh gabungan tipe kembalian dari konstruksi type class atau call signature (mana saja yang ada).
+Setelah tipe class dibuat, tipe instance ditentukan oleh gabungan tipe kembalian dari konstruksi tipe class atau call signature (mana saja yang ada).
 Jadi sekali lagi, dalam kasus kelas ES6, jenis instans adalah jenis instans kelas itu, dan dalam kasus factory function, itu akan menjadi jenis nilai yang dikembalikan dari fungsi tersebut.
 
 ```ts
@@ -178,8 +178,8 @@ class MyComponent {
 // menggunakan konstruksi signature
 var myComponent = new MyComponent();
 
-// type class elemen => MyComponent
-// type instance elemen => { render: () => void }
+// tipe class elemen => MyComponent
+// tipe instance elemen => { render: () => void }
 
 function MyFactoryFunction() {
   return {
@@ -190,11 +190,11 @@ function MyFactoryFunction() {
 // menggunakan call signature
 var myComponent = MyFactoryFunction();
 
-// type class elemen => FactoryFunction
-// type instance elemen => { render: () => void }
+// tipe class elemen => FactoryFunction
+// tipe instance elemen => { render: () => void }
 ```
 
-Type elemen instance itu menarik, karena ini harus dapat di-assign ke `JSX.ElementClass` atau hasilnya akan error.
+Tipe elemen instance itu menarik, karena ini harus dapat di-assign ke `JSX.ElementClass` atau hasilnya akan galat.
 Standarnya `JSX.ElementClass` adalah `{}`, tetapi ini bisa ditambah untuk membatasi penggunaan JSX hanya untuk jenis yang sesuai dengan interface yang tepat.
 
 ```ts
@@ -219,16 +219,16 @@ function NotAValidFactoryFunction() {
   return {};
 }
 
-<NotAValidComponent />; // error
-<NotAValidFactoryFunction />; // error
+<NotAValidComponent />; // galat
+<NotAValidFactoryFunction />; // galat
 ```
 
-## Pemeriksaan Type Atribut
+## Pemeriksaan Tipe Atribut
 
-Langkah pertama untuk memeriksa type atribut adalah menentukan type atribut elemen.
+Langkah pertama untuk memeriksa tipe atribut adalah menentukan tipe atribut elemen.
 Ini sedikit berbeda antara elemen intrinsik dan berbasis nilai.
 
-Untuk elemen intrinsik, ini adalah type dari property pada `JSX.IntrinsicElements`
+Untuk elemen intrinsik, ini adalah tipe dari properti pada `JSX.IntrinsicElements`
 
 ```ts
 declare namespace JSX {
@@ -237,32 +237,32 @@ declare namespace JSX {
   }
 }
 
-// type atribut elemen untuk 'foo' is '{bar?: boolean}'
+// tipe atribut elemen untuk 'foo' is '{bar?: boolean}'
 <foo bar />;
 ```
 
 Untuk elemen berbasis nilai, ini sedikit lebih kompleks.
-Ini ditentukan oleh type dari property pada _type elemen instance_ yang telah ditentukan.
+Ini ditentukan oleh tipe dari properti pada _type elemen instance_ yang telah ditentukan.
 Property mana yang digunakan untuk ditentukan oleh `JSX.ElementAttributesProperty`.
-Ini harus dideklarasikan dengan satu property.
-Nama property itu kemudian digunakan.
+Ini harus dideklarasikan dengan satu properti.
+Nama properti itu kemudian digunakan.
 Mulai TypeScript 2.8, jika `JSX.ElementAttributesProperty` tidak disediakan, jenis parameter pertama dari konstruktor elemen kelas atau pemanggilan Function Component akan digunakan sebagai gantinya.
 
 ```ts
 declare namespace JSX {
   interface ElementAttributesProperty {
-    props; // menentukan nama property yang akan digunakan
+    props; // menentukan nama properti yang akan digunakan
   }
 }
 
 class MyComponent {
-  // menentukan property pada type instance elemen
+  // menentukan properti pada tipe instance elemen
   props: {
     foo?: string;
   };
 }
 
-// type atribut elemen untuk 'MyComponent' adalah '{foo?: string}'
+// tipe atribut elemen untuk 'MyComponent' adalah '{foo?: string}'
 <MyComponent foo="bar" />;
 ```
 
@@ -278,15 +278,15 @@ declare namespace JSX {
 
 <foo requiredProp="bar" />; // ok
 <foo requiredProp="bar" optionalProp={0} />; // ok
-<foo />; // error, tidak ada requiredProp
-<foo requiredProp={0} />; // error, requiredProp seharusnya ber-type string
-<foo requiredProp="bar" unknownProp />; // error, unknownProp tidak ada
+<foo />; // galat, tidak ada requiredProp
+<foo requiredProp={0} />; // galat, requiredProp seharusnya bertipe string
+<foo requiredProp="bar" unknownProp />; // galat, unknownProp tidak ada
 <foo requiredProp="bar" some-unknown-prop />; // ok, karena 'some-unknown-prop' bukan identifier yang valid
 ```
 
-> Catatan: Jika nama atribut bukan identifier JS yang valid (seperti atribut `data- *`), itu tidak dianggap sebagai kesalahan jika tidak ditemukan dalam type atribut elemen.
+> Catatan: Jika nama atribut bukan identifier JS yang valid (seperti atribut `data- *`), itu tidak dianggap sebagai kesalahan jika tidak ditemukan dalam tipe atribut elemen.
 
-Selain itu, antarmuka `JSX.IntrinsicAttributes` dapat digunakan untuk menentukan properti tambahan yang digunakan oleh framework JSX yang umumnya tidak digunakan oleh props atau argumen komponen - misalnya `key` di React. Mengkhususkan lebih lanjut, type generik `JSX.IntrinsicClassAttributes<T>` juga dapat digunakan untuk menetapkan type atribut tambahan yang sama hanya untuk class component (dan bukan function component). Dalam type ini, parameter generik sesuai dengan type instance class. Di React, ini digunakan untuk mengizinkan atribut `ref` dengan type `Ref <T>`. Secara umum, semua properti pada interface ini harus bersifat opsional, kecuali Anda bermaksud agar pengguna framework JSX Anda perlu menyediakan beberapa atribut pada setiap tag.
+Selain itu, antarmuka `JSX.IntrinsicAttributes` dapat digunakan untuk menentukan properti tambahan yang digunakan oleh framework JSX yang umumnya tidak digunakan oleh props atau argumen komponen - misalnya `key` di React. Mengkhususkan lebih lanjut, tipe generik `JSX.IntrinsicClassAttributes<T>` juga dapat digunakan untuk menetapkan tipe atribut tambahan yang sama hanya untuk class component (dan bukan function component). Dalam tipe ini, parameter generik sesuai dengan tipe instance class. Di React, ini digunakan untuk mengizinkan atribut `ref` dengan tipe `Ref <T>`. Secara umum, semua properti pada interface ini harus bersifat opsional, kecuali Anda bermaksud agar pengguna framework JSX Anda perlu menyediakan beberapa atribut pada setiap tag.
 
 Spread operator juga bekerja:
 
@@ -295,14 +295,14 @@ var props = { requiredProp: "bar" };
 <foo {...props} />; // ok
 
 var badProps = {};
-<foo {...badProps} />; // error
+<foo {...badProps} />; // galat
 ```
 
 ## Pemeriksaan Type Children
 
-Di TypeScript 2.3, TS mengenalkan pemeriksaan type pada _children_. _Children_ adalah property khusus di _type atribut elemen_ dimana child _JSXExpression_ diambil untuk dimasukkan ke atribut.
+Di TypeScript 2.3, TS mengenalkan pemeriksaan tipe pada _children_. _Children_ adalah properti khusus di _type atribut elemen_ dimana child _JSXExpression_ diambil untuk dimasukkan ke atribut.
 Mirip dengan bagaimana menggunakan `JSX.ElementAttributesProperty` untuk menentukan nama dari _props_, TS menggunakan `JSX`.
-`JSX.ElementChildrenAttribute` harus dideklarasikan dengan property tunggal.
+`JSX.ElementChildrenAttribute` harus dideklarasikan dengan properti tunggal.
 
 ```ts
 declare namespace JSX {
@@ -329,7 +329,7 @@ const CustomComp = (props) => <div>{props.children}</div>
 </CustomComp>
 ```
 
-Anda bisa menentukan type dari _children_ seperti atribut lainnya. Ini akan mengganti type standarnya, misalnya [React typings](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react) jika Anda menggunakannya.
+Anda bisa menentukan tipe dari _children_ seperti atribut lainnya. Ini akan mengganti tipe standarnya, misalnya [React typings](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react) jika Anda menggunakannya.
 
 ```ts
 interface PropsType {
@@ -352,13 +352,13 @@ class Component extends React.Component<PropsType, {}> {
   <h1>Hello World</h1>
 </Component>
 
-// Error: children adalah type JSX.Element, bukan array dari JSX.Element.
+// Error: children adalah tipe JSX.Element, bukan array dari JSX.Element.
 <Component name="bar">
   <h1>Hello World</h1>
   <h2>Hello World</h2>
 </Component>
 
-// Error: children adalah type JSX.Element, bukan array dari JSX.Element maupun string.
+// Error: children adalah tipe JSX.Element, bukan array dari JSX.Element maupun string.
 <Component name="baz">
   <h1>Hello</h1>
   World
@@ -367,9 +367,9 @@ class Component extends React.Component<PropsType, {}> {
 
 ## Type hasil JSX
 
-Secara standar, hasil dari ekspresi JSX ber-type `any`.
-Anda bisa menyesuaikan type dengan menentukan interface `JSX.Element`.
-Namun, tidak mungkin untuk mengambil informasi type tentang elemen, atribut atau turunan dari JSX dari interface ini.
+Secara standar, hasil dari ekspresi JSX bertipe `any`.
+Anda bisa menyesuaikan tipe dengan menentukan interface `JSX.Element`.
+Namun, tidak mungkin untuk mengambil informasi tipe tentang elemen, atribut atau turunan dari JSX dari interface ini.
 Itu adalah black box.
 
 ## Menyematkan Ekspresi
@@ -401,7 +401,7 @@ var a = (
 
 ## Integrasi React
 
-Untuk menggunakan JSX dengan React, anda harus menggunakan [React typings](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react). Typings ini mendefinisikan namespace `JSX` dengan tepat untuk digunakan dengan React.
+Untuk menggunakan JSX dengan React, Anda harus menggunakan [React typings](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react). Typings ini mendefinisikan namespace `JSX` dengan tepat untuk digunakan dengan React.
 
 ```ts
 /// <reference path="react.d.ts" />
@@ -417,12 +417,12 @@ class MyComponent extends React.Component<Props, {}> {
 }
 
 <MyComponent foo="bar" />; // ok
-<MyComponent foo={0} />; // error
+<MyComponent foo={0} />; // galat
 ```
 
 ## Factory Function
 
-Factory function yang digunakan oleh opsi compiler `jsx: react` dapat dikonfigurasi. Ini dapat disetel menggunakan opsi baris perintah `jsxFactory`, atau komentar `@jsx` sebaris untuk menyetelnya pada basis per file. Misalnya, jika Anda menyetel `jsxFactory` ke `createElement`, `<div />` akan melakukannya sebagai `createElement("div")` bukan `React.createElement("div")`.
+Factory function yang digunakan oleh opsi kompilator `jsx: react` dapat dikonfigurasi. Ini dapat disetel menggunakan opsi baris perintah `jsxFactory`, atau komentar `@jsx` sebaris untuk menyetelnya pada basis per file. Misalnya, jika Anda menyetel `jsxFactory` ke `createElement`, `<div />` akan melakukannya sebagai `createElement("div")` bukan `React.createElement("div")`.
 
 Versi pragma komentar dapat digunakan seperti itu (dalam TypeScript 2.8):
 
@@ -439,4 +439,4 @@ const preact = require("preact");
 const x = preact.h("div", null);
 ```
 
-Factory yang dipilih juga akan mempengaruhi di mana namespace `JSX` dicari (untuk informasi pemeriksaan type) sebelum kembali ke global. Jika factory ditentukan sebagai `React.createElement` (standar), compiler akan memeriksa `React.JSX` sebelum memeriksa `JSX` global. Jika factory ditentukan sebagai `h`, maka ia akan memeriksa `h.JSX` sebelum `JSX` global.
+Factory yang dipilih juga akan mempengaruhi di mana namespace `JSX` dicari (untuk informasi pemeriksaan tipe) sebelum kembali ke global. Jika factory ditentukan sebagai `React.createElement` (standar), kompilator akan memeriksa `React.JSX` sebelum memeriksa `JSX` global. Jika factory ditentukan sebagai `h`, maka ia akan memeriksa `h.JSX` sebelum `JSX` global.

--- a/packages/documentation/copy/id/reference/JSX.md
+++ b/packages/documentation/copy/id/reference/JSX.md
@@ -7,33 +7,33 @@ translatable: true
 ---
 
 [JSX](https://facebook.github.io/jsx/) adalah sebuah sintaks tertanam, yang seperti XML.
-Ini dimaksudkan untuk diubah menjadi JavaScript yang valid, meskipun semantik dari transformasi itu khusus untuk implementasi.
+Ini dimaksudkan untuk diubah menjadi JavaScript yang _valid_, meskipun semantik dari transformasi itu khusus untuk implementasi.
 JSX menjadi populer dengan kerangka kerja [React](https://reactjs.org/), tetapi sejak itu juga melihat implementasi lain.
-TypeScript mendukung embeding, pemeriksaan tipe, dan mengkompilasi JSX secara langsung ke JavaScript.
+TypeScript mendukung _embeding_, pemeriksaan tipe, dan mengkompilasi JSX secara langsung ke JavaScript.
 
 ## Dasar Penggunaan
 
 Untuk menggunakan JSX, Anda harus melakukan dua hal berikut:
 
-1. Penamaan file dengan ekstensi `.tsx`
+1. Penamaan berkas dengan ekstensi `.tsx`
 2. Mengaktifkan opsi `jsx`
 
 TypeScript memiliki tiga jenis mode JSX: `preserve`, `react`, dan `react-native`.
-Mode tersebut hanya berlaku untuk stage, sedangkan untuk pemeriksaan tipe, hal itu tidak berlaku.
-Mode `preserve` akan mempertahankan JSX sebagai bagian dari output untuk selanjutnya digunakan oleh langkah transformasi lain (mis. [Babel](https://babeljs.io/)).
-Selain itu, output-nya akan memiliki ekstensi file `.jsx`.
-Mode `react` akan mengeluarkan`React.createElement`, tidak perlu melalui transformasi JSX sebelum digunakan, dan outputnya akan memiliki ekstensi file `.js`.
-Mode `react-native` sama dengan `pertahankan` yang mempertahankan semua JSX, tetapi hasilnya justru akan memiliki ekstensi file `.js`.
+Mode tersebut hanya berlaku untuk _stage_, sedangkan untuk pemeriksaan tipe, hal itu tidak berlaku.
+Mode `preserve` akan mempertahankan JSX sebagai bagian dari _output_ untuk selanjutnya digunakan oleh langkah transformasi lain (mis. [Babel](https://babeljs.io/)).
+Selain itu, _output_-nya akan memiliki ekstensi berkas `.jsx`.
+Mode `react` akan mengeluarkan`React.createElement`, tidak perlu melalui transformasi JSX sebelum digunakan, dan outputnya akan memiliki ekstensi berkas `.js`.
+Mode `react-native` sama dengan `pertahankan` yang mempertahankan semua JSX, tetapi hasilnya justru akan memiliki ekstensi berkas `.js`.
 
-| Mode           | Input     | Output                       | Output File Extension |
-| -------------- | --------- | ---------------------------- | --------------------- |
-| `preserve`     | `<div />` | `<div />`                    | `.jsx`                |
-| `react`        | `<div />` | `React.createElement("div")` | `.js`                 |
-| `react-native` | `<div />` | `<div />`                    | `.js`                 |
+| Mode           | Input     | Output                       | Berkas Output Extension |
+| -------------- | --------- | ---------------------------- | ----------------------- |
+| `preserve`     | `<div />` | `<div />`                    | `.jsx`                  |
+| `react`        | `<div />` | `React.createElement("div")` | `.js`                   |
+| `react-native` | `<div />` | `<div />`                    | `.js`                   |
 
-Anda dapat menetapkan mode ini menggunakan flag baris perintah `--jsx` atau opsi yang sesuai di file [tsconfig.json](/docs/handbook/tsconfig-json.html) Anda.
+Anda dapat menetapkan mode ini menggunakan _flag_ baris perintah `--jsx` atau opsi yang sesuai di berkas [tsconfig.json](/docs/handbook/tsconfig-json.html) Anda.
 
-> \*Catatan: Anda dapat menentukan fungsi factory JSX yang akan digunakan saat menargetkan react JSX emit dengan opsi `--jsxFactory` (nilai bawaan ke `React.createElement`)
+> \*Catatan: Anda dapat menentukan fungsi _factory_ JSX yang akan digunakan saat menargetkan react JSX _emit_ dengan opsi `--jsxFactory` (nilai bawaan ke `React.createElement`)
 
 ## Opeartor `as`
 
@@ -44,16 +44,16 @@ var foo = <foo>bar;
 ```
 
 Ini menegaskan variabel `bar` memiliki tipe `foo`.
-Sejak TypeScript juga menggunakan kurung siku untuk penegasan tipe, mengkombinasikannya dengan sintaks JSX akan menimbulkan kesulitan tertentu. Hasilnya, TypeScript tidak membolehkan penggunaan kurung siku untuk penegasan tipe pada file `.tsx`.
+Sejak TypeScript juga menggunakan kurung siku untuk penegasan tipe, mengkombinasikannya dengan sintaks JSX akan menimbulkan kesulitan tertentu. Hasilnya, TypeScript tidak membolehkan penggunaan kurung siku untuk penegasan tipe pada berkas `.tsx`.
 
-Karena sintaks diatas tidak bisa digunakan pada file `.tsx`, maka alternatif untuk penegasan tipe dapat menggunakan operator `as`.
+Karena sintaks diatas tidak bisa digunakan pada berkas `.tsx`, maka alternatif untuk penegasan tipe dapat menggunakan operator `as`.
 Contohnya dapat dengan mudah ditulis ulang dengan operator `as`.
 
 ```ts
 var foo = bar as foo;
 ```
 
-Operator `as` tersedia dikedua jenis file, `.ts` dan `.tsx`, dan memiliki perlakuan yang sama seperti penegasan tipe menggunakan kurung siku.
+Operator `as` tersedia dikedua jenis berkas, `.ts` dan `.tsx`, dan memiliki perlakuan yang sama seperti penegasan tipe menggunakan kurung siku.
 
 ## Pemeriksaan Tipe
 
@@ -69,9 +69,9 @@ Elemen intrinsik selalu dimulai dengan huruf kecil, dan elemen berbasiskan nilai
 
 ## Elemen intrinsik
 
-Elemen intrinsik dicari pada interface khusus, yaitu `JSX.IntrinsicElements`.
-Standarnya, jika interface ini tidak ditentukan, maka apapun yang terjadi dan elemen intrinsik tidak akan diperiksa tipenya.
-Namun, jika interface ini ada, maka nama elemen intrinsik akan dicari sebagai properti di interface `JSX.IntrinsicElements`.
+Elemen intrinsik dicari pada _interface_ khusus, yaitu `JSX.IntrinsicElements`.
+Standarnya, jika _interface_ ini tidak ditentukan, maka apapun yang terjadi dan elemen intrinsik tidak akan diperiksa tipenya.
+Namun, jika _interface_ ini ada, maka nama elemen intrinsik akan dicari sebagai properti di _interface_ `JSX.IntrinsicElements`.
 Contohnya:
 
 ```ts
@@ -85,9 +85,9 @@ declare namespace JSX {
 <bar />; // galat
 ```
 
-Pada contoh diatas, `<foo />` akan berjalan dengan baik, tapi `<bar />` akan menghasilkan galat, karena `<bar />` tidak ditentukan pada interface `JSX.IntrinsicElements`.
+Pada contoh diatas, `<foo />` akan berjalan dengan baik, tapi `<bar />` akan menghasilkan galat, karena `<bar />` tidak ditentukan pada _interface_ `JSX.IntrinsicElements`.
 
-> Catatan: Anda juga bisa menentukan indexer untuk mendapatkan seluruh elemen bertipe string didalam `JSX.IntrinsicElements`, seperti berikut:
+> Catatan: Anda juga bisa menentukan _indexer_ untuk mendapatkan seluruh elemen bertipe string didalam `JSX.IntrinsicElements`, seperti berikut:
 
 ```ts
 declare namespace JSX {
@@ -99,7 +99,7 @@ declare namespace JSX {
 
 ## Elemen Berbasiskan Nilai
 
-Elemen berbasiskan nilai akan dicari oleh identifier yang ada pada sebuah scope.
+Elemen berbasiskan nilai akan dicari oleh _identifier_ yang ada pada sebuah _scope_.
 
 ```ts
 import MyComponent from "./myComponent";
@@ -110,12 +110,12 @@ import MyComponent from "./myComponent";
 
 Terdapat dua cara untuk mendefinisikan sebuah elemen berbasiskan nilai, yaitu:
 
-1. Function Component (FC)
-2. Class Component
+1. _Function Component_ (FC)
+2. _Class Component_
 
-Karena kedua jenis elemen berbasis nilai ini tidak dapat dibedakan satu sama lain dalam ekspresi JSX, maka pertama TS akan mencoba menyelesaikan ekspresi tersebut sebagai Function Component menggunakan overloading. Jika proses berhasil, maka TS selesai menyelesaikan ekspresi ke deklarasinya. Jika gagal untuk menyelesaikan sebagai Function Component, maka TS kemudian akan mencoba untuk menyelesaikannya sebagai Class Component. Jika gagal, TS akan melaporkan kesalahan.
+Karena kedua jenis elemen berbasis nilai ini tidak dapat dibedakan satu sama lain dalam ekspresi JSX, maka pertama TS akan mencoba menyelesaikan ekspresi tersebut sebagai _Function Component_ menggunakan _overloading_. Jika proses berhasil, maka TS selesai menyelesaikan ekspresi ke deklarasinya. Jika gagal untuk menyelesaikan sebagai _Function Component_, maka TS kemudian akan mencoba untuk menyelesaikannya sebagai _Class Component_. Jika gagal, TS akan melaporkan kesalahan.
 
-### Function Component
+### _Function Component_
 
 Seperti namanya, komponen ini didefinisikan menggunakan fungsi JavaScript dimana argumen pertamanya adalah sebuah `props` objek.
 TS memberlakukan bahwa tipe kembaliannya harus dapat diberikan ke `JSX.Element`.
@@ -135,7 +135,7 @@ function ComponentFoo(prop: FooProp) {
 const Button = (prop: {value: string}, context: { color: string }) => <button>
 ```
 
-Karena Function Component adalah fungsi JavaScript, maka fungsi overload dapat digunakan di sini:
+Karena _Function Component_ adalah fungsi JavaScript, maka fungsi overload dapat digunakan di sini:
 
 ```ts
 interface ClickableProps {
@@ -156,19 +156,19 @@ function MainButton(prop: SideProps): JSX.Element {
 }
 ```
 
-> Catatan: Function Component sebelumnya dikenal sebagai Stateless Function Component (SFC). Karena Function Component tidak dapat lagi dianggap stateless di versi terbaru react, jenis `SFC` dan aliasnya`StatelessComponent` tidak digunakan lagi.
+> Catatan: _Function Component_ sebelumnya dikenal sebagai _Stateless Function Component_ (SFC). Karena _Function Component_ tidak dapat lagi dianggap _stateless_ di versi terbaru react, jenis `SFC` dan aliasnya`StatelessComponent` tidak digunakan lagi.
 
-### Class Component
+### _Class Component_
 
-Ini memungkinkan untuk mendefinisikan tipe dari class component.
+Ini memungkinkan untuk mendefinisikan tipe dari _class component_.
 Namun, untuk melakukannya, yang terbaik adalah memahami dua istilah baru berikut: _type class elemen_ dan _type instance elemen_.
 
 Jika terdapat `<Expr />`, maka _type class elemennya_ adalah `Expr`.
-Jadi pada contoh diatas, jika `MyComponent` adalah class ES6, maka tipe class-nya adalah konstruktor dan static dari class tersebut.
-Jika `MyComponent` adalah factory function, maka tipe class-nya adalah fungsi itu sendiri.
+Jadi pada contoh diatas, jika `MyComponent` adalah _class_ ES6, maka tipe _class_-nya adalah konstruktor dan _static_ dari _class_ tersebut.
+Jika `MyComponent` adalah factory function, maka tipe _class_-nya adalah fungsi itu sendiri.
 
-Setelah tipe class dibuat, tipe instance ditentukan oleh gabungan tipe kembalian dari konstruksi tipe class atau call signature (mana saja yang ada).
-Jadi sekali lagi, dalam kasus kelas ES6, jenis instans adalah jenis instans kelas itu, dan dalam kasus factory function, itu akan menjadi jenis nilai yang dikembalikan dari fungsi tersebut.
+Setelah tipe class dibuat, tipe _instance_ ditentukan oleh gabungan tipe kembalian dari konstruksi tipe _class_ atau _call signature_ (mana saja yang ada).
+Jadi sekali lagi, dalam kasus kelas ES6, jenis instans adalah jenis instans kelas itu, dan dalam kasus _factory function_, itu akan menjadi jenis nilai yang dikembalikan dari fungsi tersebut.
 
 ```ts
 class MyComponent {
@@ -194,7 +194,7 @@ var myComponent = MyFactoryFunction();
 // tipe instance elemen => { render: () => void }
 ```
 
-Tipe elemen instance itu menarik, karena ini harus dapat di-assign ke `JSX.ElementClass` atau hasilnya akan galat.
+Tipe elemen _instance_ itu menarik, karena ini harus dapat di-_assign_ ke `JSX.ElementClass` atau hasilnya akan galat.
 Standarnya `JSX.ElementClass` adalah `{}`, tetapi ini bisa ditambah untuk membatasi penggunaan JSX hanya untuk jenis yang sesuai dengan interface yang tepat.
 
 ```ts
@@ -243,10 +243,10 @@ declare namespace JSX {
 
 Untuk elemen berbasis nilai, ini sedikit lebih kompleks.
 Ini ditentukan oleh tipe dari properti pada _type elemen instance_ yang telah ditentukan.
-Property mana yang digunakan untuk ditentukan oleh `JSX.ElementAttributesProperty`.
+Properti mana yang digunakan untuk ditentukan oleh `JSX.ElementAttributesProperty`.
 Ini harus dideklarasikan dengan satu properti.
 Nama properti itu kemudian digunakan.
-Mulai TypeScript 2.8, jika `JSX.ElementAttributesProperty` tidak disediakan, jenis parameter pertama dari konstruktor elemen kelas atau pemanggilan Function Component akan digunakan sebagai gantinya.
+Mulai TypeScript 2.8, jika `JSX.ElementAttributesProperty` tidak disediakan, jenis parameter pertama dari konstruktor elemen kelas atau pemanggilan _Function Component_ akan digunakan sebagai gantinya.
 
 ```ts
 declare namespace JSX {
@@ -266,7 +266,7 @@ class MyComponent {
 <MyComponent foo="bar" />;
 ```
 
-Type atribut elemen digunakan untuk memeriksa atribut di JSX.
+Tipe atribut elemen digunakan untuk memeriksa atribut di JSX.
 Properti opsional dan wajib telah didukung.
 
 ```ts
@@ -284,11 +284,11 @@ declare namespace JSX {
 <foo requiredProp="bar" some-unknown-prop />; // ok, karena 'some-unknown-prop' bukan identifier yang valid
 ```
 
-> Catatan: Jika nama atribut bukan identifier JS yang valid (seperti atribut `data- *`), itu tidak dianggap sebagai kesalahan jika tidak ditemukan dalam tipe atribut elemen.
+> Catatan: Jika nama atribut bukan _identifier_ JS yang valid (seperti atribut `data- *`), itu tidak dianggap sebagai kesalahan jika tidak ditemukan dalam tipe atribut elemen.
 
-Selain itu, antarmuka `JSX.IntrinsicAttributes` dapat digunakan untuk menentukan properti tambahan yang digunakan oleh framework JSX yang umumnya tidak digunakan oleh props atau argumen komponen - misalnya `key` di React. Mengkhususkan lebih lanjut, tipe generik `JSX.IntrinsicClassAttributes<T>` juga dapat digunakan untuk menetapkan tipe atribut tambahan yang sama hanya untuk class component (dan bukan function component). Dalam tipe ini, parameter generik sesuai dengan tipe instance class. Di React, ini digunakan untuk mengizinkan atribut `ref` dengan tipe `Ref <T>`. Secara umum, semua properti pada interface ini harus bersifat opsional, kecuali Anda bermaksud agar pengguna framework JSX Anda perlu menyediakan beberapa atribut pada setiap tag.
+Selain itu, antarmuka `JSX.IntrinsicAttributes` dapat digunakan untuk menentukan properti tambahan yang digunakan oleh _framework_ JSX yang umumnya tidak digunakan oleh props atau argumen komponen - misalnya `key` di React. Mengkhususkan lebih lanjut, tipe generik `JSX.IntrinsicClassAttributes<T>` juga dapat digunakan untuk menetapkan tipe atribut tambahan yang sama hanya untuk _class component_ (dan bukan _function component_). Dalam tipe ini, parameter generik sesuai dengan tipe _instance class_. Di React, ini digunakan untuk mengizinkan atribut `ref` dengan tipe `Ref <T>`. Secara umum, semua properti pada interface ini harus bersifat opsional, kecuali Anda bermaksud agar pengguna _framework_ JSX Anda perlu menyediakan beberapa atribut pada setiap tag.
 
-Spread operator juga bekerja:
+_Spread operator_ juga bekerja:
 
 ```ts
 var props = { requiredProp: "bar" };
@@ -298,9 +298,9 @@ var badProps = {};
 <foo {...badProps} />; // galat
 ```
 
-## Pemeriksaan Type Children
+## Pemeriksaan _Children Type_
 
-Di TypeScript 2.3, TS mengenalkan pemeriksaan tipe pada _children_. _Children_ adalah properti khusus di _type atribut elemen_ dimana child _JSXExpression_ diambil untuk dimasukkan ke atribut.
+Di TypeScript 2.3, TS mengenalkan pemeriksaan tipe pada _children_. _Children_ adalah properti khusus di _type atribut elemen_ dimana _child_ _JSXExpression_ diambil untuk dimasukkan ke atribut.
 Mirip dengan bagaimana menggunakan `JSX.ElementAttributesProperty` untuk menentukan nama dari _props_, TS menggunakan `JSX`.
 `JSX.ElementChildrenAttribute` harus dideklarasikan dengan properti tunggal.
 
@@ -365,12 +365,12 @@ class Component extends React.Component<PropsType, {}> {
 </Component>
 ```
 
-## Type hasil JSX
+## Tipe hasil JSX
 
 Secara standar, hasil dari ekspresi JSX bertipe `any`.
-Anda bisa menyesuaikan tipe dengan menentukan interface `JSX.Element`.
-Namun, tidak mungkin untuk mengambil informasi tipe tentang elemen, atribut atau turunan dari JSX dari interface ini.
-Itu adalah black box.
+Anda bisa menyesuaikan tipe dengan menentukan _interface_ `JSX.Element`.
+Namun, tidak mungkin untuk mengambil informasi tipe tentang elemen, atribut atau turunan dari JSX dari _interface_ ini.
+Itu adalah _black box_.
 
 ## Menyematkan Ekspresi
 
@@ -386,8 +386,8 @@ var a = (
 );
 ```
 
-Kode di atas akan menghasilkan kesalahan karena Anda tidak dapat membagi string dengan angka.
-Outputnya, saat menggunakan opsi `preserve`, terlihat seperti:
+Kode di atas akan menghasilkan kesalahan karena Anda tidak dapat membagi _string_ dengan angka.
+_Output_-nya, saat menggunakan opsi `preserve`, terlihat seperti:
 
 ```ts
 var a = (
@@ -401,7 +401,7 @@ var a = (
 
 ## Integrasi React
 
-Untuk menggunakan JSX dengan React, Anda harus menggunakan [React typings](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react). Typings ini mendefinisikan namespace `JSX` dengan tepat untuk digunakan dengan React.
+Untuk menggunakan JSX dengan React, Anda harus menggunakan [React typings](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react). Typings ini mendefinisikan _namespace_ `JSX` dengan tepat untuk digunakan dengan React.
 
 ```ts
 /// <reference path="react.d.ts" />
@@ -422,7 +422,7 @@ class MyComponent extends React.Component<Props, {}> {
 
 ## Factory Function
 
-Factory function yang digunakan oleh opsi kompilator `jsx: react` dapat dikonfigurasi. Ini dapat disetel menggunakan opsi baris perintah `jsxFactory`, atau komentar `@jsx` sebaris untuk menyetelnya pada basis per file. Misalnya, jika Anda menyetel `jsxFactory` ke `createElement`, `<div />` akan melakukannya sebagai `createElement("div")` bukan `React.createElement("div")`.
+Factory function yang digunakan oleh opsi kompilator `jsx: react` dapat dikonfigurasi. Ini dapat disetel menggunakan opsi baris perintah `jsxFactory`, atau komentar `@jsx` sebaris untuk menyetelnya pada basis per berkas. Misalnya, jika Anda menyetel `jsxFactory` ke `createElement`, `<div />` akan melakukannya sebagai `createElement("div")` bukan `React.createElement("div")`.
 
 Versi pragma komentar dapat digunakan seperti itu (dalam TypeScript 2.8):
 
@@ -439,4 +439,4 @@ const preact = require("preact");
 const x = preact.h("div", null);
 ```
 
-Factory yang dipilih juga akan mempengaruhi di mana namespace `JSX` dicari (untuk informasi pemeriksaan tipe) sebelum kembali ke global. Jika factory ditentukan sebagai `React.createElement` (standar), kompilator akan memeriksa `React.JSX` sebelum memeriksa `JSX` global. Jika factory ditentukan sebagai `h`, maka ia akan memeriksa `h.JSX` sebelum `JSX` global.
+_Factory_ yang dipilih juga akan mempengaruhi di mana _namespace_ `JSX` dicari (untuk informasi pemeriksaan tipe) sebelum kembali ke _global_. Jika _factory_ ditentukan sebagai `React.createElement` (standar), kompilator akan memeriksa `React.JSX` sebelum memeriksa `JSX` _global_. Jika _factory_ ditentukan sebagai `h`, maka ia akan memeriksa `h.JSX` sebelum `JSX` _global_.

--- a/packages/documentation/copy/id/reference/JSX.md
+++ b/packages/documentation/copy/id/reference/JSX.md
@@ -1,0 +1,442 @@
+---
+title: JSX
+layout: docs
+permalink: /id/docs/handbook/jsx.html
+oneline: Menggunakan JSX dengan TypeScript
+translatable: true
+---
+
+[JSX](https://facebook.github.io/jsx/) adalah sebuah sintaks tertanam, yang seperti XML.
+Ini dimaksudkan untuk diubah menjadi JavaScript yang valid, meskipun semantik dari transformasi itu khusus untuk implementasi.
+JSX menjadi populer dengan kerangka kerja [React](https://reactjs.org/), tetapi sejak itu juga melihat implementasi lain.
+TypeScript mendukung embeding, pemeriksaan type, dan mengkompilasi JSX secara langsung ke JavaScript.
+
+## Dasar Penggunaan
+
+Untuk menggunakan JSX, anda harus melakukan dua hal berikut:
+
+1. Penamaan file dengan ekstensi `.tsx`
+2. Mengaktifkan opsi `jsx`
+
+TypeScript memiliki tiga jenis mode JSX: `preserve`, `react`, dan `react-native`.
+Mode tersebut hanya berlaku untuk stage, sedangkan untuk pemeriksaan type, hal itu tidak berlaku.
+Mode `preserve` akan mempertahankan JSX sebagai bagian dari output untuk selanjutnya digunakan oleh langkah transformasi lain (mis. [Babel](https://babeljs.io/)).
+Selain itu, output-nya akan memiliki ekstensi file `.jsx`.
+Mode `react` akan mengeluarkan`React.createElement`, tidak perlu melalui transformasi JSX sebelum digunakan, dan outputnya akan memiliki ekstensi file `.js`.
+Mode `react-native` sama dengan `pertahankan` yang mempertahankan semua JSX, tetapi hasilnya justru akan memiliki ekstensi file `.js`.
+
+| Mode           | Input     | Output                       | Output File Extension |
+| -------------- | --------- | ---------------------------- | --------------------- |
+| `preserve`     | `<div />` | `<div />`                    | `.jsx`                |
+| `react`        | `<div />` | `React.createElement("div")` | `.js`                 |
+| `react-native` | `<div />` | `<div />`                    | `.js`                 |
+
+Anda dapat menetapkan mode ini menggunakan flag baris perintah `--jsx` atau opsi yang sesuai di file [tsconfig.json](/docs/handbook/tsconfig-json.html) Anda.
+
+> \*Catatan: Anda dapat menentukan fungsi factory JSX yang akan digunakan saat menargetkan react JSX emit dengan opsi `--jsxFactory` (default ke `React.createElement`)
+
+## Opeartor `as`
+
+Ingat bagaimana menulis penegasan type:
+
+```ts
+var foo = <foo>bar;
+```
+
+Ini menegaskan variabel `bar` memiliki type `foo`.
+Sejak TypeScript juga menggunakan kurung siku untuk penegasan type, mengkombinasikannya dengan sintaks JSX akan menimbulkan kesulitan tertentu. Hasilnya, TypeScript tidak membolehkan penggunaan kurung siku untuk penegasan type pada file `.tsx`.
+
+Karena sintaks diatas tidak bisa digunakan pada file `.tsx`, maka alternatif untuk penegasan type dapat menggunakan operator `as`.
+Contohnya dapat dengan mudah ditulis ulang dengan operator `as`.
+
+```ts
+var foo = bar as foo;
+```
+
+Operator `as` tersedia dikedua jenis file, `.ts` dan `.tsx`, dan memiliki perlakuan yang sama seperti penegasan type menggunakan kurung siku.
+
+## Pemeriksaan Type
+
+Urutan yang harus dimengerti mengenai pemeriksaan type di JSX, yaitu pertama anda harus memahami perbedaan antara elemen intrinsik dan elemen berbasiskan nilai. Terdapat sebuah ekspresi `<expr />` dan `expr` yang mungkin mengacu pada suatu hal yang intrinsik pada suatu lingkungan (misalnya `div` atau `span` dalam lingkungan DOM) atau pada komponen custom yang telah Anda buat.
+Ini penting karena dua alasan berikut:
+
+1. Untuk React, elemen intrinsik dianggap sebagai string (`React.createElement("div")`), sedangkan komponen yang Anda buat bukan (`React.createElement(MyComponent)`).
+2. Type dari atribut yang dilewatkan ke elemen JSX seharusnya terlihat berbeda.
+   Atribut elemen intrinsik seharusnya diketahui _secara intrinsik_ sedangkan komponen akan seperti ingin untuk menentukan kumpulan atribut mereka sendiri.
+
+TypeScript menggunakan [beberapa convention yang dengan React](http://facebook.github.io/react/docs/jsx-in-depth.html#html-tags-vs.-react-components) untuk membedakannya.
+Elemen intrinsik selalu dimulai dengan huruf kecil, dan elemen berbasiskan nilai selalu dimulai dengan huruf besar.
+
+## Elemen intrinsik
+
+Elemen intrinsik dicari pada interface khusus, yaitu `JSX.IntrinsicElements`.
+Standarnya, jika interface ini tidak ditentukan, maka apapun yang terjadi dan elemen intrinsik tidak akan diperiksa type-nya.
+Namun, jika interface ini ada, maka nama elemen intrinsik akan dicari sebagai property di interface `JSX.IntrinsicElements`.
+Contohnya:
+
+```ts
+declare namespace JSX {
+  interface IntrinsicElements {
+    foo: any;
+  }
+}
+
+<foo />; // ok
+<bar />; // error
+```
+
+Pada contoh diatas, `<foo />` akan berjalan dengan baik, tapi `<bar />` akan menghasilkan error, karena `<bar />` tidak ditentukan pada interface `JSX.IntrinsicElements`.
+
+> Catatan: Anda juga bisa menentukan indexer untuk mendapatkan seluruh elemen bertipe string didalam `JSX.IntrinsicElements`, seperti berikut:
+
+```ts
+declare namespace JSX {
+  interface IntrinsicElements {
+    [elemName: string]: any;
+  }
+}
+```
+
+## Elemen Berbasiskan Nilai
+
+Elemen berbasiskan nilai akan dicari oleh identifier yang ada pada sebuah scope.
+
+```ts
+import MyComponent from "./myComponent";
+
+<MyComponent />; // ok
+<SomeOtherComponent />; // error
+```
+
+Terdapat dua cara untuk mendefinisikan sebuah elemen berbasiskan nilai, yaitu:
+
+1. Function Component (FC)
+2. Class Component
+
+Karena kedua jenis elemen berbasis nilai ini tidak dapat dibedakan satu sama lain dalam ekspresi JSX, maka pertama TS akan mencoba menyelesaikan ekspresi tersebut sebagai Function Component menggunakan overloading. Jika proses berhasil, maka TS selesai menyelesaikan ekspresi ke deklarasinya. Jika gagal untuk menyelesaikan sebagai Function Component, maka TS kemudian akan mencoba untuk menyelesaikannya sebagai Class Component. Jika gagal, TS akan melaporkan kesalahan.
+
+### Function Component
+
+Seperti namanya, komponen ini didefinisikan menggunakan fungsi JavaScript dimana argumen pertamanya adalah sebuah `props` objek.
+TS memberlakukan bahwa type kembaliannya harus dapat diberikan ke `JSX.Element`.
+
+```ts
+interface FooProp {
+  name: string;
+  X: number;
+  Y: number;
+}
+
+declare function AnotherComponent(prop: {name: string});
+function ComponentFoo(prop: FooProp) {
+  return <AnotherComponent name={prop.name} />;
+}
+
+const Button = (prop: {value: string}, context: { color: string }) => <button>
+```
+
+Karena Function Component adalah fungsi JavaScript, maka fungsi overload dapat digunakan di sini:
+
+```ts
+interface ClickableProps {
+  children: JSX.Element[] | JSX.Element
+}
+
+interface HomeProps extends ClickableProps {
+  home: JSX.Element;
+}
+
+interface SideProps extends ClickableProps {
+  side: JSX.Element | string;
+}
+
+function MainButton(prop: HomeProps): JSX.Element;
+function MainButton(prop: SideProps): JSX.Element {
+  ...
+}
+```
+
+> Catatan: Function Component sebelumnya dikenal sebagai Stateless Function Component (SFC). Karena Function Component tidak dapat lagi dianggap stateless di versi terbaru react, jenis `SFC` dan aliasnya`StatelessComponent` tidak digunakan lagi.
+
+### Class Component
+
+Ini memungkinkan untuk mendefinisikan type dari class component.
+Namun, untuk melakukannya, yang terbaik adalah memahami dua istilah baru berikut: _type class elemen_ dan _type instance elemen_.
+
+Jika terdapat `<Expr />`, maka _type class elemennya_ adalah `Expr`.
+Jadi pada contoh diatas, jika `MyComponent` adalah class ES6, maka type class-nya adalah konstruktor dan static dari class tersebut.
+Jika `MyComponent` adalah factory function, maka type class-nya adalah fungsi itu sendiri.
+
+Setelah type class dibuat, type instance ditentukan oleh gabungan tipe kembalian dari konstruksi type class atau call signature (mana saja yang ada).
+Jadi sekali lagi, dalam kasus kelas ES6, jenis instans adalah jenis instans kelas itu, dan dalam kasus factory function, itu akan menjadi jenis nilai yang dikembalikan dari fungsi tersebut.
+
+```ts
+class MyComponent {
+  render() {}
+}
+
+// menggunakan konstruksi signature
+var myComponent = new MyComponent();
+
+// type class elemen => MyComponent
+// type instance elemen => { render: () => void }
+
+function MyFactoryFunction() {
+  return {
+    render: () => {},
+  };
+}
+
+// menggunakan call signature
+var myComponent = MyFactoryFunction();
+
+// type class elemen => FactoryFunction
+// type instance elemen => { render: () => void }
+```
+
+Type elemen instance itu menarik, karena ini harus dapat di-assign ke `JSX.ElementClass` atau hasilnya akan error.
+Standarnya `JSX.ElementClass` adalah `{}`, tetapi ini bisa ditambah untuk membatasi penggunaan JSX hanya untuk jenis yang sesuai dengan interface yang tepat.
+
+```ts
+declare namespace JSX {
+  interface ElementClass {
+    render: any;
+  }
+}
+
+class MyComponent {
+  render() {}
+}
+function MyFactoryFunction() {
+  return { render: () => {} };
+}
+
+<MyComponent />; // ok
+<MyFactoryFunction />; // ok
+
+class NotAValidComponent {}
+function NotAValidFactoryFunction() {
+  return {};
+}
+
+<NotAValidComponent />; // error
+<NotAValidFactoryFunction />; // error
+```
+
+## Pemeriksaan Type Atribut
+
+Langkah pertama untuk memeriksa type atribut adalah menentukan type atribut elemen.
+Ini sedikit berbeda antara elemen intrinsik dan berbasis nilai.
+
+Untuk elemen intrinsik, ini adalah type dari property pada `JSX.IntrinsicElements`
+
+```ts
+declare namespace JSX {
+  interface IntrinsicElements {
+    foo: { bar?: boolean };
+  }
+}
+
+// type atribut elemen untuk 'foo' is '{bar?: boolean}'
+<foo bar />;
+```
+
+Untuk elemen berbasis nilai, ini sedikit lebih kompleks.
+Ini ditentukan oleh type dari property pada _type elemen instance_ yang telah ditentukan.
+Property mana yang digunakan untuk ditentukan oleh `JSX.ElementAttributesProperty`.
+Ini harus dideklarasikan dengan satu property.
+Nama property itu kemudian digunakan.
+Mulai TypeScript 2.8, jika `JSX.ElementAttributesProperty` tidak disediakan, jenis parameter pertama dari konstruktor elemen kelas atau pemanggilan Function Component akan digunakan sebagai gantinya.
+
+```ts
+declare namespace JSX {
+  interface ElementAttributesProperty {
+    props; // menentukan nama property yang akan digunakan
+  }
+}
+
+class MyComponent {
+  // menentukan property pada type instance elemen
+  props: {
+    foo?: string;
+  };
+}
+
+// type atribut elemen untuk 'MyComponent' adalah '{foo?: string}'
+<MyComponent foo="bar" />;
+```
+
+Type atribut elemen digunakan untuk memeriksa atribut di JSX.
+Properti opsional dan wajib telah didukung.
+
+```ts
+declare namespace JSX {
+  interface IntrinsicElements {
+    foo: { requiredProp: string; optionalProp?: number };
+  }
+}
+
+<foo requiredProp="bar" />; // ok
+<foo requiredProp="bar" optionalProp={0} />; // ok
+<foo />; // error, tidak ada requiredProp
+<foo requiredProp={0} />; // error, requiredProp seharusnya ber-type string
+<foo requiredProp="bar" unknownProp />; // error, unknownProp tidak ada
+<foo requiredProp="bar" some-unknown-prop />; // ok, karena 'some-unknown-prop' bukan identifier yang valid
+```
+
+> Catatan: Jika nama atribut bukan identifier JS yang valid (seperti atribut `data- *`), itu tidak dianggap sebagai kesalahan jika tidak ditemukan dalam type atribut elemen.
+
+Selain itu, antarmuka `JSX.IntrinsicAttributes` dapat digunakan untuk menentukan properti tambahan yang digunakan oleh framework JSX yang umumnya tidak digunakan oleh props atau argumen komponen - misalnya `key` di React. Mengkhususkan lebih lanjut, type generik `JSX.IntrinsicClassAttributes<T>` juga dapat digunakan untuk menetapkan type atribut tambahan yang sama hanya untuk class component (dan bukan function component). Dalam type ini, parameter generik sesuai dengan type instance class. Di React, ini digunakan untuk mengizinkan atribut `ref` dengan type `Ref <T>`. Secara umum, semua properti pada interface ini harus bersifat opsional, kecuali Anda bermaksud agar pengguna framework JSX Anda perlu menyediakan beberapa atribut pada setiap tag.
+
+Spread operator juga bekerja:
+
+```ts
+var props = { requiredProp: "bar" };
+<foo {...props} />; // ok
+
+var badProps = {};
+<foo {...badProps} />; // error
+```
+
+## Pemeriksaan Type Children
+
+Di TypeScript 2.3, TS mengenalkan pemeriksaan type pada _children_. _Children_ adalah property khusus di _type atribut elemen_ dimana child _JSXExpression_ diambil untuk dimasukkan ke atribut.
+Mirip dengan bagaimana menggunakan `JSX.ElementAttributesProperty` untuk menentukan nama dari _props_, TS menggunakan `JSX`.
+`JSX.ElementChildrenAttribute` harus dideklarasikan dengan property tunggal.
+
+```ts
+declare namespace JSX {
+  interface ElementChildrenAttribute {
+    children: {}; // menentukan nama children untuk digunakan
+  }
+}
+```
+
+```ts
+<div>
+  <h1>Hello</h1>
+</div>;
+
+<div>
+  <h1>Hello</h1>
+  World
+</div>;
+
+const CustomComp = (props) => <div>{props.children}</div>
+<CustomComp>
+  <div>Hello World</div>
+  {"This is just a JS expression..." + 1000}
+</CustomComp>
+```
+
+Anda bisa menentukan type dari _children_ seperti atribut lainnya. Ini akan mengganti type standarnya, misalnya [React typings](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react) jika Anda menggunakannya.
+
+```ts
+interface PropsType {
+  children: JSX.Element
+  name: string
+}
+
+class Component extends React.Component<PropsType, {}> {
+  render() {
+    return (
+      <h2>
+        {this.props.children}
+      </h2>
+    )
+  }
+}
+
+// OK
+<Component name="foo">
+  <h1>Hello World</h1>
+</Component>
+
+// Error: children adalah type JSX.Element, bukan array dari JSX.Element.
+<Component name="bar">
+  <h1>Hello World</h1>
+  <h2>Hello World</h2>
+</Component>
+
+// Error: children adalah type JSX.Element, bukan array dari JSX.Element maupun string.
+<Component name="baz">
+  <h1>Hello</h1>
+  World
+</Component>
+```
+
+## Type hasil JSX
+
+Secara standar, hasil dari ekspresi JSX ber-type `any`.
+Anda bisa menyesuaikan type dengan menentukan interface `JSX.Element`.
+Namun, tidak mungkin untuk mengambil informasi type tentang elemen, atribut atau turunan dari JSX dari interface ini.
+Itu adalah black box.
+
+## Menyematkan Ekspresi
+
+JSX memungkinkan Anda untuk menyematkan ekspresi di antara tag dengan mengapit ekspresi dengan kurung kurawal (`{}`).
+
+```ts
+var a = (
+  <div>
+    {["foo", "bar"].map((i) => (
+      <span>{i / 2}</span>
+    ))}
+  </div>
+);
+```
+
+Kode di atas akan menghasilkan kesalahan karena Anda tidak dapat membagi string dengan angka.
+Outputnya, saat menggunakan opsi `preserve`, terlihat seperti:
+
+```ts
+var a = (
+  <div>
+    {["foo", "bar"].map(function (i) {
+      return <span>{i / 2}</span>;
+    })}
+  </div>
+);
+```
+
+## Integrasi React
+
+Untuk menggunakan JSX dengan React, anda harus menggunakan [React typings](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react). Typings ini mendefinisikan namespace `JSX` dengan tepat untuk digunakan dengan React.
+
+```ts
+/// <reference path="react.d.ts" />
+
+interface Props {
+  foo: string;
+}
+
+class MyComponent extends React.Component<Props, {}> {
+  render() {
+    return <span>{this.props.foo}</span>;
+  }
+}
+
+<MyComponent foo="bar" />; // ok
+<MyComponent foo={0} />; // error
+```
+
+## Factory Function
+
+Factory function yang digunakan oleh opsi compiler `jsx: react` dapat dikonfigurasi. Ini dapat disetel menggunakan opsi baris perintah `jsxFactory`, atau komentar `@jsx` sebaris untuk menyetelnya pada basis per file. Misalnya, jika Anda menyetel `jsxFactory` ke `createElement`, `<div />` akan melakukannya sebagai `createElement("div")` bukan `React.createElement("div")`.
+
+Versi pragma komentar dapat digunakan seperti itu (dalam TypeScript 2.8):
+
+```ts
+import preact = require("preact");
+/* @jsx preact.h */
+const x = <div />;
+```
+
+akan menjadi:
+
+```ts
+const preact = require("preact");
+const x = preact.h("div", null);
+```
+
+Factory yang dipilih juga akan mempengaruhi di mana namespace `JSX` dicari (untuk informasi pemeriksaan type) sebelum kembali ke global. Jika factory ditentukan sebagai `React.createElement` (standar), compiler akan memeriksa `React.JSX` sebelum memeriksa `JSX` global. Jika factory ditentukan sebagai `h`, maka ia akan memeriksa `h.JSX` sebelum `JSX` global.

--- a/packages/documentation/copy/id/reference/Mixins.md
+++ b/packages/documentation/copy/id/reference/Mixins.md
@@ -29,7 +29,7 @@ class Sprite {
 }
 ```
 
-Kemudian kamu butuh sebuah type dan sebuah fungsi factory yang mengembalikan sebuah ekspresi kelas untuk meng-extend kelas dasar.
+Kemudian kamu butuh sebuah tipe dan sebuah fungsi factory yang mengembalikan sebuah ekspresi kelas untuk meng-extend kelas dasar.
 
 ```ts twoslash
 // Untuk memulai, kita membutuhkan tipe yang akan kita gunakan untuk memperluas kelas lain.
@@ -37,12 +37,12 @@ Kemudian kamu butuh sebuah type dan sebuah fungsi factory yang mengembalikan seb
 
 type Constructor = new (...args: any[]) => {};
 
-// Mixin ini menambahkan property scale, dengan getter dan setter
+// Mixin ini menambahkan properti scale, dengan getter dan setter
 // untuk mengubahnya dengan properti private yang dienkapsulasi:
 
 function Scale<TBase extends Constructor>(Base: TBase) {
   return class Scaling extends Base {
-    // Mixin mungkin tidak mendeklarasikan property private/protected
+    // Mixin mungkin tidak mendeklarasikan properti private/protected
     // namun, Anda dapat menggunakan field private ES2020
     _scale = 1;
 
@@ -72,7 +72,7 @@ class Sprite {
 type Constructor = new (...args: any[]) => {};
 function Scale<TBase extends Constructor>(Base: TBase) {
   return class Scaling extends Base {
-    // Mixin mungkin tidak mendeklarasikan property private/protected
+    // Mixin mungkin tidak mendeklarasikan properti private/protected
     // namun, Anda dapat menggunakan field private ES2020
     _scale = 1;
 
@@ -160,7 +160,7 @@ function Jumpable<TBase extends Positionable>(Base: TBase) {
 
 ## Pola Alternatif
 
-Versi sebelumnya dari dokumen ini merekomendasikan cara untuk menulis mixin di mana Anda membuat runtime dan hierarki type secara terpisah, lalu menggabungkannya di akhir:
+Versi sebelumnya dari dokumen ini merekomendasikan cara untuk menulis mixin di mana Anda membuat runtime dan hierarki tipe secara terpisah, lalu menggabungkannya di akhir:
 
 ```ts twoslash
 // @strict: false
@@ -204,11 +204,11 @@ function applyMixins(derivedCtor: any, constructors: any[]) {
 }
 ```
 
-Pola ini tidak terlalu bergantung pada compiler, dan lebih banyak pada basis kode Anda untuk memastikan runtime dan sistem tipe tetap sinkron dengan benar.
+Pola ini tidak terlalu bergantung pada kompilator, dan lebih banyak pada basis kode Anda untuk memastikan runtime dan sistem tipe tetap sinkron dengan benar.
 
 ## Kendala
 
-Pola mixin didukung secara native di dalam compiler TypeScript oleh code flow analysis.
+Pola mixin didukung secara native di dalam kompilator TypeScript oleh code flow analysis.
 Ada beberapa kasus di mana Anda dapat mencapai tepi dukungan native.
 
 #### Decorator dan Mixin [`#4881`](https://github.com/microsoft/TypeScript/issues/4881)
@@ -245,7 +245,7 @@ playerTwo.shouldFreeze;
 
 #### Static Property Mixins [`#17829`](https://github.com/microsoft/TypeScript/issues/17829)
 
-Pola ekspresi kelas membuat singletons, jadi mereka tidak dapat dipetakan pada sistem type untuk mendukung tipe variabel yang berbeda.
+Pola ekspresi kelas membuat singletons, jadi mereka tidak dapat dipetakan pada sistem tipe untuk mendukung tipe variabel yang berbeda.
 
 Anda bisa mengatasinya dengan menggunakan fungsi untuk mengembalikan kelas Anda yang berbeda berdasarkan generik:
 

--- a/packages/documentation/copy/id/reference/Mixins.md
+++ b/packages/documentation/copy/id/reference/Mixins.md
@@ -7,15 +7,15 @@ translatable: true
 ---
 
 Bersamaan dengan hierarki OO tradisional, cara populer lainnya untuk membangun kelas dari komponen yang dapat digunakan kembali adalah membangunnya dengan menggabungkan kelas parsial yang lebih sederhana.
-Anda mungkin sudah familiar dengan ide mixin atau ciri untuk bahasa seperti Scala, dan polanya juga mendapatkan popularitas di komunitas JavaScript.
+Anda mungkin sudah familiar dengan ide _mixin_ atau ciri untuk bahasa seperti Scala, dan polanya juga mendapatkan popularitas di komunitas JavaScript.
 
 ## Bagaimana Cara Kerja Mixin?
 
 Pola ini bergantung pada penggunaan Generik dengan warisan kelas untuk memperluas kelas dasar.
-Dukungan mixin terbaik TypeScript dilakukan melalui pola ekspresi kelas.
+Dukungan _mixin_ terbaik TypeScript dilakukan melalui pola ekspresi kelas.
 Anda dapat membaca lebih lanjut mengenai bagaimana pola ini bekerja di [Javscript disini](https://justinfagnani.com/2015/12/21/real-mixins-with-javascript-classes/).
 
-Untuk memulai, kita akan butuh kelas yang akan diterapkan mixin:
+Untuk memulai, kita akan butuh kelas yang akan diterapkan _mixin_:
 
 ```ts twoslash
 class Sprite {
@@ -29,7 +29,7 @@ class Sprite {
 }
 ```
 
-Kemudian kamu butuh sebuah tipe dan sebuah fungsi factory yang mengembalikan sebuah ekspresi kelas untuk meng-extend kelas dasar.
+Kemudian kamu butuh sebuah tipe dan sebuah fungsi factory yang mengembalikan sebuah ekspresi kelas untuk meng-_extend_ kelas dasar.
 
 ```ts twoslash
 // Untuk memulai, kita membutuhkan tipe yang akan kita gunakan untuk memperluas kelas lain.
@@ -57,7 +57,7 @@ function Scale<TBase extends Constructor>(Base: TBase) {
 }
 ```
 
-Setelah hal-hal diatas siap, Anda dapat membuat kelas yang mewakili kelas dasar dengan mixin yang diterapkan:
+Setelah hal-hal diatas siap, Anda dapat membuat kelas yang mewakili kelas dasar dengan _mixin_ yang diterapkan:
 
 ```ts twoslash
 class Sprite {
@@ -95,11 +95,11 @@ flappySprite.setScale(0.8);
 console.log(flappySprite.scale);
 ```
 
-## Mixin yang Dibatasi
+## _Mixin_ yang Dibatasi
 
-Dalam bentuk di atas, mixin tidak memiliki pengetahuan yang mendasari kelas yang dapat menyulitkan pembuatan desain yang diinginkan.
+Dalam bentuk di atas, _mixin_ tidak memiliki pengetahuan yang mendasari kelas yang dapat menyulitkan pembuatan desain yang diinginkan.
 
-Untuk memodelkan ini, kami memodifikasi tipe konstruktor asli untuk menerima argumen generic.
+Untuk memodelkan ini, kami memodifikasi tipe konstruktor asli untuk menerima argumen _generic_.
 
 ```ts twoslash
 // Ini adalah konstruktor kita sebelumnya:
@@ -128,7 +128,7 @@ type Spritable = GConstructor<typeof Sprite>;
 type Loggable = GConstructor<{ print: () => void }>;
 ```
 
-Kemudian Anda dapat membuat mixin yang hanya berfungsi jika Anda memiliki basis tertentu untuk dibangun:
+Kemudian Anda dapat membuat _mixin_ yang hanya berfungsi jika Anda memiliki basis tertentu untuk dibangun:
 
 ```ts twoslash
 type GConstructor<T = {}> = new (...args: any[]) => T;
@@ -160,7 +160,7 @@ function Jumpable<TBase extends Positionable>(Base: TBase) {
 
 ## Pola Alternatif
 
-Versi sebelumnya dari dokumen ini merekomendasikan cara untuk menulis mixin di mana Anda membuat runtime dan hierarki tipe secara terpisah, lalu menggabungkannya di akhir:
+Versi sebelumnya dari dokumen ini merekomendasikan cara untuk menulis _mixin_ di mana Anda membuat runtime dan hierarki tipe secara terpisah, lalu menggabungkannya di akhir:
 
 ```ts twoslash
 // @strict: false
@@ -208,12 +208,12 @@ Pola ini tidak terlalu bergantung pada kompilator, dan lebih banyak pada basis k
 
 ## Kendala
 
-Pola mixin didukung secara native di dalam kompilator TypeScript oleh code flow analysis.
-Ada beberapa kasus di mana Anda dapat mencapai tepi dukungan native.
+Pola _mixin_ didukung secara native di dalam kompilator TypeScript oleh _code flow analysis_.
+Ada beberapa kasus di mana Anda dapat mencapai tepi dukungan _native_.
 
-#### Decorator dan Mixin [`#4881`](https://github.com/microsoft/TypeScript/issues/4881)
+#### _Decorator_ dan _Mixin_ [`#4881`](https://github.com/microsoft/TypeScript/issues/4881)
 
-Anda tidak bisa menggunakan decorator untuk menyediakan mixin melalui code flow analysis:
+Anda tidak bisa menggunakan decorator untuk menyediakan _mixin_ melalui _code flow analysis_:
 
 ```ts twoslash
 // @experimentalDecorators
@@ -243,9 +243,9 @@ const playerTwo = (new Player() as unknown) as FreezablePlayer;
 playerTwo.shouldFreeze;
 ```
 
-#### Static Property Mixins [`#17829`](https://github.com/microsoft/TypeScript/issues/17829)
+#### _Static Property Mixins_ [`#17829`](https://github.com/microsoft/TypeScript/issues/17829)
 
-Pola ekspresi kelas membuat singletons, jadi mereka tidak dapat dipetakan pada sistem tipe untuk mendukung tipe variabel yang berbeda.
+Pola ekspresi kelas membuat _singletons_, jadi mereka tidak dapat dipetakan pada sistem tipe untuk mendukung tipe variabel yang berbeda.
 
 Anda bisa mengatasinya dengan menggunakan fungsi untuk mengembalikan kelas Anda yang berbeda berdasarkan generik:
 

--- a/packages/documentation/copy/id/reference/Mixins.md
+++ b/packages/documentation/copy/id/reference/Mixins.md
@@ -1,0 +1,271 @@
+---
+title: Mixins
+layout: docs
+permalink: /id/docs/handbook/mixins.html
+oneline: Menggunakan pola mixin dengan TypeScript
+translatable: true
+---
+
+Bersamaan dengan hierarki OO tradisional, cara populer lainnya untuk membangun kelas dari komponen yang dapat digunakan kembali adalah membangunnya dengan menggabungkan kelas parsial yang lebih sederhana.
+Anda mungkin sudah familiar dengan ide mixin atau ciri untuk bahasa seperti Scala, dan polanya juga mendapatkan popularitas di komunitas JavaScript.
+
+## Bagaimana Cara Kerja Mixin?
+
+Pola ini bergantung pada penggunaan Generik dengan warisan kelas untuk memperluas kelas dasar.
+Dukungan mixin terbaik TypeScript dilakukan melalui pola ekspresi kelas.
+Anda dapat membaca lebih lanjut mengenai bagaimana pola ini bekerja di [Javscript disini](https://justinfagnani.com/2015/12/21/real-mixins-with-javascript-classes/).
+
+Untuk memulai, kita akan butuh kelas yang akan diterapkan mixin:
+
+```ts twoslash
+class Sprite {
+  name = "";
+  x = 0;
+  y = 0;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+}
+```
+
+Kemudian kamu butuh sebuah type dan sebuah fungsi factory yang mengembalikan sebuah ekspresi kelas untuk meng-extend kelas dasar.
+
+```ts twoslash
+// Untuk memulai, kita membutuhkan tipe yang akan kita gunakan untuk memperluas kelas lain.
+// Tanggung jawab utama adalah mendeklarasikan bahwa tipe yang diteruskan adalah sebuah kelas.
+
+type Constructor = new (...args: any[]) => {};
+
+// Mixin ini menambahkan property scale, dengan getter dan setter
+// untuk mengubahnya dengan properti private yang dienkapsulasi:
+
+function Scale<TBase extends Constructor>(Base: TBase) {
+  return class Scaling extends Base {
+    // Mixin mungkin tidak mendeklarasikan property private/protected
+    // namun, Anda dapat menggunakan field private ES2020
+    _scale = 1;
+
+    setScale(scale: number) {
+      this._scale = scale;
+    }
+
+    get scale(): number {
+      return this._scale;
+    }
+  };
+}
+```
+
+Setelah hal-hal diatas siap, Anda dapat membuat kelas yang mewakili kelas dasar dengan mixin yang diterapkan:
+
+```ts twoslash
+class Sprite {
+  name = "";
+  x = 0;
+  y = 0;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+}
+type Constructor = new (...args: any[]) => {};
+function Scale<TBase extends Constructor>(Base: TBase) {
+  return class Scaling extends Base {
+    // Mixin mungkin tidak mendeklarasikan property private/protected
+    // namun, Anda dapat menggunakan field private ES2020
+    _scale = 1;
+
+    setScale(scale: number) {
+      this._scale = scale;
+    }
+
+    get scale(): number {
+      return this._scale;
+    }
+  };
+}
+// ---potong---
+// Buat kelas baru dari kelas Sprite,
+// dengan Mixin Scale:
+const EightBitSprite = Scale(Sprite);
+
+const flappySprite = new EightBitSprite("Bird");
+flappySprite.setScale(0.8);
+console.log(flappySprite.scale);
+```
+
+## Mixin yang Dibatasi
+
+Dalam bentuk di atas, mixin tidak memiliki pengetahuan yang mendasari kelas yang dapat menyulitkan pembuatan desain yang diinginkan.
+
+Untuk memodelkan ini, kami memodifikasi tipe konstruktor asli untuk menerima argumen generic.
+
+```ts twoslash
+// Ini adalah konstruktor kita sebelumnya:
+type Constructor = new (...args: any[]) => {};
+// Sekarang kami menggunakan versi generik yang dapat menerapkan batasan
+// pada kelas tempat mixin ini diterapkan
+type GConstructor<T = {}> = new (...args: any[]) => T;
+```
+
+Ini memungkinkan untuk membuat kelas yang hanya bekerja dengan kelas dasar yang dibatasi:
+
+```ts twoslash
+type GConstructor<T = {}> = new (...args: any[]) => T;
+class Sprite {
+  name = "";
+  x = 0;
+  y = 0;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+}
+// ---potong---
+type Positionable = GConstructor<{ setPos: (x: number, y: number) => void }>;
+type Spritable = GConstructor<typeof Sprite>;
+type Loggable = GConstructor<{ print: () => void }>;
+```
+
+Kemudian Anda dapat membuat mixin yang hanya berfungsi jika Anda memiliki basis tertentu untuk dibangun:
+
+```ts twoslash
+type GConstructor<T = {}> = new (...args: any[]) => T;
+class Sprite {
+  name = "";
+  x = 0;
+  y = 0;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+}
+type Positionable = GConstructor<{ setPos: (x: number, y: number) => void }>;
+type Spritable = GConstructor<typeof Sprite>;
+type Loggable = GConstructor<{ print: () => void }>;
+// ---potong---
+
+function Jumpable<TBase extends Positionable>(Base: TBase) {
+  return class Jumpable extends Base {
+    jump() {
+      // Mixin ini hanya akan berfungsi jika itu melewati kelas dasar
+      // yang telah ditetapkan setPos
+      // karena kendala Positionable.
+      this.setPos(0, 20);
+    }
+  };
+}
+```
+
+## Pola Alternatif
+
+Versi sebelumnya dari dokumen ini merekomendasikan cara untuk menulis mixin di mana Anda membuat runtime dan hierarki type secara terpisah, lalu menggabungkannya di akhir:
+
+```ts twoslash
+// @strict: false
+// Setiap mixin adalah kelas ES tradisional
+class Jumpable {
+  jump() {}
+}
+
+class Duckable {
+  duck() {}
+}
+
+// Termasuk basisnya
+class Sprite {
+  x = 0;
+  y = 0;
+}
+
+// Kemudian Anda membuat antarmuka yang menggabungkan mixin
+// yang diharapkan dengan nama yang sama sebagai basis Anda
+interface Sprite extends Jumpable, Duckable {}
+// Terapkan mixin ke dalam kelas dasar melalui
+// JS saat runtime
+applyMixins(Sprite, [Jumpable, Duckable]);
+
+let player = new Sprite();
+player.jump();
+console.log(player.x, player.y);
+
+// Ini dapat hidup di mana saja di basis kode Anda:
+function applyMixins(derivedCtor: any, constructors: any[]) {
+  constructors.forEach((baseCtor) => {
+    Object.getOwnPropertyNames(baseCtor.prototype).forEach((name) => {
+      Object.defineProperty(
+        derivedCtor.prototype,
+        name,
+        Object.getOwnPropertyDescriptor(baseCtor.prototype, name)
+      );
+    });
+  });
+}
+```
+
+Pola ini tidak terlalu bergantung pada compiler, dan lebih banyak pada basis kode Anda untuk memastikan runtime dan sistem tipe tetap sinkron dengan benar.
+
+## Kendala
+
+Pola mixin didukung secara native di dalam compiler TypeScript oleh code flow analysis.
+Ada beberapa kasus di mana Anda dapat mencapai tepi dukungan native.
+
+#### Decorator dan Mixin [`#4881`](https://github.com/microsoft/TypeScript/issues/4881)
+
+Anda tidak bisa menggunakan decorator untuk menyediakan mixin melalui code flow analysis:
+
+```ts twoslash
+// @experimentalDecorators
+// @errors: 2339
+// Fungsi dekorator yang mereplikasi pola mixin:
+const Pausable = (target: typeof Player) => {
+  return class Pausable extends target {
+    shouldFreeze = false;
+  };
+};
+
+@Pausable
+class Player {
+  x = 0;
+  y = 0;
+}
+
+// Kelas Player tidak menggabungkan type dekorator:
+const player = new Player();
+player.shouldFreeze;
+
+// Aspek runtime ini dapat direplikasi secara manual
+// melalui komposisi tipe atau penggabungan interface.
+type FreezablePlayer = typeof Player & { shouldFreeze: boolean };
+
+const playerTwo = (new Player() as unknown) as FreezablePlayer;
+playerTwo.shouldFreeze;
+```
+
+#### Static Property Mixins [`#17829`](https://github.com/microsoft/TypeScript/issues/17829)
+
+Pola ekspresi kelas membuat singletons, jadi mereka tidak dapat dipetakan pada sistem type untuk mendukung tipe variabel yang berbeda.
+
+Anda bisa mengatasinya dengan menggunakan fungsi untuk mengembalikan kelas Anda yang berbeda berdasarkan generik:
+
+```ts twoslash
+function base<T>() {
+  class Base {
+    static prop: T;
+  }
+  return Base;
+}
+
+function derived<T>() {
+  class Derived extends base<T>() {
+    static anotherProp: T;
+  }
+  return Derived;
+}
+
+class Spec extends derived<string>() {}
+
+Spec.prop; // string
+Spec.anotherProp; // string
+```

--- a/packages/documentation/copy/id/reference/Symbols.md
+++ b/packages/documentation/copy/id/reference/Symbols.md
@@ -25,7 +25,7 @@ let sym3 = Symbol("key");
 sym2 === sym3; // false, symbol itu unik
 ```
 
-Sama seperti string, simbol dapat digunakan sebagai kunci untuk properti objek.
+Sama seperti _string_, simbol dapat digunakan sebagai kunci untuk properti objek.
 
 ```ts
 const sym = Symbol();
@@ -61,27 +61,27 @@ Berikut adalah daftar simbol yang terkenal:
 
 ## `Symbol.hasInstance`
 
-Sebuah method yang menentukan apakah objek konstruktor mengenali objek sebagai salah satu contoh konstruktor. Dipanggil oleh semantik dari operator instanceof.
+Sebuah method yang menentukan apakah objek konstruktor mengenali objek sebagai salah satu contoh konstruktor. Dipanggil oleh semantik dari operator _instanceof_.
 
 ## `Symbol.isConcatSpreadable`
 
-Nilai Boolean yang menunjukkan bahwa sebuah objek harus diratakan ke elemen arraynya dengan Array.prototype.concat.
+Nilai _Boolean_ yang menunjukkan bahwa sebuah objek harus diratakan ke elemen _array_-nya dengan Array.prototype.concat.
 
 ## `Symbol.iterator`
 
-Sebuah method yang mengembalikan iterator standar untuk sebuah objek. Dipanggil oleh semantik pada pernyataan for-of.
+Sebuah method yang mengembalikan _iterator_ standar untuk sebuah objek. Dipanggil oleh semantik pada pernyataan _for-of_.
 
 ## `Symbol.match`
 
-Metode ekspresi reguler yang mencocokkan ekspresi reguler dengan string. Dipanggil dengan method `String.prototype.match`.
+_Method_ ekspresi reguler yang mencocokkan ekspresi reguler dengan _string_. Dipanggil dengan _method_ `String.prototype.match`.
 
 ## `Symbol.replace`
 
-Method regular expression yang menggantikan substring yang cocok dari sebuah string. Dipanggil dengan method `String.prototype.replace`.
+_Method regular expression_ yang menggantikan substring yang cocok dari sebuah string. Dipanggil dengan method `String.prototype.replace`.
 
 ## `Symbol.search`
 
-Method regular expression yang mengembalikan indeks dalam string yang cocok dengan ekspresi reguler. Dipanggil dengan method `String.prototype.search`.
+_Method regular expression_ yang mengembalikan indeks dalam _string_ yang cocok dengan ekspresi reguler. Dipanggil dengan method `String.prototype.search`.
 
 ## `Symbol.species`
 
@@ -89,7 +89,7 @@ Properti bernilai fungsi yang merupakan fungsi konstruktor yang digunakan untuk 
 
 ## `Symbol.split`
 
-Method regular expression yang memisahkan string pada indeks yang cocok dengan ekspresi reguler.
+_Method regular expression_ yang memisahkan _string_ pada indeks yang cocok dengan ekspresi reguler.
 Dipanggil dengan method `String.prototype.split`.
 
 ## `Symbol.toPrimitive`

--- a/packages/documentation/copy/id/reference/Symbols.md
+++ b/packages/documentation/copy/id/reference/Symbols.md
@@ -25,7 +25,7 @@ let sym3 = Symbol("key");
 sym2 === sym3; // false, symbol itu unik
 ```
 
-Sama seperti string, simbol dapat digunakan sebagai kunci untuk property objek.
+Sama seperti string, simbol dapat digunakan sebagai kunci untuk properti objek.
 
 ```ts
 const sym = Symbol();
@@ -99,7 +99,7 @@ Dipanggil oleh operasi abstrak `ToPrimitive`.
 
 ## `Symbol.toStringTag`
 
-Nilai String yang digunakan dalam pembuatan deskripsi string default dari suatu objek.
+Nilai String yang digunakan dalam pembuatan deskripsi string bawaan dari suatu objek.
 Dipanggil oleh method bawaan `Object.prototype.toString`.
 
 ## `Symbol.unscopables`

--- a/packages/documentation/copy/id/reference/Symbols.md
+++ b/packages/documentation/copy/id/reference/Symbols.md
@@ -1,0 +1,107 @@
+---
+title: Symbols
+layout: docs
+permalink: /id/docs/handbook/symbols.html
+oneline: Menggunakan Simbol JavaScript primitif di TypeScript
+translatable: true
+---
+
+Mulai dari ECMAScript 2015, `symbol` adalah tipe data primitif, sama seperti `number` dan `string`.
+
+Nilai `simbol` dibuat dengan memanggil konstruktor `Symbol`.
+
+```ts
+let sym1 = Symbol();
+
+let sym2 = Symbol("key"); // kunci string opsional
+```
+
+Simbol tidak dapat diubah, dan unik.
+
+```ts
+let sym2 = Symbol("key");
+let sym3 = Symbol("key");
+
+sym2 === sym3; // false, symbol itu unik
+```
+
+Sama seperti string, simbol dapat digunakan sebagai kunci untuk property objek.
+
+```ts
+const sym = Symbol();
+
+let obj = {
+  [sym]: "value",
+};
+
+console.log(obj[sym]); // "value"
+```
+
+Simbol juga dapat digabungkan dengan deklarasi properti yang dihitung untuk mendeklarasikan properti objek dan anggota kelas.
+
+```ts
+const getClassNameSymbol = Symbol();
+
+class C {
+  [getClassNameSymbol]() {
+    return "C";
+  }
+}
+
+let c = new C();
+let className = c[getClassNameSymbol](); // "C"
+```
+
+## Simbol Terkenal
+
+Selain simbol yang ditentukan pengguna, ada simbol bawaan yang terkenal.
+Simbol bawaan digunakan untuk mewakili perilaku bahasa internal.
+
+Berikut adalah daftar simbol yang terkenal:
+
+## `Symbol.hasInstance`
+
+Sebuah method yang menentukan apakah objek konstruktor mengenali objek sebagai salah satu contoh konstruktor. Dipanggil oleh semantik dari operator instanceof.
+
+## `Symbol.isConcatSpreadable`
+
+Nilai Boolean yang menunjukkan bahwa sebuah objek harus diratakan ke elemen arraynya dengan Array.prototype.concat.
+
+## `Symbol.iterator`
+
+Sebuah method yang mengembalikan iterator standar untuk sebuah objek. Dipanggil oleh semantik pada pernyataan for-of.
+
+## `Symbol.match`
+
+Metode ekspresi reguler yang mencocokkan ekspresi reguler dengan string. Dipanggil dengan method `String.prototype.match`.
+
+## `Symbol.replace`
+
+Method regular expression yang menggantikan substring yang cocok dari sebuah string. Dipanggil dengan method `String.prototype.replace`.
+
+## `Symbol.search`
+
+Method regular expression yang mengembalikan indeks dalam string yang cocok dengan ekspresi reguler. Dipanggil dengan method `String.prototype.search`.
+
+## `Symbol.species`
+
+Properti bernilai fungsi yang merupakan fungsi konstruktor yang digunakan untuk membuat objek turunan.
+
+## `Symbol.split`
+
+Method regular expression yang memisahkan string pada indeks yang cocok dengan ekspresi reguler.
+Dipanggil dengan method `String.prototype.split`.
+
+## `Symbol.toPrimitive`
+
+Method yang mengonversi objek menjadi nilai primitif yang sesuai.
+Dipanggil oleh operasi abstrak `ToPrimitive`.
+
+## `Symbol.toStringTag`
+
+Nilai String yang digunakan dalam pembuatan deskripsi string default dari suatu objek.
+Dipanggil oleh method bawaan `Object.prototype.toString`.
+
+## `Symbol.unscopables`
+
+Objek yang nama propertinya adalah nama properti yang dikecualikan dari environment 'dengan' dari objek terkait.

--- a/packages/documentation/copy/id/tutorials/Babel with TypeScript.md
+++ b/packages/documentation/copy/id/tutorials/Babel with TypeScript.md
@@ -1,5 +1,5 @@
 ---
-title: Using Babel with TypeScript
+title: Menggunakan Babel dengan TypeScript
 layout: docs
 permalink: /id/docs/handbook/babel-with-typescript.html
 oneline: Cara membuat proyek hybrid Babel + TypeScript
@@ -15,23 +15,23 @@ Sering kali jawabannya adalah _"tergantung"_, atau _"seseorang mungkin telah mem
 Namun, heuristic yang berguna bisa jadi:
 
 - Apakah keluaran dari build-mu sebagian besar sama seperti file-file yang di-input-kan? Jika iya, maka gunakan `tsc`
-- Apakah anda butuh build pipeline dengan output yang memiliki beberapa potensi? Jika iya, maka gunakan `babel` untuk transpiling dan `tsc` untuk pemeriksaan type
+- Apakah anda butuh build pipeline dengan output yang memiliki beberapa potensi? Jika iya, maka gunakan `babel` untuk transpiling dan `tsc` untuk pemeriksaan tipe
 
-## Babel untuk transpiling, `tsc` untuk types
+## Babel untuk transpiling, `tsc` untuk tipe
 
 Ini adalah pola umum untuk proyek dengan infrastruktur build yang ada, yang mungkin telah ditransfer dari kode JavaScript ke TypeScript.
 
-Teknik ini adalah pendekatan hybrid, menggunakan [preset-typescript](https://babeljs.io/docs/en/babel-preset-typescript) Babel untuk menghasilkan file-file JS mu, dan kemudian menggunakan TypeScript untuk pemeriksaan type dan pembuatan file `.d.ts`
+Teknik ini adalah pendekatan hybrid, menggunakan [preset-typescript](https://babeljs.io/docs/en/babel-preset-typescript) Babel untuk menghasilkan file-file JS mu, dan kemudian menggunakan TypeScript untuk pemeriksaan tipe dan pembuatan file `.d.ts`
 
-Dengan menggunakan dukungan babel untuk TypeScript, anda mendapatkan kemampuan untuk bekerja pada pipeline build yang sudah ada dan lebih seperti memiliki JS yang lebih cepat, karena Babel tidak melakukan pemeriksaan type pada kodemu
+Dengan menggunakan dukungan babel untuk TypeScript, anda mendapatkan kemampuan untuk bekerja pada pipeline build yang sudah ada dan lebih seperti memiliki JS yang lebih cepat, karena Babel tidak melakukan pemeriksaan tipe pada kodemu
 
 #### Pemeriksaan Type dan menghasilkan file d.ts
 
-Kelemahan menggunakan babel adalah Anda tidak mendapatkan pemeriksaan type selama transisi dari TS ke JS. Ini berarti bahwa kesalahan type yang Anda lewatkan di editor-mu dapat menyusup ke dalam kode saat fase produksi.
+Kelemahan menggunakan babel adalah Anda tidak mendapatkan pemeriksaan tipe selama transisi dari TS ke JS. Ini berarti bahwa kesalahan tipe yang Anda lewatkan di editor-mu dapat menyusup ke dalam kode saat fase produksi.
 
 Selain itu, Babel tidak dapat membuat file `.d.ts` untuk TypeScript-mu yang dapat mempersulit pengerjaan proyekmu jika itu adalah sebuah pustaka.
 
-Untuk mengatasi hal tersebut, Anda perlu melakukan set up perintah untuk memeriksa type pada proyekmu menggunakan TSC. Ini seperti menduplikasi beberapa konfigurasi babel menjadi sesuai dengan `tsconfig.json`](/tconfig) dan memastikan bahwa flag-flag ini aktif:
+Untuk mengatasi hal tersebut, Anda perlu melakukan set up perintah untuk memeriksa tipe pada proyekmu menggunakan TSC. Ini seperti menduplikasi beberapa konfigurasi babel menjadi sesuai dengan `tsconfig.json`](/tconfig) dan memastikan bahwa flag-flag ini aktif:
 
 ```json tsconfig
 "compilerOptions": {

--- a/packages/documentation/copy/id/tutorials/Babel with TypeScript.md
+++ b/packages/documentation/copy/id/tutorials/Babel with TypeScript.md
@@ -8,42 +8,42 @@ translatable: true
 
 ## Babel vs `tsc` untuk TypeScript
 
-Ketika membuat proyek JavaScript modern, anda mungkin bertanya pada dirimu sendiri, apa cara yang benar untuk mengkonversi file-file dari TypeScript ke JavaScript.
+Ketika membuat proyek JavaScript modern, anda mungkin bertanya pada dirimu sendiri, apa cara yang benar untuk mengkonversi berkas-berkas dari TypeScript ke JavaScript.
 
-Sering kali jawabannya adalah _"tergantung"_, atau _"seseorang mungkin telah memutuskan untukmu"_ bergantung pada proyeknya. Jika anda membangun proyekmu dengan framework yang sudah ada, seperti [tsdx](https://tsdx.io), [Angular](https://angular.io/), [NestJS](https://nestjs.com/) atau framework apapun yang disebutkan di [Getting Started](/docs/home).
+Sering kali jawabannya adalah _"tergantung"_, atau _"seseorang mungkin telah memutuskan untukmu"_ bergantung pada proyeknya. Jika anda membangun proyekmu dengan _framework_ yang sudah ada, seperti [tsdx](https://tsdx.io), [Angular](https://angular.io/), [NestJS](https://nestjs.com/) atau _framework_ apapun yang disebutkan di [_Getting Started_](/docs/home).
 
-Namun, heuristic yang berguna bisa jadi:
+Namun, _heuristic_ yang berguna bisa jadi:
 
-- Apakah keluaran dari build-mu sebagian besar sama seperti file-file yang di-input-kan? Jika iya, maka gunakan `tsc`
-- Apakah anda butuh build pipeline dengan output yang memiliki beberapa potensi? Jika iya, maka gunakan `babel` untuk transpiling dan `tsc` untuk pemeriksaan tipe
+- Apakah keluaran dari _build_-mu sebagian besar sama seperti berkas-berkas yang di-_input_-kan? Jika iya, maka gunakan `tsc`
+- Apakah anda butuh build pipeline dengan output yang memiliki beberapa potensi? Jika iya, maka gunakan `babel` untuk _transpiling_ dan `tsc` untuk pemeriksaan tipe
 
 ## Babel untuk transpiling, `tsc` untuk tipe
 
 Ini adalah pola umum untuk proyek dengan infrastruktur build yang ada, yang mungkin telah ditransfer dari kode JavaScript ke TypeScript.
 
-Teknik ini adalah pendekatan hybrid, menggunakan [preset-typescript](https://babeljs.io/docs/en/babel-preset-typescript) Babel untuk menghasilkan file-file JS mu, dan kemudian menggunakan TypeScript untuk pemeriksaan tipe dan pembuatan file `.d.ts`
+Teknik ini adalah pendekatan _hybrid_, menggunakan [preset-typescript](https://babeljs.io/docs/en/babel-preset-typescript) Babel untuk menghasilkan berkas-berkas JS mu, dan kemudian menggunakan TypeScript untuk pemeriksaan tipe dan pembuatan berkas `.d.ts`
 
-Dengan menggunakan dukungan babel untuk TypeScript, anda mendapatkan kemampuan untuk bekerja pada pipeline build yang sudah ada dan lebih seperti memiliki JS yang lebih cepat, karena Babel tidak melakukan pemeriksaan tipe pada kodemu
+Dengan menggunakan dukungan Babel untuk TypeScript, anda mendapatkan kemampuan untuk bekerja pada _pipeline build_ yang sudah ada dan lebih seperti memiliki JS yang lebih cepat, karena Babel tidak melakukan pemeriksaan tipe pada kodemu
 
-#### Pemeriksaan Type dan menghasilkan file d.ts
+#### Pemeriksaan Tipe dan menghasilkan berkas d.ts
 
-Kelemahan menggunakan babel adalah Anda tidak mendapatkan pemeriksaan tipe selama transisi dari TS ke JS. Ini berarti bahwa kesalahan tipe yang Anda lewatkan di editor-mu dapat menyusup ke dalam kode saat fase produksi.
+Kelemahan menggunakan Babel adalah Anda tidak mendapatkan pemeriksaan tipe selama transisi dari TS ke JS. Ini berarti bahwa kesalahan tipe yang Anda lewatkan di editor-mu dapat menyusup ke dalam kode saat fase produksi.
 
-Selain itu, Babel tidak dapat membuat file `.d.ts` untuk TypeScript-mu yang dapat mempersulit pengerjaan proyekmu jika itu adalah sebuah pustaka.
+Selain itu, Babel tidak dapat membuat berkas `.d.ts` untuk TypeScript-mu yang dapat mempersulit pengerjaan proyekmu jika itu adalah sebuah pustaka.
 
-Untuk mengatasi hal tersebut, Anda perlu melakukan set up perintah untuk memeriksa tipe pada proyekmu menggunakan TSC. Ini seperti menduplikasi beberapa konfigurasi babel menjadi sesuai dengan `tsconfig.json`](/tconfig) dan memastikan bahwa flag-flag ini aktif:
+Untuk mengatasi hal tersebut, Anda perlu melakukan set up perintah untuk memeriksa tipe pada proyekmu menggunakan TSC. Ini seperti menduplikasi beberapa konfigurasi babel menjadi sesuai dengan `tsconfig.json`](/tconfig) dan memastikan bahwa _flags_ ini aktif:
 
 ```json tsconfig
 "compilerOptions": {
-  // Memastikan bahwa file-file .d.ts dibuat oleh tsc, bukan file .js
+  // Memastikan bahwa berkas-berkas .d.ts dibuat oleh tsc, bukan berkas .js
   "declaration": true,
   "emitDeclarationOnly": true,
-  // Memastikan bahwa Babel secara aman dapat men-transpile file-file di proyek TypeScript
+  // Memastikan bahwa Babel secara aman dapat men-transpile berkas-berkas di proyek TypeScript
   "isolatedModules": true
 }
 ```
 
-Informasi lebih lanjut mengenai flag-flag tersebut:
+Informasi lebih lanjut mengenai _flags_ tersebut:
 
 - [`isolatedModules`](/tsconfig#isolatedModules)
 - [`declaration`](/tsconfig#declaration), [`emitDeclarationOnly`](/tsconfig#emitDeclarationOnly)

--- a/packages/documentation/copy/id/tutorials/Babel with TypeScript.md
+++ b/packages/documentation/copy/id/tutorials/Babel with TypeScript.md
@@ -1,0 +1,49 @@
+---
+title: Using Babel with TypeScript
+layout: docs
+permalink: /id/docs/handbook/babel-with-typescript.html
+oneline: Cara membuat proyek hybrid Babel + TypeScript
+translatable: true
+---
+
+## Babel vs `tsc` untuk TypeScript
+
+Ketika membuat proyek JavaScript modern, anda mungkin bertanya pada dirimu sendiri, apa cara yang benar untuk mengkonversi file-file dari TypeScript ke JavaScript.
+
+Sering kali jawabannya adalah _"tergantung"_, atau _"seseorang mungkin telah memutuskan untukmu"_ bergantung pada proyeknya. Jika anda membangun proyekmu dengan framework yang sudah ada, seperti [tsdx](https://tsdx.io), [Angular](https://angular.io/), [NestJS](https://nestjs.com/) atau framework apapun yang disebutkan di [Getting Started](/docs/home).
+
+Namun, heuristic yang berguna bisa jadi:
+
+- Apakah keluaran dari build-mu sebagian besar sama seperti file-file yang di-input-kan? Jika iya, maka gunakan `tsc`
+- Apakah anda butuh build pipeline dengan output yang memiliki beberapa potensi? Jika iya, maka gunakan `babel` untuk transpiling dan `tsc` untuk pemeriksaan type
+
+## Babel untuk transpiling, `tsc` untuk types
+
+Ini adalah pola umum untuk proyek dengan infrastruktur build yang ada, yang mungkin telah ditransfer dari kode JavaScript ke TypeScript.
+
+Teknik ini adalah pendekatan hybrid, menggunakan [preset-typescript](https://babeljs.io/docs/en/babel-preset-typescript) Babel untuk menghasilkan file-file JS mu, dan kemudian menggunakan TypeScript untuk pemeriksaan type dan pembuatan file `.d.ts`
+
+Dengan menggunakan dukungan babel untuk TypeScript, anda mendapatkan kemampuan untuk bekerja pada pipeline build yang sudah ada dan lebih seperti memiliki JS yang lebih cepat, karena Babel tidak melakukan pemeriksaan type pada kodemu
+
+#### Pemeriksaan Type dan menghasilkan file d.ts
+
+Kelemahan menggunakan babel adalah Anda tidak mendapatkan pemeriksaan type selama transisi dari TS ke JS. Ini berarti bahwa kesalahan type yang Anda lewatkan di editor-mu dapat menyusup ke dalam kode saat fase produksi.
+
+Selain itu, Babel tidak dapat membuat file `.d.ts` untuk TypeScript-mu yang dapat mempersulit pengerjaan proyekmu jika itu adalah sebuah pustaka.
+
+Untuk mengatasi hal tersebut, Anda perlu melakukan set up perintah untuk memeriksa type pada proyekmu menggunakan TSC. Ini seperti menduplikasi beberapa konfigurasi babel menjadi sesuai dengan `tsconfig.json`](/tconfig) dan memastikan bahwa flag-flag ini aktif:
+
+```json tsconfig
+"compilerOptions": {
+  // Memastikan bahwa file-file .d.ts dibuat oleh tsc, bukan file .js
+  "declaration": true,
+  "emitDeclarationOnly": true,
+  // Memastikan bahwa Babel secara aman dapat men-transpile file-file di proyek TypeScript
+  "isolatedModules": true
+}
+```
+
+Informasi lebih lanjut mengenai flag-flag tersebut:
+
+- [`isolatedModules`](/tsconfig#isolatedModules)
+- [`declaration`](/tsconfig#declaration), [`emitDeclarationOnly`](/tsconfig#emitDeclarationOnly)

--- a/packages/documentation/copy/id/tutorials/DOM Manipulation.md
+++ b/packages/documentation/copy/id/tutorials/DOM Manipulation.md
@@ -1,0 +1,201 @@
+---
+title: DOM Manipulation
+layout: docs
+permalink: /id/docs/handbook/dom-manipulation.html
+oneline: Menggunakan DOM dengan TypeScript
+translatable: true
+---
+
+## Manipulasi DOM
+
+### _Eksplorasi ke dalam type `HTMLElement`_
+
+Dalam 20+ tahun sejak standarisasi, JavaScript telah berkembang pesat. Meskipun pada tahun 2020, JavaScript dapat digunakan di server, dalam ilmu data, dan bahkan pada perangkat IoT, penting untuk mengingat kasus penggunaannya yang paling populer: web browser.
+
+Situs web terdiri dari dokumen HTML dan/atau XML. Dokumen-dokumen ini statis, tidak berubah. _Document Object Model (DOM)_ adalah antarmuka pemrograman yang diterapkan oleh browser untuk membuat situs web statis berfungsi. API DOM dapat digunakan untuk mengubah struktur dokumen, style, dan konten. API ini sangat kuat sehingga framework frontend yang tak terhitung jumlahnya (jQuery, React, Angular, dll.) telah dikembangkan di sekitarnya untuk membuat situs web dinamis lebih mudah dikembangkan.
+
+TypeScript adalah superset dari JavaScript, dan TypeScript dilengkapi dengan definisi tipe untuk DOM API. Secara standar, definisi ini sudah tersedia dalam proyek TypeScript. Dari 20.000+ baris definisi di _lib.dom.d.ts_, satu yang menonjol di antara yang lain: `HTMLElement`. Jenis ini adalah hal penting untuk manipulasi DOM dengan TypeScript.
+
+> Anda bisa mengeksplor source code [Definisi tipe DOM](https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts)
+
+## Contoh Dasar
+
+Diberikan file _index.html_ yang disederhanakan:
+
+    <!DOCTYPE html>
+    <html lang="en">
+      <head><title>TypeScript Dom Manipulation</title></head>
+      <body>
+        <div id="app"></div>
+        <!-- Assume index.js is the compiled output of index.ts -->
+        <script src="index.js"></script>
+      </body>
+    </html>
+
+Mari kita jelajahi skrip TypeScript yang menambahkan elemen `<p> Hello, World </p>` ke elemen `#app`.
+
+```ts
+// 1. Pilih elemen div menggunakan property id
+const app = document.getElementById("app");
+
+// 2. Buat element <p></p> baru secara terprogram
+const p = document.createElement("p");
+
+// 3. Tambahkan konten teks
+p.textContent = "Hello, World!";
+
+// 4. Tambahkan elemen p ke elemen div
+app?.appendChild(p);
+```
+
+Setelah menyusun dan menjalankan halaman _index.html_, HTML yang dihasilkan adalah:
+
+```html
+<div id="app">
+  <p>Hello, World!</p>
+</div>
+```
+
+## Antarmuka `Document`
+
+Baris pertama kode TypeScript menggunakan variabel global `document`. Memeriksa variabel menunjukkan bahwa ia didefinisikan oleh antarmuka `Dokumen` dari file _lib.dom.d.ts_. Cuplikan kode berisi panggilan ke dua metode, `getElementById` dan `createElement`.
+
+### `Document.getElementById`
+
+Definisi dari metode ini adalah sebagai berikut:
+
+```ts
+getElementById(elementId: string): HTMLElement | null;
+```
+
+Berikan string id elemen dan itu akan mengembalikan `HTMLElement` atau`null`. Metode ini memperkenalkan salah satu jenis terpenting, `HTMLElement`. Ini berfungsi sebagai antarmuka dasar untuk setiap antarmuka elemen lainnya. Misalnya, variabel `p` dalam contoh kode berjenis `HTMLParagraphElement`. Perhatikan juga bahwa metode ini dapat mengembalikan `null`. Ini karena metode tidak dapat memastikan kapan elemen itu tersedia atau apakah elemen tersebut ada atau tidak. Di baris terakhir cuplikan kode, operator _optional chaining_ digunakan untuk memanggil `appendChild`.
+
+### `Document.createElement`
+
+Definisi untuk metode ini adalah (definisi _deprecated_ telah dihilangkan):
+
+```ts
+createElement<K extends keyof HTMLElementTagNameMap>(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K];
+createElement(tagName: string, options?: ElementCreationOptions): HTMLElement;
+```
+
+Ini adalah definisi fungsi yang kelebihan beban. Kelebihan kedua adalah yang paling sederhana dan bekerja sangat mirip dengan method `getElementById`. Berikan setiap `string` dan ia akan mengembalikan standar HTMLElement. Definisi inilah yang memungkinkan developer membuat tag elemen HTML yang unik.
+
+Misalnya `document.createElement('xyz')` mengembalikan elemen `<xyz></xyz>`, jelas bukan elemen yang ditentukan oleh spesifikasi HTML.
+
+> Jika tertarik, Anda dapat berinteraksi dengan elemen tag kustom menggunakan `document.getElementsByTagName`
+
+Untuk definisi pertama dari `createElement`, ini menggunakan beberapa pola umum lanjutan. Paling baik dipahami jika dipecah menjadi beberapa bagian, dimulai dengan ekspresi umum: `<K extends keyof HTMLElementTagNameMap>`. Ekspresi ini mendefinisikan parameter umum `K` yang _constrained_ ke kunci antarmuka`HTMLElementTagNameMap`. Antarmuka peta berisi setiap nama tag HTML yang ditentukan dan antarmuka tipe yang sesuai. Berikut adalah 5 nilai yang dipetakan pertama:
+
+```ts
+interface HTMLElementTagNameMap {
+    "a": HTMLAnchorElement;
+    "abbr": HTMLElement;
+    "address": HTMLElement;
+    "applet": HTMLAppletElement;
+    "area": HTMLAreaElement;
+        ...
+}
+```
+
+Beberapa elemen tidak menunjukkan properti unik sehingga mereka hanya mengembalikan `HTMLElement`, tetapi tipe lain memiliki property dan method unik sehingga mereka mengembalikan antarmuka spesifiknya (yang akan memperluas atau mengimplementasikan `HTMLElement`).
+
+Sekarang, untuk sisa definisi `createElement`:`(tagName: K, options ?: ElementCreationOptions): HTMLElementTagNameMap [K]`. Argumen pertama `tagName` didefinisikan sebagai parameter umum `K`. Interpreter TypeScript cukup pintar untuk _infer_ parameter generik dari argumen ini. Ini berarti bahwa pengembang sebenarnya tidak harus menentukan parameter umum saat menggunakan metode ini; nilai apa pun yang diteruskan ke argumen `tagName` akan disimpulkan sebagai `K` dan karenanya dapat digunakan di seluruh definisi lainnya. Itulah yang sebenarnya terjadi; nilai kembalian `HTMLElementTagNameMap [K]` mengambil argumen `tagName` dan menggunakannya untuk mengembalikan jenis yang sesuai. Definisi ini adalah bagaimana variabel `p` dari kode sebelumnya mendapatkan jenis `HTMLParagraphElement`. Dan jika kodenya adalah `document.createElement ('a')`, maka itu akan menjadi elemen jenis `HTMLAnchorElement`.
+
+## Antarmuka `Node`
+
+Fungsi `document.getElementById` mengembalikan `HTMLElement`. Antarmuka `HTMLElement` memperluas antarmuka `Element`, yang memperluas antarmuka `Node`. Ekstensi prototipe ini memungkinkan semua `HTMLElements` untuk menggunakan subset method standar. Dalam cuplikan kode, kami menggunakan properti yang ditentukan pada antarmuka `Node` untuk menambahkan elemen`p` baru ke situs web.
+
+### `Node.appendChild`
+
+Baris terakhir dari potongan kode adalah `app?.AppendChild (p)`. Bagian sebelumnya, `document.getElementById`, merinci bahwa operator _optional chaining_ digunakan di sini karena `app` berpotensi menjadi null pada waktu proses. Method `appendChild` didefinisikan oleh:
+
+```ts
+appendChild<T extends Node>(newChild: T): T;
+```
+
+Method ini bekerja mirip dengan metode `createElement` karena parameter umum `T` disimpulkan dari argumen `newChild`. `T` adalah _constrained_ ke antarmuka dasar lain`Node`.
+
+## Perbedaan antara `children` dan `childNodes`
+
+Sebelumnya, dokumen ini merinci antarmuka `HTMLElement` yang diperluas dari `Element` yang diturunkan dari `Node`. Di DOM API ada konsep elemen _children_. Misalnya dalam HTML berikut, tag `p` adalah turunan dari elemen `div`
+
+```tsx
+<div>
+  <p>Hello, World</p>
+  <p>TypeScript!</p>
+</div>;
+
+const div = document.getElementsByTagName("div")[0];
+
+div.children;
+// HTMLCollection(2) [p, p]
+
+div.childNodes;
+// NodeList(2) [p, p]
+```
+
+Setelah menangkap elemen `div`, prop `children` akan mengembalikan daftar `HTMLCollection` yang berisi `HTMLParagraphElements`. Property `childNodes` akan mengembalikan daftar node `NodeList` yang serupa. Setiap tag `p` akan tetap berjenis `HTMLParagraphElements`, tetapi `NodeList` dapat berisi _HTML node_ tambahan yang tidak bisa dilakukan oleh list `HTMLCollection`.
+
+Ubah html dengan menghapus salah satu tag `p`, tetapi pertahankan teksnya.
+
+```tsx
+<div>
+  <p>Hello, World</p>
+  TypeScript!
+</div>;
+
+const div = document.getElementsByTagName("div")[0];
+
+div.children;
+// HTMLCollection(1) [p]
+
+div.childNodes;
+// NodeList(2) [p, text]
+```
+
+Lihat bagaimana kedua daftar berubah. `children` sekarang hanya berisi elemen `<p>Hello, World</p>`, dan `childNodes` berisi simpul `teks` daripada dua simpul `p`. Bagian `teks` dari `NodeList` adalah `Node` literal yang berisi teks `TypeScript!`. List `children` tidak berisi `Node`, ini karena tidak dianggap sebagai `HTMLElement`.
+
+## Method `querySelector` dan `querySelectorAll`
+
+Kedua method ini adalah tool yang hebat untuk mendapatkan daftar elemen dom yang sesuai dengan kumpulan constraint yang lebih unik. Mereka didefinisikan di _lib.dom.d.ts_ sebagai:
+
+```ts
+/**
+ * Mengembalikan elemen pertama yang merupakan turunan dari node yang cocok dengan selector.
+ */
+querySelector<K extends keyof HTMLElementTagNameMap>(selectors: K): HTMLElementTagNameMap[K] | null;
+querySelector<K extends keyof SVGElementTagNameMap>(selectors: K): SVGElementTagNameMap[K] | null;
+querySelector<E extends Element = Element>(selectors: string): E | null;
+
+/**
+ * Menampilkan semua turunan elemen node yang cocok dengan selector.
+ */
+querySelectorAll<K extends keyof HTMLElementTagNameMap>(selectors: K): NodeListOf<HTMLElementTagNameMap[K]>;
+querySelectorAll<K extends keyof SVGElementTagNameMap>(selectors: K): NodeListOf<SVGElementTagNameMap[K]>;
+querySelectorAll<E extends Element = Element>(selectors: string): NodeListOf<E>;
+```
+
+Definisi `querySelectorAll` mirip dengan `getElementsByTagName`, kecuali ia mengembalikan tipe baru: `NodeListOf`. Jenis kembalian ini pada dasarnya adalah implementasi khusus dari elemen daftar standar JavaScript. Bisa dibilang, mengganti `NodeListOf<E>` dengan `E[]` akan menghasilkan pengalaman pengguna yang sangat mirip. `NodeListOf` hanya mengimplementasikan property dan method berikut:`length`, `item (index)`,`forEach ((value, key, parent) => void)`, dan numeric indexing. Selain itu, metode ini mengembalikan daftar _elements_, bukan _nodes_, yang dikembalikan oleh `NodeList` dari method `.childNodes`. Meskipun ini mungkin tampak sebagai perbedaan, perhatikan bahwa antarmuka `Element` merupakan turunan dari `Node`.
+
+Untuk melihat method ini beraksi, ubah kode yang ada menjadi:
+
+```tsx
+<ul>
+  <li>First :)</li>
+  <li>Second!</li>
+  <li>Third times a charm.</li>
+</ul>;
+
+const first = document.querySelector("li"); // mengembalikan elemen li pertama
+const all = document.querySelectorAll("li"); // mengembalikan daftar semua elemen li
+```
+
+## Tertarik untuk mempelajari lebih lanjut?
+
+Bagian terbaik tentang definisi type _lib.dom.d.ts_ adalah bahwa definisi tersebut mencerminkan type yang dijelaskan di situs dokumentasi Mozilla Developer Network (MDN). Misalnya, antarmuka `HTMLElement` didokumentasikan oleh [halaman HTMLElement](https://developer.mozilla.org/docs/Web/API/HTMLElement) di MDN. Halaman ini mencantumkan semua property yang tersedia, method, dan terkadang bahkan contoh. Aspek hebat lainnya dari halaman-halaman tersebut adalah mereka menyediakan tautan ke dokumen standar yang sesuai. Berikut ini tautan ke [Rekomendasi W3C untuk HTMLElement](https://www.w3.org/TR/html52/dom.html#htmlelement).
+
+Sumber:
+
+- [ECMA-262 Standard](http://www.ecma-international.org/ecma-262/10.0/index.html)
+- [Introduction to the DOM](https://developer.mozilla.org/docs/Web/API/Document_Object_Model/Introduction)

--- a/packages/documentation/copy/id/tutorials/DOM Manipulation.md
+++ b/packages/documentation/copy/id/tutorials/DOM Manipulation.md
@@ -1,5 +1,5 @@
 ---
-title: DOM Manipulation
+title: Manipulasi DOM
 layout: docs
 permalink: /id/docs/handbook/dom-manipulation.html
 oneline: Menggunakan DOM dengan TypeScript
@@ -8,7 +8,7 @@ translatable: true
 
 ## Manipulasi DOM
 
-### _Eksplorasi ke dalam type `HTMLElement`_
+### _Eksplorasi ke dalam tipe `HTMLElement`_
 
 Dalam 20+ tahun sejak standarisasi, JavaScript telah berkembang pesat. Meskipun pada tahun 2020, JavaScript dapat digunakan di server, dalam ilmu data, dan bahkan pada perangkat IoT, penting untuk mengingat kasus penggunaannya yang paling populer: web browser.
 
@@ -35,7 +35,7 @@ Diberikan file _index.html_ yang disederhanakan:
 Mari kita jelajahi skrip TypeScript yang menambahkan elemen `<p> Hello, World </p>` ke elemen `#app`.
 
 ```ts
-// 1. Pilih elemen div menggunakan property id
+// 1. Pilih elemen div menggunakan properti id
 const app = document.getElementById("app");
 
 // 2. Buat element <p></p> baru secara terprogram
@@ -98,7 +98,7 @@ interface HTMLElementTagNameMap {
 }
 ```
 
-Beberapa elemen tidak menunjukkan properti unik sehingga mereka hanya mengembalikan `HTMLElement`, tetapi tipe lain memiliki property dan method unik sehingga mereka mengembalikan antarmuka spesifiknya (yang akan memperluas atau mengimplementasikan `HTMLElement`).
+Beberapa elemen tidak menunjukkan properti unik sehingga mereka hanya mengembalikan `HTMLElement`, tetapi tipe lain memiliki properti dan method unik sehingga mereka mengembalikan antarmuka spesifiknya (yang akan memperluas atau mengimplementasikan `HTMLElement`).
 
 Sekarang, untuk sisa definisi `createElement`:`(tagName: K, options ?: ElementCreationOptions): HTMLElementTagNameMap [K]`. Argumen pertama `tagName` didefinisikan sebagai parameter umum `K`. Interpreter TypeScript cukup pintar untuk _infer_ parameter generik dari argumen ini. Ini berarti bahwa pengembang sebenarnya tidak harus menentukan parameter umum saat menggunakan metode ini; nilai apa pun yang diteruskan ke argumen `tagName` akan disimpulkan sebagai `K` dan karenanya dapat digunakan di seluruh definisi lainnya. Itulah yang sebenarnya terjadi; nilai kembalian `HTMLElementTagNameMap [K]` mengambil argumen `tagName` dan menggunakannya untuk mengembalikan jenis yang sesuai. Definisi ini adalah bagaimana variabel `p` dari kode sebelumnya mendapatkan jenis `HTMLParagraphElement`. Dan jika kodenya adalah `document.createElement ('a')`, maka itu akan menjadi elemen jenis `HTMLAnchorElement`.
 
@@ -176,7 +176,7 @@ querySelectorAll<K extends keyof SVGElementTagNameMap>(selectors: K): NodeListOf
 querySelectorAll<E extends Element = Element>(selectors: string): NodeListOf<E>;
 ```
 
-Definisi `querySelectorAll` mirip dengan `getElementsByTagName`, kecuali ia mengembalikan tipe baru: `NodeListOf`. Jenis kembalian ini pada dasarnya adalah implementasi khusus dari elemen daftar standar JavaScript. Bisa dibilang, mengganti `NodeListOf<E>` dengan `E[]` akan menghasilkan pengalaman pengguna yang sangat mirip. `NodeListOf` hanya mengimplementasikan property dan method berikut:`length`, `item (index)`,`forEach ((value, key, parent) => void)`, dan numeric indexing. Selain itu, metode ini mengembalikan daftar _elements_, bukan _nodes_, yang dikembalikan oleh `NodeList` dari method `.childNodes`. Meskipun ini mungkin tampak sebagai perbedaan, perhatikan bahwa antarmuka `Element` merupakan turunan dari `Node`.
+Definisi `querySelectorAll` mirip dengan `getElementsByTagName`, kecuali ia mengembalikan tipe baru: `NodeListOf`. Jenis kembalian ini pada dasarnya adalah implementasi khusus dari elemen daftar standar JavaScript. Bisa dibilang, mengganti `NodeListOf<E>` dengan `E[]` akan menghasilkan pengalaman pengguna yang sangat mirip. `NodeListOf` hanya mengimplementasikan properti dan method berikut:`length`, `item (index)`,`forEach ((value, key, parent) => void)`, dan numeric indexing. Selain itu, metode ini mengembalikan daftar _elements_, bukan _nodes_, yang dikembalikan oleh `NodeList` dari method `.childNodes`. Meskipun ini mungkin tampak sebagai perbedaan, perhatikan bahwa antarmuka `Element` merupakan turunan dari `Node`.
 
 Untuk melihat method ini beraksi, ubah kode yang ada menjadi:
 
@@ -193,7 +193,7 @@ const all = document.querySelectorAll("li"); // mengembalikan daftar semua eleme
 
 ## Tertarik untuk mempelajari lebih lanjut?
 
-Bagian terbaik tentang definisi type _lib.dom.d.ts_ adalah bahwa definisi tersebut mencerminkan type yang dijelaskan di situs dokumentasi Mozilla Developer Network (MDN). Misalnya, antarmuka `HTMLElement` didokumentasikan oleh [halaman HTMLElement](https://developer.mozilla.org/docs/Web/API/HTMLElement) di MDN. Halaman ini mencantumkan semua property yang tersedia, method, dan terkadang bahkan contoh. Aspek hebat lainnya dari halaman-halaman tersebut adalah mereka menyediakan tautan ke dokumen standar yang sesuai. Berikut ini tautan ke [Rekomendasi W3C untuk HTMLElement](https://www.w3.org/TR/html52/dom.html#htmlelement).
+Bagian terbaik tentang definisi tipe _lib.dom.d.ts_ adalah bahwa definisi tersebut mencerminkan tipe yang dijelaskan di situs dokumentasi Mozilla Developer Network (MDN). Misalnya, antarmuka `HTMLElement` didokumentasikan oleh [halaman HTMLElement](https://developer.mozilla.org/docs/Web/API/HTMLElement) di MDN. Halaman ini mencantumkan semua properti yang tersedia, method, dan terkadang bahkan contoh. Aspek hebat lainnya dari halaman-halaman tersebut adalah mereka menyediakan tautan ke dokumen standar yang sesuai. Berikut ini tautan ke [Rekomendasi W3C untuk HTMLElement](https://www.w3.org/TR/html52/dom.html#htmlelement).
 
 Sumber:
 

--- a/packages/documentation/copy/id/tutorials/DOM Manipulation.md
+++ b/packages/documentation/copy/id/tutorials/DOM Manipulation.md
@@ -8,19 +8,19 @@ translatable: true
 
 ## Manipulasi DOM
 
-### _Eksplorasi ke dalam tipe `HTMLElement`_
+### Eksplorasi ke dalam tipe `HTMLElement`
 
-Dalam 20+ tahun sejak standarisasi, JavaScript telah berkembang pesat. Meskipun pada tahun 2020, JavaScript dapat digunakan di server, dalam ilmu data, dan bahkan pada perangkat IoT, penting untuk mengingat kasus penggunaannya yang paling populer: web browser.
+Dalam 20+ tahun sejak standarisasi, JavaScript telah berkembang pesat. Meskipun pada tahun 2020, JavaScript dapat digunakan di _server_, dalam ilmu data, dan bahkan pada perangkat _IoT_, penting untuk mengingat kasus penggunaannya yang paling populer: _web browser_.
 
-Situs web terdiri dari dokumen HTML dan/atau XML. Dokumen-dokumen ini statis, tidak berubah. _Document Object Model (DOM)_ adalah antarmuka pemrograman yang diterapkan oleh browser untuk membuat situs web statis berfungsi. API DOM dapat digunakan untuk mengubah struktur dokumen, style, dan konten. API ini sangat kuat sehingga framework frontend yang tak terhitung jumlahnya (jQuery, React, Angular, dll.) telah dikembangkan di sekitarnya untuk membuat situs web dinamis lebih mudah dikembangkan.
+Situs _web_ terdiri dari dokumen HTML dan/atau XML. Dokumen-dokumen ini statis, tidak berubah. _Document Object Model (DOM)_ adalah antarmuka pemrograman yang diterapkan oleh _browser_ untuk membuat situs _web_ statis berfungsi. API DOM dapat digunakan untuk mengubah struktur dokumen, _style_, dan konten. API ini sangat kuat sehingga _framework frontend_ yang tak terhitung jumlahnya (jQuery, React, Angular, dll.) telah dikembangkan di sekitarnya untuk membuat situs _web_ dinamis lebih mudah dikembangkan.
 
-TypeScript adalah superset dari JavaScript, dan TypeScript dilengkapi dengan definisi tipe untuk DOM API. Secara standar, definisi ini sudah tersedia dalam proyek TypeScript. Dari 20.000+ baris definisi di _lib.dom.d.ts_, satu yang menonjol di antara yang lain: `HTMLElement`. Jenis ini adalah hal penting untuk manipulasi DOM dengan TypeScript.
+TypeScript adalah _superset_ dari JavaScript, dan TypeScript dilengkapi dengan definisi tipe untuk DOM API. Secara standar, definisi ini sudah tersedia dalam proyek TypeScript. Dari 20.000+ baris definisi di _lib.dom.d.ts_, satu yang menonjol di antara yang lain: `HTMLElement`. Jenis ini adalah hal penting untuk manipulasi DOM dengan TypeScript.
 
 > Anda bisa mengeksplor source code [Definisi tipe DOM](https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts)
 
 ## Contoh Dasar
 
-Diberikan file _index.html_ yang disederhanakan:
+Diberikan berkas _index.html_ yang disederhanakan:
 
     <!DOCTYPE html>
     <html lang="en">
@@ -32,7 +32,7 @@ Diberikan file _index.html_ yang disederhanakan:
       </body>
     </html>
 
-Mari kita jelajahi skrip TypeScript yang menambahkan elemen `<p> Hello, World </p>` ke elemen `#app`.
+Mari kita jelajahi kode TypeScript yang menambahkan elemen `<p>Hello, World</p>` ke elemen `#app`.
 
 ```ts
 // 1. Pilih elemen div menggunakan properti id
@@ -58,17 +58,17 @@ Setelah menyusun dan menjalankan halaman _index.html_, HTML yang dihasilkan adal
 
 ## Antarmuka `Document`
 
-Baris pertama kode TypeScript menggunakan variabel global `document`. Memeriksa variabel menunjukkan bahwa ia didefinisikan oleh antarmuka `Dokumen` dari file _lib.dom.d.ts_. Cuplikan kode berisi panggilan ke dua metode, `getElementById` dan `createElement`.
+Baris pertama kode TypeScript menggunakan variabel global `document`. Memeriksa variabel menunjukkan bahwa ia didefinisikan oleh antarmuka `Dokumen` dari berkas _lib.dom.d.ts_. Cuplikan kode berisi panggilan ke dua _method_, `getElementById` dan `createElement`.
 
 ### `Document.getElementById`
 
-Definisi dari metode ini adalah sebagai berikut:
+Definisi dari _method_ ini adalah sebagai berikut:
 
 ```ts
 getElementById(elementId: string): HTMLElement | null;
 ```
 
-Berikan string id elemen dan itu akan mengembalikan `HTMLElement` atau`null`. Metode ini memperkenalkan salah satu jenis terpenting, `HTMLElement`. Ini berfungsi sebagai antarmuka dasar untuk setiap antarmuka elemen lainnya. Misalnya, variabel `p` dalam contoh kode berjenis `HTMLParagraphElement`. Perhatikan juga bahwa metode ini dapat mengembalikan `null`. Ini karena metode tidak dapat memastikan kapan elemen itu tersedia atau apakah elemen tersebut ada atau tidak. Di baris terakhir cuplikan kode, operator _optional chaining_ digunakan untuk memanggil `appendChild`.
+Berikan string id elemen dan itu akan mengembalikan `HTMLElement` atau`null`. _Method_ ini memperkenalkan salah satu jenis terpenting, `HTMLElement`. Ini berfungsi sebagai antarmuka dasar untuk setiap antarmuka elemen lainnya. Misalnya, variabel `p` dalam contoh kode berjenis `HTMLParagraphElement`. Perhatikan juga bahwa _method_ ini dapat mengembalikan `null`. Ini karena _method_ tidak dapat memastikan kapan elemen itu tersedia atau apakah elemen tersebut ada atau tidak. Di baris terakhir cuplikan kode, operator _optional chaining_ digunakan untuk memanggil `appendChild`.
 
 ### `Document.createElement`
 
@@ -83,7 +83,7 @@ Ini adalah definisi fungsi yang kelebihan beban. Kelebihan kedua adalah yang pal
 
 Misalnya `document.createElement('xyz')` mengembalikan elemen `<xyz></xyz>`, jelas bukan elemen yang ditentukan oleh spesifikasi HTML.
 
-> Jika tertarik, Anda dapat berinteraksi dengan elemen tag kustom menggunakan `document.getElementsByTagName`
+> Jika tertarik, Anda dapat berinteraksi dengan elemen _tag_ kustom menggunakan `document.getElementsByTagName`
 
 Untuk definisi pertama dari `createElement`, ini menggunakan beberapa pola umum lanjutan. Paling baik dipahami jika dipecah menjadi beberapa bagian, dimulai dengan ekspresi umum: `<K extends keyof HTMLElementTagNameMap>`. Ekspresi ini mendefinisikan parameter umum `K` yang _constrained_ ke kunci antarmuka`HTMLElementTagNameMap`. Antarmuka peta berisi setiap nama tag HTML yang ditentukan dan antarmuka tipe yang sesuai. Berikut adalah 5 nilai yang dipetakan pertama:
 
@@ -104,11 +104,11 @@ Sekarang, untuk sisa definisi `createElement`:`(tagName: K, options ?: ElementCr
 
 ## Antarmuka `Node`
 
-Fungsi `document.getElementById` mengembalikan `HTMLElement`. Antarmuka `HTMLElement` memperluas antarmuka `Element`, yang memperluas antarmuka `Node`. Ekstensi prototipe ini memungkinkan semua `HTMLElements` untuk menggunakan subset method standar. Dalam cuplikan kode, kami menggunakan properti yang ditentukan pada antarmuka `Node` untuk menambahkan elemen`p` baru ke situs web.
+Fungsi `document.getElementById` mengembalikan `HTMLElement`. Antarmuka `HTMLElement` memperluas antarmuka `Element`, yang memperluas antarmuka `Node`. Ekstensi prototipe ini memungkinkan semua `HTMLElements` untuk menggunakan _subset_ method standar. Dalam cuplikan kode, kami menggunakan properti yang ditentukan pada antarmuka `Node` untuk menambahkan elemen`p` baru ke situs _web_.
 
 ### `Node.appendChild`
 
-Baris terakhir dari potongan kode adalah `app?.AppendChild (p)`. Bagian sebelumnya, `document.getElementById`, merinci bahwa operator _optional chaining_ digunakan di sini karena `app` berpotensi menjadi null pada waktu proses. Method `appendChild` didefinisikan oleh:
+Baris terakhir dari potongan kode adalah `app?.AppendChild (p)`. Bagian sebelumnya, `document.getElementById`, merinci bahwa operator _optional chaining_ digunakan di sini karena `app` berpotensi menjadi _null_ pada waktu proses. Method `appendChild` didefinisikan oleh:
 
 ```ts
 appendChild<T extends Node>(newChild: T): T;
@@ -135,9 +135,9 @@ div.childNodes;
 // NodeList(2) [p, p]
 ```
 
-Setelah menangkap elemen `div`, prop `children` akan mengembalikan daftar `HTMLCollection` yang berisi `HTMLParagraphElements`. Property `childNodes` akan mengembalikan daftar node `NodeList` yang serupa. Setiap tag `p` akan tetap berjenis `HTMLParagraphElements`, tetapi `NodeList` dapat berisi _HTML node_ tambahan yang tidak bisa dilakukan oleh list `HTMLCollection`.
+Setelah menangkap elemen `div`, _prop_ `children` akan mengembalikan daftar `HTMLCollection` yang berisi `HTMLParagraphElements`. Properti `childNodes` akan mengembalikan daftar node `NodeList` yang serupa. Setiap _tag_ `p` akan tetap berjenis `HTMLParagraphElements`, tetapi `NodeList` dapat berisi _HTML node_ tambahan yang tidak bisa dilakukan oleh _list_ `HTMLCollection`.
 
-Ubah html dengan menghapus salah satu tag `p`, tetapi pertahankan teksnya.
+Ubah html dengan menghapus salah satu _tag_ `p`, tetapi pertahankan teksnya.
 
 ```tsx
 <div>
@@ -154,11 +154,11 @@ div.childNodes;
 // NodeList(2) [p, text]
 ```
 
-Lihat bagaimana kedua daftar berubah. `children` sekarang hanya berisi elemen `<p>Hello, World</p>`, dan `childNodes` berisi simpul `teks` daripada dua simpul `p`. Bagian `teks` dari `NodeList` adalah `Node` literal yang berisi teks `TypeScript!`. List `children` tidak berisi `Node`, ini karena tidak dianggap sebagai `HTMLElement`.
+Lihat bagaimana kedua daftar berubah. `children` sekarang hanya berisi elemen `<p>Hello, World</p>`, dan `childNodes` berisi simpul `teks` daripada dua simpul `p`. Bagian `teks` dari `NodeList` adalah `Node` _literal_ yang berisi teks `TypeScript!`. _List_ `children` tidak berisi `Node`, ini karena tidak dianggap sebagai `HTMLElement`.
 
-## Method `querySelector` dan `querySelectorAll`
+## _Method_ `querySelector` dan `querySelectorAll`
 
-Kedua method ini adalah tool yang hebat untuk mendapatkan daftar elemen dom yang sesuai dengan kumpulan constraint yang lebih unik. Mereka didefinisikan di _lib.dom.d.ts_ sebagai:
+Kedua _method_ ini adalah _tool_ yang hebat untuk mendapatkan daftar elemen dom yang sesuai dengan kumpulan _constraint_ yang lebih unik. Mereka didefinisikan di _lib.dom.d.ts_ sebagai:
 
 ```ts
 /**
@@ -176,9 +176,9 @@ querySelectorAll<K extends keyof SVGElementTagNameMap>(selectors: K): NodeListOf
 querySelectorAll<E extends Element = Element>(selectors: string): NodeListOf<E>;
 ```
 
-Definisi `querySelectorAll` mirip dengan `getElementsByTagName`, kecuali ia mengembalikan tipe baru: `NodeListOf`. Jenis kembalian ini pada dasarnya adalah implementasi khusus dari elemen daftar standar JavaScript. Bisa dibilang, mengganti `NodeListOf<E>` dengan `E[]` akan menghasilkan pengalaman pengguna yang sangat mirip. `NodeListOf` hanya mengimplementasikan properti dan method berikut:`length`, `item (index)`,`forEach ((value, key, parent) => void)`, dan numeric indexing. Selain itu, metode ini mengembalikan daftar _elements_, bukan _nodes_, yang dikembalikan oleh `NodeList` dari method `.childNodes`. Meskipun ini mungkin tampak sebagai perbedaan, perhatikan bahwa antarmuka `Element` merupakan turunan dari `Node`.
+Definisi `querySelectorAll` mirip dengan `getElementsByTagName`, kecuali ia mengembalikan tipe baru: `NodeListOf`. Jenis kembalian ini pada dasarnya adalah implementasi khusus dari elemen daftar standar JavaScript. Bisa dibilang, mengganti `NodeListOf<E>` dengan `E[]` akan menghasilkan pengalaman pengguna yang sangat mirip. `NodeListOf` hanya mengimplementasikan properti dan method berikut:`length`, `item (index)`,`forEach ((value, key, parent) => void)`, dan _numeric indexing_. Selain itu, _method_ ini mengembalikan daftar _elements_, bukan _nodes_, yang dikembalikan oleh `NodeList` dari _method_ `.childNodes`. Meskipun ini mungkin tampak sebagai perbedaan, perhatikan bahwa antarmuka `Element` merupakan turunan dari `Node`.
 
-Untuk melihat method ini beraksi, ubah kode yang ada menjadi:
+Untuk melihat _method_ ini beraksi, ubah kode yang ada menjadi:
 
 ```tsx
 <ul>
@@ -193,9 +193,9 @@ const all = document.querySelectorAll("li"); // mengembalikan daftar semua eleme
 
 ## Tertarik untuk mempelajari lebih lanjut?
 
-Bagian terbaik tentang definisi tipe _lib.dom.d.ts_ adalah bahwa definisi tersebut mencerminkan tipe yang dijelaskan di situs dokumentasi Mozilla Developer Network (MDN). Misalnya, antarmuka `HTMLElement` didokumentasikan oleh [halaman HTMLElement](https://developer.mozilla.org/docs/Web/API/HTMLElement) di MDN. Halaman ini mencantumkan semua properti yang tersedia, method, dan terkadang bahkan contoh. Aspek hebat lainnya dari halaman-halaman tersebut adalah mereka menyediakan tautan ke dokumen standar yang sesuai. Berikut ini tautan ke [Rekomendasi W3C untuk HTMLElement](https://www.w3.org/TR/html52/dom.html#htmlelement).
+Bagian terbaik tentang definisi tipe _lib.dom.d.ts_ adalah bahwa definisi tersebut mencerminkan tipe yang dijelaskan di situs dokumentasi _Mozilla Developer Network_ (MDN). Misalnya, antarmuka `HTMLElement` didokumentasikan oleh [halaman HTMLElement](https://developer.mozilla.org/docs/Web/API/HTMLElement) di MDN. Halaman ini mencantumkan semua properti yang tersedia, method, dan terkadang bahkan contoh. Aspek hebat lainnya dari halaman-halaman tersebut adalah mereka menyediakan tautan ke dokumen standar yang sesuai. Berikut ini tautan ke [Rekomendasi W3C untuk HTMLElement](https://www.w3.org/TR/html52/dom.html#htmlelement).
 
 Sumber:
 
 - [ECMA-262 Standard](http://www.ecma-international.org/ecma-262/10.0/index.html)
-- [Introduction to the DOM](https://developer.mozilla.org/docs/Web/API/Document_Object_Model/Introduction)
+- [Pengenalan DOM](https://developer.mozilla.org/docs/Web/API/Document_Object_Model/Introduction)

--- a/packages/documentation/copy/id/tutorials/React.md
+++ b/packages/documentation/copy/id/tutorials/React.md
@@ -1,0 +1,26 @@
+---
+title: React
+layout: docs
+permalink: /id/docs/handbook/react.html
+oneline: Tautan untuk mempelajari tentang TypeScript dan React
+translatable: true
+---
+
+TypeScript mendukung [JSX](/docs/handbook/jsx.html) dan dapat dengan baik memodelkan pola untuk digunakan pada kode React, seperti `useState`.
+
+### Memulai Set Up Dengan Proyek React
+
+Saat ini ada beberapa framework yang mendukung TypeScript:
+
+- [Create React App](https://create-react-app.dev) - [TS docs](https://create-react-app.dev/docs/adding-typescript/)
+- [Next.js](https://nextjs.org) - [TS docs](https://nextjs.org/learn/excel/typescript)
+- [Gatsby](https://www.gatsbyjs.org) - [TS Docs](https://www.gatsbyjs.org/docs/typescript/)
+
+Framework diatas adalah titik awal yang bagus untuk mulai menggunakan TypeScript. Pada situs ini, kami [menggunakan Gatsby](https://www.gatsbyjs.org/blog/2020-01-23-why-typescript-chose-gatsby/#reach-skip-nav) dengan TypeScript. Sehingga dapat digunakan sebagai referensi untuk implementasinya.
+
+### Dokumentasi
+
+Berikut adalah beberapa tempat terbaik untuk menemukan informasi terbaru tentang React dan TypeScript:
+
+- [React TypeScript Cheatsheets](https://react-typescript-cheatsheet.netlify.app)
+- [React & Redux in TypeScript](https://github.com/piotrwitek/react-redux-typescript-guide#react--redux-in-typescript---complete-guide)

--- a/packages/documentation/copy/id/tutorials/React.md
+++ b/packages/documentation/copy/id/tutorials/React.md
@@ -8,15 +8,15 @@ translatable: true
 
 TypeScript mendukung [JSX](/docs/handbook/jsx.html) dan dapat dengan baik memodelkan pola untuk digunakan pada kode React, seperti `useState`.
 
-### Memulai Set Up Dengan Proyek React
+### Memulai _Set Up_ Dengan Proyek React
 
-Saat ini ada beberapa framework yang mendukung TypeScript:
+Saat ini ada beberapa _framework_ yang mendukung TypeScript:
 
 - [Create React App](https://create-react-app.dev) - [TS docs](https://create-react-app.dev/docs/adding-typescript/)
 - [Next.js](https://nextjs.org) - [TS docs](https://nextjs.org/learn/excel/typescript)
 - [Gatsby](https://www.gatsbyjs.org) - [TS Docs](https://www.gatsbyjs.org/docs/typescript/)
 
-Framework diatas adalah titik awal yang bagus untuk mulai menggunakan TypeScript. Pada situs ini, kami [menggunakan Gatsby](https://www.gatsbyjs.org/blog/2020-01-23-why-typescript-chose-gatsby/#reach-skip-nav) dengan TypeScript. Sehingga dapat digunakan sebagai referensi untuk implementasinya.
+_Framework_ diatas adalah titik awal yang bagus untuk mulai menggunakan TypeScript. Pada situs ini, kami [menggunakan Gatsby](https://www.gatsbyjs.org/blog/2020-01-23-why-typescript-chose-gatsby/#reach-skip-nav) dengan TypeScript. Sehingga dapat digunakan sebagai referensi untuk implementasinya.
 
 ### Dokumentasi
 

--- a/packages/documentation/copy/id/tutorials/TypeScript Tooling in 5 minutes.md
+++ b/packages/documentation/copy/id/tutorials/TypeScript Tooling in 5 minutes.md
@@ -1,0 +1,187 @@
+---
+title: TypeScript Tooling in 5 minutes
+layout: docs
+permalink: /id/docs/handbook/typescript-tooling-in-5-minutes.html
+oneline: Sebuah tutorial untuk memahami cara membuat situs web kecil dengan TypeScript
+translatable: true
+---
+
+Mulai membangun aplikasi web sederhana dengan TypeScript.
+
+## Memasang TypeScript
+
+Berikut adalah 2 cara agar TypeScript ada pada proyekmu:
+
+- Melalui npm (package manager dari Node.js)
+- Dengan memasang plugin Visual Studio TypeScript
+
+Standar dari Visual Studio 2017 dan Visual Studio 2015 Update 3 telah menyertakan TypeScript.
+Jika anda belum memasang TypeScript dengan Visual Studio, anda masih bisa [mengunduhnya disini](/download).
+
+Untuk pengguna npm:
+
+```shell
+> npm install -g typescript
+```
+
+## Membangun file TypeScript pertamamu
+
+Di editormu, ketik kode JavaScript berikut pada file `greeter.ts`:
+
+```ts twoslash
+// @noImplicitAny: false
+function greeter(person) {
+  return "Hello, " + person;
+}
+
+let user = "Jane User";
+
+document.body.textContent = greeter(user);
+```
+
+## Mengkompilasi kodemu
+
+Kita menggunakan ekstensi `.ts`, tapi kode ini hanyalah JavaScript.
+Anda dapat menyalin/menempel ini langsung dari aplikasi JavaScript yang ada.
+
+Di command line, jalankan TypeScript compiler:
+
+```shell
+tsc greeter.ts
+```
+
+Hasilnya akan menjadi file `greeter.js` yang berisi JavaScript yang sama dengan yang anda masukkan.
+Kodenya telah berhasil menjalankannya menggunakan TypeScript di aplikasi JavaScript!
+
+Sekarang kita bisa melangkah lebih jauh tentang tool yang ditawarkan oleh TypeScript.
+Tambahkan sebuah jenis anotasi `: string` ke argumen 'person' pada fungsi `greeter`, seperti berikut:
+
+```ts twoslash
+function greeter(person: string) {
+  return "Hello, " + person;
+}
+
+let user = "Jane User";
+
+document.body.textContent = greeter(user);
+```
+
+## Jenis Anotasi
+
+Jenis anotasi di TypeScript adalah cara yang mudah untuk mengetahui bagaimana fungsi atau variabel tersebut yang dimaksudkan.
+Dalam kasus ini, kami bermaksud agar fungsi greeter dipanggil dengan parameter string tunggal.
+Kita dapat mencoba mengubah pemanggilan fungsi greeter untuk mengirimkan array sebagai gantinya:
+
+```ts twoslash
+// @errors: 2345
+function greeter(person: string) {
+  return "Hello, " + person;
+}
+
+let user = [0, 1, 2];
+
+document.body.textContent = greeter(user);
+```
+
+Compile ulang, dan anda akan melihat error berikut:
+
+```shell
+error TS2345: Argument of type 'number[]' is not assignable to parameter of type 'string'.
+```
+
+Demikian pula, coba hapus semua argumen saat pemanggilan fungsi greeter.
+TypeScript akan memberi tahu Anda bahwa Anda telah memanggil fungsi ini dengan jumlah parameter yang tidak terduga.
+Dalam kedua kasus, TypeScript dapat menawarkan analisis statis berdasarkan struktur kode Anda, dan jenis anotasi yang Anda berikan.
+
+Perhatikan ketika terjadi error, file `greeter.js` tetap dibuat.
+Anda bisa menggunakan TypeScript bahkan jika terjadi error pada kodemu. Tapi pada kasus ini, TypeScript memperingatkan bahwa kodemu akan bekerja tidak sesuai dengan ekspektasi.
+
+## Interfaces
+
+Mari kembangkan sampel kita lebih jauh. Di sini kami menggunakan interface yang mendeskripsikan objek yang memiliki field firstName dan lastName.
+Di TypeScript, dua jenis anotasi akan kompatibel jika struktur internalnya juga kompatibel.
+Ini membolehkan kita untuk mengimplementasikan sebuah interface hanya dengan memiliki bentuk interface yang dibutuhkan, tanpa klausa `implements` yang eksplisit.
+
+```ts twoslash
+interface Person {
+  firstName: string;
+  lastName: string;
+}
+
+function greeter(person: Person) {
+  return "Hello, " + person.firstName + " " + person.lastName;
+}
+
+let user = { firstName: "Jane", lastName: "User" };
+
+document.body.textContent = greeter(user);
+```
+
+## Kelas
+
+Terakhir, mari menambahkan penggunaan kelas pada contoh yang sedang kita kerjakan.
+TypeScript mendukung fitur baru di JavaScript, seperti dukungan untuk kelas berbasiskan pemrograman objek.
+
+Disini kita mulai dengan membuat kelas `Student` dengan konstruktor dan beberapa field publik.
+Perhatikan bahwa kelas dan interface saling bersinergi, sehingga memberikan kebebasan ke programmer untuk memutuskan level abstraksi yang tepat.
+
+Juga perlu perhatikan, pernggunaan `public` pada argumen di konstruktor adalah singkatan yang membolehkan kita untuk secara otomatis membuat property dengan nama tersebut.
+
+```ts twoslash
+class Student {
+  fullName: string;
+  constructor(
+    public firstName: string,
+    public middleInitial: string,
+    public lastName: string
+  ) {
+    this.fullName = firstName + " " + middleInitial + " " + lastName;
+  }
+}
+
+interface Person {
+  firstName: string;
+  lastName: string;
+}
+
+function greeter(person: Person) {
+  return "Hello, " + person.firstName + " " + person.lastName;
+}
+
+let user = new Student("Jane", "M.", "User");
+
+document.body.textContent = greeter(user);
+```
+
+Jalankan ulang perintah `tsc greeter.ts` dan anda akan melihat kode JavaScript-nya.
+Kelas pada TypeScript hanyalah singkatan untuk object-oriented berbasiskan prototipe yang sama, yang sering digunakan di JavaScript.
+
+## Menjalankan aplikasi web TypeScript-mu
+
+Sekarang ketik kode berikut di `greeter.html`:
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>TypeScript Greeter</title>
+  </head>
+  <body>
+    <script src="greeter.js"></script>
+  </body>
+</html>
+```
+
+Buka `greeter.html` di browser untuk menjalankan aplikasi web TypeScript-mu yang pertama!
+
+Opsional: Buka `greeter.ts` di Visual Studio, atau salin kode ke TypeScript playground.
+Anda dapat mengarahkan kursor ke identifier untuk melihat type mereka.
+Perhatikan bahwa dalam beberapa kasus, tipe ini disimpulkan secara otomatis untuk Anda.
+Ketik ulang baris terakhir, dan lihat daftar penyelesaian dan bantuan parameter berdasarkan jenis elemen DOM.
+Letakkan kursor Anda pada referensi ke fungsi greeter, dan tekan F12 untuk masuk ke definisinya.
+Perhatikan juga bahwa Anda dapat mengklik kanan pada simbol dan menggunakan refactoring untuk mengganti namanya.
+
+Jenis informasi yang disediakan bekerja sama dengan tool untuk memudahkan pekerjaan dengan aplikasi JavaScript.
+Untuk informasi lebih lanjut tentang apa yang mungkin kita bisa lakukan dengan TypeScript, anda dapat melihat beberapa sample di situs ini.
+
+![Visual Studio picture](/images/docs/greet_person.png)

--- a/packages/documentation/copy/id/tutorials/TypeScript Tooling in 5 minutes.md
+++ b/packages/documentation/copy/id/tutorials/TypeScript Tooling in 5 minutes.md
@@ -1,5 +1,5 @@
 ---
-title: TypeScript Tooling in 5 minutes
+title: TypeScript Tooling dalam 5 menit
 layout: docs
 permalink: /id/docs/handbook/typescript-tooling-in-5-minutes.html
 oneline: Sebuah tutorial untuk memahami cara membuat situs web kecil dengan TypeScript
@@ -44,7 +44,7 @@ document.body.textContent = greeter(user);
 Kita menggunakan ekstensi `.ts`, tapi kode ini hanyalah JavaScript.
 Anda dapat menyalin/menempel ini langsung dari aplikasi JavaScript yang ada.
 
-Di command line, jalankan TypeScript compiler:
+Di command line, jalankan TypeScript kompilator:
 
 ```shell
 tsc greeter.ts
@@ -83,7 +83,7 @@ let user = [0, 1, 2];
 document.body.textContent = greeter(user);
 ```
 
-Compile ulang, dan anda akan melihat error berikut:
+Compile ulang, dan Anda akan melihat galat berikut:
 
 ```shell
 error TS2345: Argument of type 'number[]' is not assignable to parameter of type 'string'.
@@ -93,8 +93,8 @@ Demikian pula, coba hapus semua argumen saat pemanggilan fungsi greeter.
 TypeScript akan memberi tahu Anda bahwa Anda telah memanggil fungsi ini dengan jumlah parameter yang tidak terduga.
 Dalam kedua kasus, TypeScript dapat menawarkan analisis statis berdasarkan struktur kode Anda, dan jenis anotasi yang Anda berikan.
 
-Perhatikan ketika terjadi error, file `greeter.js` tetap dibuat.
-Anda bisa menggunakan TypeScript bahkan jika terjadi error pada kodemu. Tapi pada kasus ini, TypeScript memperingatkan bahwa kodemu akan bekerja tidak sesuai dengan ekspektasi.
+Perhatikan ketika terjadi galat, file `greeter.js` tetap dibuat.
+Anda bisa menggunakan TypeScript bahkan jika terjadi galat pada kodemu. Tapi pada kasus ini, TypeScript memperingatkan bahwa kodemu akan bekerja tidak sesuai dengan ekspektasi.
 
 ## Interfaces
 
@@ -125,7 +125,7 @@ TypeScript mendukung fitur baru di JavaScript, seperti dukungan untuk kelas berb
 Disini kita mulai dengan membuat kelas `Student` dengan konstruktor dan beberapa field publik.
 Perhatikan bahwa kelas dan interface saling bersinergi, sehingga memberikan kebebasan ke programmer untuk memutuskan level abstraksi yang tepat.
 
-Juga perlu perhatikan, pernggunaan `public` pada argumen di konstruktor adalah singkatan yang membolehkan kita untuk secara otomatis membuat property dengan nama tersebut.
+Juga perlu perhatikan, pernggunaan `public` pada argumen di konstruktor adalah singkatan yang membolehkan kita untuk secara otomatis membuat properti dengan nama tersebut.
 
 ```ts twoslash
 class Student {
@@ -175,7 +175,7 @@ Sekarang ketik kode berikut di `greeter.html`:
 Buka `greeter.html` di browser untuk menjalankan aplikasi web TypeScript-mu yang pertama!
 
 Opsional: Buka `greeter.ts` di Visual Studio, atau salin kode ke TypeScript playground.
-Anda dapat mengarahkan kursor ke identifier untuk melihat type mereka.
+Anda dapat mengarahkan kursor ke identifier untuk melihat tipe mereka.
 Perhatikan bahwa dalam beberapa kasus, tipe ini disimpulkan secara otomatis untuk Anda.
 Ketik ulang baris terakhir, dan lihat daftar penyelesaian dan bantuan parameter berdasarkan jenis elemen DOM.
 Letakkan kursor Anda pada referensi ke fungsi greeter, dan tekan F12 untuk masuk ke definisinya.

--- a/packages/documentation/copy/id/tutorials/TypeScript Tooling in 5 minutes.md
+++ b/packages/documentation/copy/id/tutorials/TypeScript Tooling in 5 minutes.md
@@ -13,7 +13,7 @@ Mulai membangun aplikasi web sederhana dengan TypeScript.
 Berikut adalah 2 cara agar TypeScript ada pada proyekmu:
 
 - Melalui npm (package manager dari Node.js)
-- Dengan memasang plugin Visual Studio TypeScript
+- Dengan memasang _plugin_ Visual Studio TypeScript
 
 Standar dari Visual Studio 2017 dan Visual Studio 2015 Update 3 telah menyertakan TypeScript.
 Jika anda belum memasang TypeScript dengan Visual Studio, anda masih bisa [mengunduhnya disini](/download).
@@ -24,9 +24,9 @@ Untuk pengguna npm:
 > npm install -g typescript
 ```
 
-## Membangun file TypeScript pertamamu
+## Membangun berkas TypeScript pertamamu
 
-Di editormu, ketik kode JavaScript berikut pada file `greeter.ts`:
+Di editormu, ketik kode JavaScript berikut pada berkas `greeter.ts`:
 
 ```ts twoslash
 // @noImplicitAny: false
@@ -44,13 +44,13 @@ document.body.textContent = greeter(user);
 Kita menggunakan ekstensi `.ts`, tapi kode ini hanyalah JavaScript.
 Anda dapat menyalin/menempel ini langsung dari aplikasi JavaScript yang ada.
 
-Di command line, jalankan TypeScript kompilator:
+Di _command line_, jalankan TypeScript kompilator:
 
 ```shell
 tsc greeter.ts
 ```
 
-Hasilnya akan menjadi file `greeter.js` yang berisi JavaScript yang sama dengan yang anda masukkan.
+Hasilnya akan menjadi berkas `greeter.js` yang berisi JavaScript yang sama dengan yang anda masukkan.
 Kodenya telah berhasil menjalankannya menggunakan TypeScript di aplikasi JavaScript!
 
 Sekarang kita bisa melangkah lebih jauh tentang tool yang ditawarkan oleh TypeScript.
@@ -69,8 +69,8 @@ document.body.textContent = greeter(user);
 ## Jenis Anotasi
 
 Jenis anotasi di TypeScript adalah cara yang mudah untuk mengetahui bagaimana fungsi atau variabel tersebut yang dimaksudkan.
-Dalam kasus ini, kami bermaksud agar fungsi greeter dipanggil dengan parameter string tunggal.
-Kita dapat mencoba mengubah pemanggilan fungsi greeter untuk mengirimkan array sebagai gantinya:
+Dalam kasus ini, kami bermaksud agar fungsi _greeter_ dipanggil dengan parameter string tunggal.
+Kita dapat mencoba mengubah pemanggilan fungsi _greeter_ untuk mengirimkan _array_ sebagai gantinya:
 
 ```ts twoslash
 // @errors: 2345
@@ -83,24 +83,24 @@ let user = [0, 1, 2];
 document.body.textContent = greeter(user);
 ```
 
-Compile ulang, dan Anda akan melihat galat berikut:
+_Compile_ ulang, dan Anda akan melihat galat berikut:
 
 ```shell
 error TS2345: Argument of type 'number[]' is not assignable to parameter of type 'string'.
 ```
 
-Demikian pula, coba hapus semua argumen saat pemanggilan fungsi greeter.
-TypeScript akan memberi tahu Anda bahwa Anda telah memanggil fungsi ini dengan jumlah parameter yang tidak terduga.
+Demikian pula, coba hapus semua argumen saat pemanggilan fungsi _greeter_.
+TypeScript akan memberi tahu Anda bahwa Anda telah memanggil fungsi ini dengan jumlah _parameter_ yang tidak terduga.
 Dalam kedua kasus, TypeScript dapat menawarkan analisis statis berdasarkan struktur kode Anda, dan jenis anotasi yang Anda berikan.
 
-Perhatikan ketika terjadi galat, file `greeter.js` tetap dibuat.
+Perhatikan ketika terjadi galat, berkas `greeter.js` tetap dibuat.
 Anda bisa menggunakan TypeScript bahkan jika terjadi galat pada kodemu. Tapi pada kasus ini, TypeScript memperingatkan bahwa kodemu akan bekerja tidak sesuai dengan ekspektasi.
 
-## Interfaces
+## _Interfaces_
 
-Mari kembangkan sampel kita lebih jauh. Di sini kami menggunakan interface yang mendeskripsikan objek yang memiliki field firstName dan lastName.
+Mari kembangkan sampel kita lebih jauh. Di sini kami menggunakan _interface_ yang mendeskripsikan objek yang memiliki _field_ firstName dan lastName.
 Di TypeScript, dua jenis anotasi akan kompatibel jika struktur internalnya juga kompatibel.
-Ini membolehkan kita untuk mengimplementasikan sebuah interface hanya dengan memiliki bentuk interface yang dibutuhkan, tanpa klausa `implements` yang eksplisit.
+Ini membolehkan kita untuk mengimplementasikan sebuah _interface_ hanya dengan memiliki bentuk _interface_ yang dibutuhkan, tanpa klausa `implements` yang eksplisit.
 
 ```ts twoslash
 interface Person {
@@ -122,10 +122,10 @@ document.body.textContent = greeter(user);
 Terakhir, mari menambahkan penggunaan kelas pada contoh yang sedang kita kerjakan.
 TypeScript mendukung fitur baru di JavaScript, seperti dukungan untuk kelas berbasiskan pemrograman objek.
 
-Disini kita mulai dengan membuat kelas `Student` dengan konstruktor dan beberapa field publik.
-Perhatikan bahwa kelas dan interface saling bersinergi, sehingga memberikan kebebasan ke programmer untuk memutuskan level abstraksi yang tepat.
+Disini kita mulai dengan membuat kelas `Student` dengan konstruktor dan beberapa _field_ publik.
+Perhatikan bahwa kelas dan _interface_ saling bersinergi, sehingga memberikan kebebasan ke programmer untuk memutuskan level abstraksi yang tepat.
 
-Juga perlu perhatikan, pernggunaan `public` pada argumen di konstruktor adalah singkatan yang membolehkan kita untuk secara otomatis membuat properti dengan nama tersebut.
+Juga perlu perhatikan, penggunaan `public` pada argumen di konstruktor adalah singkatan yang membolehkan kita untuk secara otomatis membuat properti dengan nama tersebut.
 
 ```ts twoslash
 class Student {
@@ -154,7 +154,7 @@ document.body.textContent = greeter(user);
 ```
 
 Jalankan ulang perintah `tsc greeter.ts` dan anda akan melihat kode JavaScript-nya.
-Kelas pada TypeScript hanyalah singkatan untuk object-oriented berbasiskan prototipe yang sama, yang sering digunakan di JavaScript.
+Kelas pada TypeScript hanyalah singkatan untuk _object-oriented_ berbasiskan _prototipe_ yang sama, yang sering digunakan di JavaScript.
 
 ## Menjalankan aplikasi web TypeScript-mu
 
@@ -172,16 +172,16 @@ Sekarang ketik kode berikut di `greeter.html`:
 </html>
 ```
 
-Buka `greeter.html` di browser untuk menjalankan aplikasi web TypeScript-mu yang pertama!
+Buka `greeter.html` di _browser_ untuk menjalankan aplikasi web TypeScript-mu yang pertama!
 
-Opsional: Buka `greeter.ts` di Visual Studio, atau salin kode ke TypeScript playground.
-Anda dapat mengarahkan kursor ke identifier untuk melihat tipe mereka.
+Opsional: Buka `greeter.ts` di Visual Studio, atau salin kode ke TypeScript _playground_.
+Anda dapat mengarahkan kursor ke _identifier_ untuk melihat tipe mereka.
 Perhatikan bahwa dalam beberapa kasus, tipe ini disimpulkan secara otomatis untuk Anda.
-Ketik ulang baris terakhir, dan lihat daftar penyelesaian dan bantuan parameter berdasarkan jenis elemen DOM.
+Ketik ulang baris terakhir, dan lihat daftar penyelesaian dan bantuan _parameter_ berdasarkan jenis elemen DOM.
 Letakkan kursor Anda pada referensi ke fungsi greeter, dan tekan F12 untuk masuk ke definisinya.
-Perhatikan juga bahwa Anda dapat mengklik kanan pada simbol dan menggunakan refactoring untuk mengganti namanya.
+Perhatikan juga bahwa Anda dapat mengklik kanan pada simbol dan menggunakan _refactoring_ untuk mengganti namanya.
 
-Jenis informasi yang disediakan bekerja sama dengan tool untuk memudahkan pekerjaan dengan aplikasi JavaScript.
+Jenis informasi yang disediakan bekerja sama dengan _tool_ untuk memudahkan pekerjaan dengan aplikasi JavaScript.
 Untuk informasi lebih lanjut tentang apa yang mungkin kita bisa lakukan dengan TypeScript, anda dapat melihat beberapa sample di situs ini.
 
 ![Visual Studio picture](/images/docs/greet_person.png)


### PR DESCRIPTION
**Overview**
Refer to #938 and [this comment](https://github.com/microsoft/TypeScript-Website/issues/938#issuecomment-706573677), I translated the files into Indonesian.

**Changes**
Provides Indonesian translation for the following files:

- [x] Nightly Builds.md
- [x] Creating DTS files From JS.md
- [x] Intro to JS with TS.md
- [x] JSDoc Reference.md
- [x] Configuring Watch.md
- [x] Decorators.md
- [x] Iterators and Generators.md
- [x] JSX.md
- [x] Mixins.md
- [x] Symbols.md
- [x] Babel with TypeScript.md
- [x] DOM Manipulation.md
- [x] React.md
- [x] TypeScript Tooling in 5 minutes.md