### PR TITLE
Add return type void documentation

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -726,3 +726,73 @@ function sum({ a, b, c }: ABC) {
 ```
 
 ## Assignability of Functions
+
+### Return type `void`
+
+The `void` return type for functions can produce some unusual, but expected behavior.
+
+Contextual typing with a return type of `void` does **not** force functions to **not** return something. Another way to say this is a contextual function type with a `void` return type (`type vf = () => void`), when implemented, can return _any_ other value, but it will be ignored.
+
+Thus, the following implementations of the type `() => void` are valid:
+```ts twoslash
+type voidFunc = () => void
+
+const f1: voidFunc = () => {
+  return true
+}
+
+const f2: voidFunc = () => true
+
+const f3: voidFunc = function () {
+  return true
+}
+```
+
+And when the return value of one of these functions is assigned to another variable, it will retain the type of `void`:
+
+```ts twoslash
+type voidFunc = () => void
+
+const f1: voidFunc = () => {
+  return true
+}
+
+const f2: voidFunc = () => true
+
+const f3: voidFunc = function () {
+  return true
+}
+// ---cut---
+const v1 = f1()
+
+const v2 = f2()
+
+const v3 = f3()
+```
+
+This behavior exists so that the following code is valid even though `Array.prototype.push` returns a number and the `Array.prototype.forEach` method expects a function with a return type of `void`.
+```ts twoslash
+const src = [1, 2, 3]
+const dst = [0]
+
+src.forEach(el => dst.push(el))
+```
+
+There is one other special case to be aware of, when a literal function definition has a `void` return type, that function must **not** return anything.
+
+```ts twoslash
+function f2 (): void {
+  // @ts-expect-error
+  return true 
+}
+
+const f3 = function (): void {
+  // @ts-expect-error
+  return true 
+}
+```
+
+For more on `void` please refer to these other documentation entries:
+- [v1 handbook](https://www.typescriptlang.org/docs/handbook/basic-types.html#void)
+- [v2 handbook](https://www.typescriptlang.org/docs/handbook/2/functions.html#void)
+- [FAQ - "Why are functions returning non-void assignable to function returning void?"](https://github.com/Microsoft/TypeScript/wiki/FAQ#why-are-functions-returning-non-void-assignable-to-function-returning-void)


### PR DESCRIPTION
Wasn't sure if this deserved to be in the `void` part of this document. It more has to do with function assignability but I'll see what maintainers have to say about it. In addition, wasn't sure the best way to link to other things so let me know how to change that if necessary.

Rel: https://github.com/microsoft/TypeScript/issues/41138 (already closed by bot)