### PR TITLE
Fix the footer link to TSConfig Options page

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/SiteFooter.tsx
+++ b/packages/typescriptlang-org/src/components/layout/SiteFooter.tsx
@@ -46,7 +46,7 @@ const popularPages = [
   },
   {
     title: "TSConfig Options",
-    url: "/tsconfig.html",
+    url: "/tsconfig",
     description: "All the configuration options for a project",
   },
   {


### PR DESCRIPTION
Fixed the _TSConfig Options_ link in the footer [Popular documentation pages section]. 
**Issue #1291**
as suggested by @orta 