### PR TITLE
Fix typo in hyperlink

### DIFF
--- a/packages/documentation/copy/en/project-config/Integrating with Build Tools.md
+++ b/packages/documentation/copy/en/project-config/Integrating with Build Tools.md
@@ -258,7 +258,7 @@ Update project file to include locally installed `Microsoft.TypeScript.Default.p
 </Project>
 ```
 
-More details about defining MSBuild compiler options: [Setting Compiler Options in MSBuild projects](/docs/handbook/compiler-options-in-msbuild.htmld)
+More details about defining MSBuild compiler options: [Setting Compiler Options in MSBuild projects](/docs/handbook/compiler-options-in-msbuild.html)
 
 ## NuGet
 


### PR DESCRIPTION
There's an extra 'd' in the MSBuild compiler options's hyperlink