### PR TITLE
Polish translation for community.ts and documentation.ts

### DIFF
--- a/packages/typescriptlang-org/src/copy/pl/community.ts
+++ b/packages/typescriptlang-org/src/copy/pl/community.ts
@@ -1,0 +1,30 @@
+export const comCopy = {
+  com_layout_title: "Jak zacząć pracę z TypeScriptem", // FIXME: Is this the right title for the community page?
+  com_layout_description:
+    "Poznaj innych użytkowników i użytkowniczki TypeScriptu online i na żywo.",
+  com_headline: "Poznajmy się", // FIXME: I think this is not used anywhere
+  com_connect_online: "Online",
+  com_connect_online_description:
+    "Powiedz nam, co działa dobrze, co powinno być dodane lub ulepszone, i dowiedz się o nowych aktualizacjach.",
+  com_online_stack_overflow_desc:
+    "Zapytaj o poradę swoich kolegów i koleżanki, używając taga 'typescript'",
+  com_online_stack_overflow_tag: "",
+  com_online_discord_header: "Czat",
+  com_online_discord_desc:
+    "Porozmawiaj z innymi użytkowni(cz)kami TypeScriptu na Czacie Społeczności.",
+  com_online_github_desc:
+    "Znalazłeś/aś buga, albo chcesz przekazać nam konstruktywną opinię?",
+  com_online_github_href: "Powiedz nam na GitHubie",
+  com_online_twitter_desc: "Bądź na bieżąco. Śledź nas na Twitterze",
+  com_online_blog_desc:
+    "Dowiedz się o najnowszych osiągnięciach w języku TypeScript, czytając nasz ", // ... blog
+  com_online_typed_desc: "Pliki definicji TypeScript.",
+  com_online_typed_href: "Przeglądaj tysiące",
+  com_online_typed_available_for:
+    "plików dostępnych dla popularnych bibliotek i frameworków",
+  com_person: "Poznaj osobiście",
+  com_conferences: "Konferencje",
+  com_conferences_alt_img: "logo ",
+
+
+}

--- a/packages/typescriptlang-org/src/copy/pl/documentation.ts
+++ b/packages/typescriptlang-org/src/copy/pl/documentation.ts
@@ -6,16 +6,8 @@ export const docCopy = {
   doc_bootstrap_description:
     "Łańcuchy narzędzi do tworzenia CLI, aplikacji webowych, API i aplikacji.",
   doc_headline: "Zasoby szkoleniowe",
-  doc_headline_ts_for_js_title: "TS dla JS", // TODO: Remove, unused
-  doc_headline_ts_for_js_blurb:
-    "Omówienie TypeScriptu dla osób znających JavaScript", // TODO: Remove, unused
-  doc_headline_ts_first_title: "Zacznij z TypeScriptem", // TODO: Remove, unused
-  doc_headline_ts_first_blurb:
-    "Wprowadzenie do JavaScriptu i TypeScriptu dla początkujących", // TODO: Remove, unused
   doc_headline_handbook_title: "Przewodnik", // TODO: This is not actually used on headline section, should be moved to the doc_learn section
   doc_headline_handbook_blurb: "Dokumentacja języka TypeScript",
-  doc_headline_examples_title: "Przykłady", // TODO: Remove, unused
-  doc_headline_examples_blurb: "Wszechstronne samouczki z zadaniami praktycznymi", // TODO: Remove, unused
   doc_start_a_project: "Zacznij nowy projekt",
   doc_start_a_project_desc:
     "Ponieważ TypeScript jest super-setem JavaScriptu, nie ma domyślnego szablonu - byłoby ich zbyt wiele. Zamiast tego inne projekty mają własne TypeScriptowe szablony ze swoim specyficznym kontekstem. Te projekty zapewniają szablony, które obejmują obsługę TypeScriptu.",
@@ -71,7 +63,6 @@ export const docCopy = {
   doc_tooling_webpack_blurb: "Spakuj swoje assety, skrypty, obrazy i style",
   doc_learn: "Znasz już TypeScript?",
   doc_learn_3_5_release_notes_title: "Informacje o wersji",
-  doc_learn_handbook_blurb: "Dokumentacja języka TypeScript", // TODO: Remove, unused
   doc_learn_d_ts_title: "Przewodnik po plikach d.ts",
   doc_learn_d_ts_blurb: "Dowiedz się, jak opisać biblioteki JS",
   doc_learn_playground_blurb: "Przeglądaj i udostępniaj kod TypeScript online",

--- a/packages/typescriptlang-org/src/copy/pl/documentation.ts
+++ b/packages/typescriptlang-org/src/copy/pl/documentation.ts
@@ -1,0 +1,78 @@
+export const docCopy = {
+  doc_layout_title: "Punkt wyjścia do naukio TypeScriptu",
+  doc_layout_description:
+    "Znajdź projekty startowe TypeScript: od Angulara do Reacta lub Node.js i CLI",
+  doc_bootstrap_title: "Narzędzia bootstrapowania dla projektów w TypeScripcie",
+  doc_bootstrap_description:
+    "Łańcuchy narzędzi do tworzenia CLI, aplikacji webowych, API i aplikacji.",
+  doc_headline: "Zasoby szkoleniowe",
+  doc_headline_ts_for_js_title: "TS dla JS", // TODO: Remove, unused
+  doc_headline_ts_for_js_blurb:
+    "Omówienie TypeScriptu dla osób znających JavaScript", // TODO: Remove, unused
+  doc_headline_ts_first_title: "Zacznij z TypeScriptem", // TODO: Remove, unused
+  doc_headline_ts_first_blurb:
+    "Wprowadzenie do JavaScriptu i TypeScriptu dla początkujących", // TODO: Remove, unused
+  doc_headline_handbook_title: "Przewodnik", // TODO: This is not actually used on headline section, should be moved to the doc_learn section
+  doc_headline_handbook_blurb: "Dokumentacja języka TypeScript",
+  doc_headline_examples_title: "Przykłady", // TODO: Remove, unused
+  doc_headline_examples_blurb: "Wszechstronne samouczki z zadaniami praktycznymi", // TODO: Remove, unused
+  doc_start_a_project: "Zacznij nowy projekt",
+  doc_start_a_project_desc:
+    "Ponieważ TypeScript jest super-setem JavaScriptu, nie ma domyślnego szablonu - byłoby ich zbyt wiele. Zamiast tego inne projekty mają własne TypeScriptowe szablony ze swoim specyficznym kontekstem. Te projekty zapewniają szablony, które obejmują obsługę TypeScriptu.",
+  doc_node_npm: "Node + npm",
+  doc_node_npm_tsdx_blurb: "Niewymagające konfiguracji narzędzie do budowy bibliotek w TypeScripcie",
+  doc_node_npm_oclif_blurb: "Stwórz interfejs wiersza poleceń, który pokochają Twoi użytkownicy i użytkowniczki",
+  doc_node_npm_gluegun_blurb:
+    "Wspaniały zestaw narzędzi do tworzenia aplikacji wiersza poleceń opartych na języku TypeScript",
+  doc_frameworks: "Frameworki webowe",
+  doc_frameworks_angular_blurb:
+    "Sprawia, że pisanie pięknych aplikacji jest przyjemne i radosne",
+  doc_frameworks_ember_blurb: "Framework dla ambitnych webdeveloperów i webdeveloperek",
+  doc_frameworks_react_blurb:
+    "Biblioteka JavaScript do tworzenia interfejsów użytkownika",
+  doc_frameworks_vue_blurb: "Progresywny framework JavaScript",
+  doc_frameworks_ror_blurb: "Framework ceniący konwencję ponad konfiguracją",
+  doc_frameworks_asp_blurb:
+    "Framework do tworzenia nowoczesnych, opartych na chmurze aplikacji połączonych z Internetem",
+  doc_apis: "API do Node",
+  doc_apis_azure_blurb: "Twórz i wdrażaj w VS Code w mgnieniu oka",
+  doc_apis_feather_blurb:
+    "Framework dla aplikacji czasu rzeczywistego i REST API",
+  doc_apis_graphql_blurb: "Uruchom swój serwer GraphQL w ciągu kilku sekund",
+  doc_apis_nest_blurb:
+    "Progresywny framework Node.js do tworzenia wydajnych i skalowalnych aplikacji serwerowych",
+  doc_apis_node_blurb: "Udokumentowany szablon startowy od zespołu TS",
+  doc_apis_wechat_blurb: "Użyj WeChat JSSDK z TypeScriptem",
+  doc_apis_loopback_blurb:
+    "Wysoce rozszerzalny framework oparty na Node.js i TypeScripcie do tworzenia API i mikroservice'ów",
+  doc_apis_fastify_blurb: "Szybki i prosty framework webowy dla Node.js",
+  doc_react: "Projekty Reactowe",
+  doc_react_create_blurb: "Skonfiguruj nowoczesną aplikację webową jedną komendą",
+  doc_react_gatsby_blurb:
+    "Pomaga developer(k)om w tworzeniu niesamowicie szybkich stron i aplikacji",
+  doc_react_next_blurb: "Framework Reactowy",
+  doc_react_razzle_blurb:
+    "Uniwersalne aplikacje JavaScriptowe renderowane po stronie serwera bez żadnej konfiguracji",
+  doc_react_toolchains_title: "Zalecane zestawy narzędzi",
+  doc_react_toolchains_blurb: "Rekomendacje od zespołu Reacta",
+  doc_apps: "Tworzenie aplikacji",
+  doc_apps_electron_blurb:
+    "Twórz wieloplatformowe aplikacje desktopowe za pomocą JavaScriptu, HTML-a i CSS-a",
+  doc_apps_expo_blurb: "Najszybszy sposób na stworzenie aplikacji",
+  doc_apps_react_native_blurb: "Naucz się raz, użyj gdziekolwiek",
+  doc_apps_native_script_blurb:
+    "Framework open source do tworzenia natywnych aplikacji mobilnych",
+  doc_apps_make_code_blurb:
+    "Ożywia informatykę dla wszystkich uczniów i uczennic dzięki ciekawym projektom",
+  doc_tooling: "Narzędzia",
+  doc_tooling_babel_blurb: "Użyj JavaScriptu nowej generacji już dziś",
+  doc_tooling_parcel_blurb:
+    "Błyskawicznie szybki bundler aplikacji webowych z zerową konfiguracją",
+  doc_tooling_webpack_blurb: "Spakuj swoje assety, skrypty, obrazy i style",
+  doc_learn: "Znasz już TypeScript?",
+  doc_learn_3_5_release_notes_title: "Informacje o wersji",
+  doc_learn_handbook_blurb: "Dokumentacja języka TypeScript", // TODO: Remove, unused
+  doc_learn_d_ts_title: "Przewodnik po plikach d.ts",
+  doc_learn_d_ts_blurb: "Dowiedz się, jak opisać biblioteki JS",
+  doc_learn_playground_blurb: "Przeglądaj i udostępniaj kod TypeScript online",
+}

--- a/packages/typescriptlang-org/src/copy/pl/documentation.ts
+++ b/packages/typescriptlang-org/src/copy/pl/documentation.ts
@@ -1,5 +1,5 @@
 export const docCopy = {
-  doc_layout_title: "Punkt wyjścia do naukio TypeScriptu",
+  doc_layout_title: "Punkt wyjścia do nauki TypeScriptu",
   doc_layout_description:
     "Znajdź projekty startowe TypeScript: od Angulara do Reacta lub Node.js i CLI",
   doc_bootstrap_title: "Narzędzia bootstrapowania dla projektów w TypeScripcie",
@@ -19,7 +19,7 @@ export const docCopy = {
   doc_frameworks: "Frameworki webowe",
   doc_frameworks_angular_blurb:
     "Sprawia, że pisanie pięknych aplikacji jest przyjemne i radosne",
-  doc_frameworks_ember_blurb: "Framework dla ambitnych webdeveloperów i webdeveloperek",
+  doc_frameworks_ember_blurb: "Framework dla ambitnych webdeveloperów/ek",
   doc_frameworks_react_blurb:
     "Biblioteka JavaScript do tworzenia interfejsów użytkownika",
   doc_frameworks_vue_blurb: "Progresywny framework JavaScript",
@@ -55,7 +55,7 @@ export const docCopy = {
   doc_apps_native_script_blurb:
     "Framework open source do tworzenia natywnych aplikacji mobilnych",
   doc_apps_make_code_blurb:
-    "Ożywia informatykę dla wszystkich uczniów i uczennic dzięki ciekawym projektom",
+    "Urozmaica informatykę dla wszystkich uczniów i uczennic dzięki ciekawym projektom",
   doc_tooling: "Narzędzia",
   doc_tooling_babel_blurb: "Użyj JavaScriptu nowej generacji już dziś",
   doc_tooling_parcel_blurb:


### PR DESCRIPTION
A Polish translation for community.ts and documentation.ts.

I made sure male and female people are both represented (gendered language is unavoidable in Polish).

I kept the original FIXME and TODO comments from `en` files.

In my second commit, I've removed the lines marked as "unused". This can be reversed though if needed - they are still translated in the first one.