### PR TITLE
fix: playground actions `clear playground logs`

### DIFF
--- a/packages/playground/src/sidebar/runtime.ts
+++ b/packages/playground/src/sidebar/runtime.ts
@@ -14,6 +14,7 @@ export const runPlugin: PluginFactory = (i, utils) => {
       if (!addedClearAction) {
         const ui = createUI()
         addClearAction(sandbox, ui, i)
+        addedClearAction = true
       }
 
       if (allLogs.length === 0) {


### PR DESCRIPTION
<!-- Summary -->
When Run Script `Clear Playground Logs` is appended to actions every single time. they are all doing the same action.
<!-- Screenshot -->
![image](https://user-images.githubusercontent.com/29834890/97804284-c66c0f80-1c89-11eb-9f9b-c3223e9eb31a.png)

<!-- Drag a screenshot image inbetween these ^ -->

<!-- Bug Report -->

**Repro:**
- GO TO [Playground](https://www.typescriptlang.org/play?#code/DYUwLgBAlgzgIgewHYgFwQEYIaAhkiAXggDNdgYQBuIA) 
- Click Run multiple times
- Check actions in editor 
- `Clear background Logs` action is repeated
```ts
// A *self-contained* demonstration of the problem follows...
// Test this by running `tsc` on the command-line, rather than through another build tool such as Gulp, Webpack, etc.
```

**Expected behavior:**
`Clear Background Logs` is appended to actions list one time only
**Actual behavior:**
`Clear background Logs` action is repeated as much as the script runs
