### PR TITLE
fix: use correct import syntax in esModuleInterop docs

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/esModuleInterop.md
+++ b/packages/tsconfig-reference/copy/en/options/esModuleInterop.md
@@ -7,7 +7,7 @@ By default (with `esModuleInterop` false or not set) TypeScript treats CommonJS/
 
 - a namespace import like `import * as moment from "moment"` acts the same as `const moment = require("moment")`
 
-- a default import like `import moment as "moment"` acts the same as `const moment = require("moment").default`
+- a default import like `import moment from "moment"` acts the same as `const moment = require("moment").default`
 
 This mis-match causes these two issues:
 

--- a/packages/tsconfig-reference/copy/id/options/esModuleInterop.md
+++ b/packages/tsconfig-reference/copy/id/options/esModuleInterop.md
@@ -7,7 +7,7 @@ Secara bawaan (dengan `esModuleInterop` _false_ atau tidak disetel) TypeScript m
 
 - Impor namespace seperti `import * as moment from "moment"` bertindak sama seperti `const moment = require("moment")`
 
-- Impor bawaan seperti `import moment as "moment"` berfungsi sama seperti `const moment = require("moment").default`
+- Impor bawaan seperti `import moment from "moment"` berfungsi sama seperti `const moment = require("moment").default`
 
 Ketidakcocokan ini menyebabkan dua masalah berikut:
 

--- a/packages/tsconfig-reference/copy/zh/options/esModuleInterop.md
+++ b/packages/tsconfig-reference/copy/zh/options/esModuleInterop.md
@@ -6,7 +6,7 @@ oneline: "为了便于支持导入 commonjs 模块生成额外的 JS"
 
 - 形如 `import * as moment from "moment"` 这样的命名空间导入等价于 `const moment = require("moment")`
 
-- 形如 `import moment as "moment"` 这样的默认导入等价于 `const moment = require("moment").default`
+- 形如 `import moment from "moment"` 这样的默认导入等价于 `const moment = require("moment").default`
 
 
 这种错误的行为导致了这两个问题：


### PR DESCRIPTION
It seems that an incorrect import syntax is used in the documentation of `esModuleInterop` config option.

This PR fixes all markdown files having this mistake.

The [Japanese](https://github.com/microsoft/TypeScript-Website/blob/v2/packages/tsconfig-reference/copy/ja/options/esModuleInterop.md) and the [Portugese](https://github.com/microsoft/TypeScript-Website/blob/v2/packages/tsconfig-reference/copy/pt/options/esModuleInterop.md) files seem to follow a different template, so no changes there.