### PR TITLE
Add single quote example

### DIFF
--- a/packages/documentation/copy/en/handbook-v1/Basic Types.md
+++ b/packages/documentation/copy/en/handbook-v1/Basic Types.md
@@ -39,7 +39,7 @@ Just like JavaScript, TypeScript also uses double quotes (`"`) or single quotes 
 
 ```ts twoslash
 let color: string = "blue";
-color = "red";
+color = 'red';
 ```
 
 You can also use _template strings_, which can span multiple lines and have embedded expressions.

--- a/packages/documentation/copy/en/handbook-v1/Basic Types.md
+++ b/packages/documentation/copy/en/handbook-v1/Basic Types.md
@@ -39,6 +39,7 @@ Just like JavaScript, TypeScript also uses double quotes (`"`) or single quotes 
 
 ```ts twoslash
 let color: string = "blue";
+// prettier-ignore
 color = 'red';
 ```
 


### PR DESCRIPTION
This change uses 'red' instead of "red" in the color assign, so as to provide examples of both possibilities, as stated in the previous text:

> TypeScript also uses double quotes (`"`) or single quotes (`'`) to surround string data