### PR TITLE
Add backticks around readonly in Interfaces.md

### DIFF
--- a/packages/documentation/copy/en/handbook-v1/Interfaces.md
+++ b/packages/documentation/copy/en/handbook-v1/Interfaces.md
@@ -430,7 +430,7 @@ let myArray: ReadonlyStringArray = ["Alice", "Bob"];
 myArray[2] = "Mallory"; // error!
 ```
 
-You can't set `myArray[2]` because the index signature is readonly.
+You can't set `myArray[2]` because the index signature is `readonly`.
 
 ## Class Types
 


### PR DESCRIPTION
Throughout the whole document, `readonly` is always styled as an inline code, except in this occurrence.
This change adds the backticks around it so it follows the same pattern.