### PR TITLE
feat(playground): support `displayName` for plugins

### DIFF
--- a/packages/playground/scripts/getListOfPluginsFromNPM.js
+++ b/packages/playground/scripts/getListOfPluginsFromNPM.js
@@ -1,7 +1,7 @@
 // @ts-check
 
-// Looks at all the npm packages with the playground-plugin keyword, which 
-// is a default in the templates. 
+// Looks at all the npm packages with the playground-plugin keyword, which
+// is a default in the templates.
 
 // Run via: CI=true yarn workspace typescript-playground run bootstrap
 
@@ -15,7 +15,7 @@ const { writeFileSync } = require("fs")
 const { join } = require("path")
 const { format } = require("prettier")
 
-const get = async (url) => {
+const get = async url => {
   const packageJSON = await nodeFetch(url)
   const contents = await packageJSON.json()
   return contents
@@ -25,11 +25,14 @@ const go = async () => {
   const defaultRepo = "https://github.com/[you]/[repo]"
   const results = await get("http://registry.npmjs.com/-/v1/search?size=50&text=keywords:playground-plugin")
   const summary = results["objects"].map(o => ({
-    name: toName(o.package.name),
+    name: fixDesc(o.package.displayName) || toName(o.package.name),
     id: o.package.name,
     description: fixDesc(o.package.description),
     author: o.package.publisher.username,
-    href: o.package.links.repository && o.package.links.repository !== defaultRepo ? o.package.links.repository : o.package.links.npm || o.package.links.npm
+    href:
+      o.package.links.repository && o.package.links.repository !== defaultRepo
+        ? o.package.links.repository
+        : o.package.links.npm || o.package.links.npm,
   }))
 
   const path = join(__dirname, "..", "src", "sidebar", "fixtures", "npmPlugins.ts")
@@ -40,24 +43,25 @@ const go = async () => {
 // basically a fancy ID -> Name
 // with a few edge cases.
 
-const toName = (str) => {
-  return fixDesc(str.replace("typescript-playground-", "")
-    .replace("ts-playground-plugin-", "")
-    .replace("playground-plugin-", "")
-    .replace("playground-", "")
-    .replace(/-/g, " ")
-    .replace(/\w\S*/g,
-      function (txt) {
-        return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
-      })
+const capitalize = str => str.charAt(0).toUpperCase() + str.substr(1).toLowerCase()
+
+const toName = str => {
+  return fixDesc(
+    str
+      .replace("typescript-playground-", "")
+      .replace("ts-playground-plugin-", "")
+      .replace("playground-plugin-", "")
+      .replace("playground-", "")
+      .replace(/-/g, " ")
+      .replace(/\w\S*/g, capitalize)
   )
 }
 
-const fixDesc = (str) => {
-  return str.replace("Typescript", "TypeScript")
-    .replace("typescript", "TypeScript")
-    .replace("Github", "GitHub")
-    .replace("github", "GitHub")
+const fixDesc = str => {
+  return (str || "")
+    .replace(/typescript/gi, "TypeScript")
+    .replace(/github/gi, "GitHub")
+    .trim()
 }
 
 go()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11247099/99761095-360a4780-2b30-11eb-9cff-2205db4e4d7d.png)

The package naming converting can't possibly handle all the situations, instead of handling more edge cases, maybe it's better to allow customization. This PR adding a feature to the fetching script, allowing to use `displayName` if it presents.

Similar to VS Code extension manifest: https://code.visualstudio.com/api/references/extension-manifest

