### PR TITLE
Fix typo in blog link tooltip

### DIFF
--- a/packages/typescriptlang-org/src/templates/pages/community.tsx
+++ b/packages/typescriptlang-org/src/templates/pages/community.tsx
@@ -90,11 +90,11 @@ export const Comm: React.FC<Props> = props => {
             <div className="callout">
               <a aria-labelledby="blog-header" className="icon blog img-circle" href="https://devblogs.microsoft.com/typescript/" target="_blank" title="The official TypeScript blog" />
               <div className="text">
-                <a href="https://devblogs.microsoft.com/typescript/" id="blog-header" target="_blank" title="The official TypeSCript blog">
+                <a href="https://devblogs.microsoft.com/typescript/" id="blog-header" target="_blank" title="The official TypeScript blog">
                   <h3 className="community-callout-headline">Blog</h3>
                 </a>
                 {i("com_online_blog_desc") + " "}
-                <a href="https://devblogs.microsoft.com/typescript/" target="_blank" title="The official TypeSCript blog">blog</a>!
+                <a href="https://devblogs.microsoft.com/typescript/" target="_blank" title="The official TypeScript blog">blog</a>!
             </div>
             </div>
             <div className="callout">

--- a/packages/typescriptlang-org/src/templates/pages/community.tsx
+++ b/packages/typescriptlang-org/src/templates/pages/community.tsx
@@ -88,7 +88,7 @@ export const Comm: React.FC<Props> = props => {
             </div>
             </div>
             <div className="callout">
-              <a aria-labelledby="blog-header" className="icon blog img-circle" href="https://devblogs.microsoft.com/typescript/" target="_blank" title="The official TypeSCript blog" />
+              <a aria-labelledby="blog-header" className="icon blog img-circle" href="https://devblogs.microsoft.com/typescript/" target="_blank" title="The official TypeScript blog" />
               <div className="text">
                 <a href="https://devblogs.microsoft.com/typescript/" id="blog-header" target="_blank" title="The official TypeSCript blog">
                   <h3 className="community-callout-headline">Blog</h3>


### PR DESCRIPTION
:heavy_check_mark: Fixed a small typo in the `title` attribute.