### PR TITLE
fix: correct some typos in playground examples

### DIFF
--- a/packages/playground-examples/copy/en/4-0/New Checks/Class Constructor Code Flow.ts
+++ b/packages/playground-examples/copy/en/4-0/New Checks/Class Constructor Code Flow.ts
@@ -1,5 +1,5 @@
 //// { compiler: { ts: "4.0.2" } }
-//
+
 // In 4.0, we use control flow analysis to
 // infer the potential type of a class property based on
 // what values are set during the constructor.

--- a/packages/playground-examples/copy/en/4-0/New TS Features/Named Tuples.ts
+++ b/packages/playground-examples/copy/en/4-0/New TS Features/Named Tuples.ts
@@ -2,7 +2,7 @@
 // Tuples are arrays where the order is important to the type system,
 // you can learn more about them in example:tuples
 
-// In TypeScript 3.9, the type of a Tuple's gained the ability to give
+// In TypeScript 4.0, the type of a Tuple's gained the ability to give
 // a name to the different parts of the array.
 
 // For example, you used to write a Lat Long location via a tuple:

--- a/packages/playground-examples/copy/en/4-0/New TS Features/Unknown in Catch.ts
+++ b/packages/playground-examples/copy/en/4-0/New TS Features/Unknown in Catch.ts
@@ -24,7 +24,7 @@ try {
 
 try {
   // ..
-} catch (e) {
+} catch (e: unknown) {
   // You cannot use `e` at all until the type
   // system learns what it is, for more info see:
   // example:unknown-and-never

--- a/packages/playground-examples/copy/en/4-0/New TS Features/Variadic Tuples.ts
+++ b/packages/playground-examples/copy/en/4-0/New TS Features/Variadic Tuples.ts
@@ -20,7 +20,7 @@ type MaxMinDiameter = AddMax<[min: number, diameter: number]>
 type SuffixDIContext<T extends unknown[]> = [...first: T, context: any];
 type DIContainer = SuffixDIContext<[param: string]>
 
-// This mechanism can be combined with multiple input params. For example, This
+// This mechanism can be combined with multiple input params. For example, this
 // function merges two arrays but uses '\0' as a sigil to indicate where the arrays 
 // start and stop.
 function joinWithNullTerminators<T extends unknown[], U extends unknown[]>(t: [...T], u: [...U]) {
@@ -30,7 +30,6 @@ function joinWithNullTerminators<T extends unknown[], U extends unknown[]>(t: [.
 // TypeScript can infer the return type of a function like this:
 const result = joinWithNullTerminators(['variadic', 'types'], ["terminators", 3]);
 
-//
 // These tools make it possible to correctly type a function like curry which
 // is a well used concept in functional programming:
 

--- a/packages/playground-examples/copy/en/4-1/New JS Features/See in JSDoc.ts
+++ b/packages/playground-examples/copy/en/4-1/New JS Features/See in JSDoc.ts
@@ -17,5 +17,5 @@ const goodbye = "Good";
  * You say hi, I say low
  *
  * @see goodbye
- * */
+ */
 const hello = "Hello, hello";

--- a/packages/playground-examples/copy/en/4-1/Template Literals/Intro to Template Literals.ts
+++ b/packages/playground-examples/copy/en/4-1/Template Literals/Intro to Template Literals.ts
@@ -11,7 +11,7 @@ enableFeature("newPaymentSystem");
 
 // String literals supports all the way you can write a 
 // string in ES2020, with TypeScript 4.1 we've extended 
-//  support for interpolation inside a template string literal.
+// support for interpolation inside a template string literal.
 
 type Features = "Redesign" | "newArtistPage";
 

--- a/packages/playground-examples/copy/en/4-1/Template Literals/Mapped Types with Template Literals.ts
+++ b/packages/playground-examples/copy/en/4-1/Template Literals/Mapped Types with Template Literals.ts
@@ -11,10 +11,10 @@
 // type into four functions which correspond to traditional REST calls.
 
 // Template strings literals to describe each API endpoint:
-type GET<T extends string> =  `get${Capitalize<T>}`
-type POST<T extends string> =  `post${Capitalize<T>}`
-type PUT<T extends string> =  `put${Capitalize<T>}`
-type DELETE<T extends string> =  `delete${Capitalize<T>}`
+type GET<T extends string> = `get${Capitalize<T>}`
+type POST<T extends string> = `post${Capitalize<T>}`
+type PUT<T extends string> = `put${Capitalize<T>}`
+type DELETE<T extends string> = `delete${Capitalize<T>}`
 
 // A union of the above literal types
 type REST<T extends string> = GET<T> | POST<T> | PUT<T> | DELETE<T>

--- a/packages/playground-examples/copy/en/4-1/Template Literals/String Manipulation with Template Literals.ts
+++ b/packages/playground-examples/copy/en/4-1/Template Literals/String Manipulation with Template Literals.ts
@@ -50,7 +50,7 @@ type Split<S extends string, D extends string> =
         S extends '' ? [] :
             S extends `${infer T}${D}${infer U}` ?  [T, ...Split<U, D>] :  [S];
 
-// Line 1 declares two params, we'll use single characters for brevity
+// Line 1 declares two params, we'll use single characters for brevity.
 // S represents the string to split, and D is the deliminator. This
 // line ensures they are both strings.
 
@@ -77,8 +77,6 @@ type S3 = Split<"1.2", ".">
 
 // Will recurse once to get all the .'s splitted
 type S4 = Split<"1.2.3", ".">
-
-// The 
 
 // With this knowledge, you should be able to read and understand quite a
 // few of the community examples of template literals, for example:


### PR DESCRIPTION
Corrected some typos in playground examples for versions 4.0 and 4.1.