### PR TITLE
twoslash: fix list<Map> TS options

### DIFF
--- a/packages/gatsby-remark-shiki-twoslash/package.json
+++ b/packages/gatsby-remark-shiki-twoslash/package.json
@@ -20,7 +20,7 @@
     "lint": "tsdx lint"
   },
   "dependencies": {
-    "@typescript/twoslash": "1.1.1",
+    "@typescript/twoslash": "1.1.2",
     "@typescript/vfs": "1.3.0",
     "shiki": "^0.1.6",
     "shiki-languages": "^0.1.6",

--- a/packages/shiki-twoslash/package.json
+++ b/packages/shiki-twoslash/package.json
@@ -20,7 +20,7 @@
     "lint": "tsdx lint"
   },
   "dependencies": {
-    "@typescript/twoslash": "1.1.1",
+    "@typescript/twoslash": "1.1.2",
     "@typescript/vfs": "1.3.0",
     "shiki": "^0.1.6",
     "shiki-languages": "^0.1.6",

--- a/packages/ts-twoslasher/package.json
+++ b/packages/ts-twoslasher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript/twoslash",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "author": "TypeScript team",
   "main": "dist/index.js",

--- a/packages/ts-twoslasher/test/fixtures/tests/lib.ts
+++ b/packages/ts-twoslasher/test/fixtures/tests/lib.ts
@@ -1,0 +1,2 @@
+// @lib: es2015
+const map = new Map<string, Set<number>>()

--- a/packages/ts-twoslasher/test/results/tests/lib.json
+++ b/packages/ts-twoslasher/test/results/tests/lib.json
@@ -1,0 +1,37 @@
+{
+  "code": "const map = new Map<string, Set<number>>()\n",
+  "extension": "ts",
+  "highlights": [],
+  "queries": [],
+  "staticQuickInfos": [
+    {
+      "text": "const map: Map<string, Set<number>>",
+      "docs": "",
+      "start": 6,
+      "length": 3,
+      "line": 0,
+      "character": 6,
+      "targetString": "map"
+    },
+    {
+      "text": "var Map: MapConstructor\nnew <string, Set<number>>(entries?: readonly (readonly [string, Set<number>])[] | null | undefined) => Map<string, Set<number>> (+2 overloads)",
+      "docs": "",
+      "start": 16,
+      "length": 3,
+      "line": 0,
+      "character": 16,
+      "targetString": "Map"
+    },
+    {
+      "text": "interface Set<T>",
+      "docs": "",
+      "start": 28,
+      "length": 3,
+      "line": 0,
+      "character": 28,
+      "targetString": "Set"
+    }
+  ],
+  "errors": [],
+  "playgroundURL": "https://www.typescriptlang.org/play/#code/PTAEAEBsEsCMC5QFMDOAmADARgKwFgAoAYwHsA7FAF1AFsBDAB1AF5QykB3UAWUYB4qAJ2hkA5gBpQAZSSU+ZAK41YSQQD41ACgCUhIA"
+}

--- a/packages/ts-twoslasher/test/results/tests/lib.json
+++ b/packages/ts-twoslasher/test/results/tests/lib.json
@@ -33,5 +33,5 @@
     }
   ],
   "errors": [],
-  "playgroundURL": "https://www.typescriptlang.org/play/#code/PTAEAEBsEsCMC5QFMDOAmADARgKwFgAoAYwHsA7FAF1AFsBDAB1AF5QykB3UAWUYB4qAJ2hkA5gBpQAZSSU+ZAK41YSQQD41ACgCUhIA"
+  "playgroundURL": "https://www.typescriptlang.org/play/#code/PTAEAEBsEsCMC5QFMDOAmADARgKwCgBjAewDsUAXUAWwEMAHUAXlBKQHdQBZegHgoCdoJAOYAaUAGUk5HiQCuVWEn4A+FQAoAlHiA"
 }

--- a/packages/typescriptlang-org/package.json
+++ b/packages/typescriptlang-org/package.json
@@ -25,7 +25,7 @@
     "@mdx-js/react": "^1.5.5",
     "@types/node-fetch": "^2.5.3",
     "@types/react-helmet": "^5.0.15",
-    "@typescript/twoslash": "1.1.1",
+    "@typescript/twoslash": "1.1.2",
     "canvas": "^2.6.1",
     "gatsby": "^2.24.85",
     "gatsby-link": "2.4.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5676,7 +5676,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/twoslash@1.1.1, @typescript/twoslash@workspace:packages/ts-twoslasher":
+"@typescript/twoslash@1.1.2, @typescript/twoslash@workspace:packages/ts-twoslasher":
   version: 0.0.0-use.local
   resolution: "@typescript/twoslash@workspace:packages/ts-twoslasher"
   dependencies:
@@ -14478,7 +14478,7 @@ fsevents@~2.1.2:
   resolution: "gatsby-remark-shiki-twoslash@workspace:packages/gatsby-remark-shiki-twoslash"
   dependencies:
     "@types/jest": ^25.1.3
-    "@typescript/twoslash": 1.1.1
+    "@typescript/twoslash": 1.1.2
     "@typescript/vfs": 1.3.0
     rehype-stringify: ^6.0.1
     shiki: ^0.1.6
@@ -26851,7 +26851,7 @@ resolve@^1.18.1:
   resolution: "shiki-twoslash@workspace:packages/shiki-twoslash"
   dependencies:
     "@types/jest": ^25.1.3
-    "@typescript/twoslash": 1.1.1
+    "@typescript/twoslash": 1.1.2
     "@typescript/vfs": 1.3.0
     gatsby-remark-shiki-twoslash: 0.7.0
     rehype-stringify: ^6.0.1
@@ -29318,7 +29318,7 @@ resolve@^1.18.1:
     "@types/react": ^16.9.20
     "@types/react-dom": ^16.9.5
     "@types/react-helmet": ^5.0.15
-    "@typescript/twoslash": 1.1.1
+    "@typescript/twoslash": 1.1.2
     canvas: ^2.6.1
     concurrently: ^5.1.0
     gatsby: ^2.24.85


### PR DESCRIPTION
Most option types are parsed in `setOption`, even `Map` options are accounted for, but lists of `Map` are not.

This PR fixes the mentioned problem, which most notably prevents `// @lib:` from working correctly.