### PR TITLE
Fix generated allPages to use correct paths on Windows

### DIFF
--- a/packages/typescriptlang-org/lib/bootup/pathsOnSiteTracker.ts
+++ b/packages/typescriptlang-org/lib/bootup/pathsOnSiteTracker.ts
@@ -16,6 +16,8 @@ export const writeAllPathsToFixture = () => {
     `
 // Generated during bootstapping via pathsOnSiteTracker.ts
   
-export const allFiles = ["${paths.join('", "')}"]`
+export const allFiles = [${paths
+      .map(item => '"' + item.replace(/\\/g, "/") + '",')
+      .join("\n")}]`
   )
 }


### PR DESCRIPTION
On a Windows machine, running `yarn start` fails with the following error:

[SITE]
[SITE] File: src\__generated__\allPages.ts:4:7724
[SITE]
[SITE] failed Building development bundle - 14.346s

It appears this is because of Windows using backlash for certain files, leading to incorrect JS

![image](https://user-images.githubusercontent.com/2230453/100398162-2ee8ab00-3002-11eb-9138-a965375b01be.png)

This fix ensures that backlashes are converted to forward-slashes, and also changes the generated output to have each entry on its own line rather than all in one line, just for being able to see the output better.