### PR TITLE
Await evaluation of JS code to ensure logs and error-handling shows up

### DIFF
--- a/packages/playground/src/sidebar/runtime.ts
+++ b/packages/playground/src/sidebar/runtime.ts
@@ -83,9 +83,11 @@ function rewireLoggingToElement(
   console["oldclear"] = console.clear
   console.clear = clearLogs
 
-  closure.then(js => {
+  closure.then(async js => {
     try {
-      eval(js)
+      // The produced JS might well have asynchronous code in it, so await it.
+      // (Having the await fixes https://github.com/microsoft/TypeScript-Website/issues/367)
+      await eval(js)
     } catch (error) {
       console.error(i("play_run_js_fail"))
       console.error(error)


### PR DESCRIPTION
# Problem statement

As reported by me on [this issue](https://github.com/microsoft/TypeScript/issues/41695), and as noticed & reported by [someone else earlier this year](https://github.com/microsoft/TypeScript-Website/issues/367), the Console on the TypeScript playground only works for synchronous code. If you have code like:

```
console.log("start");
pause(100).then(() => console.log("end"))

function pause(ms: number) {
  return new Promise(resolve =>
    setTimeout(resolve, ms));
}
```

only the word "start" will appears with each run, but never "end". However, the real Dev Tools console does show both being logged:

![Works correctly in Dev Tools console](https://user-images.githubusercontent.com/2230453/100295651-fc29ae80-2f3e-11eb-8849-76611c8b8fba.png)

# The fix

The evaluation of user code is done today via

```
try {
      eval(js)
} catch (...) { ... }
```

With my fix, the evaluation of the JS code is `await`-ed (whether or not it's synchronous; if it's synchronous, then the `await` is just a no-op). This ensures both that the `console` variable will remain within the scope of the evaluation, and that any unhandled exceptions would get correctly caught by the `catch` statement.

# Verification
Verified that the TS playground continues to work correctly, and that async code gets logged and error-handled correctly.