### PR TITLE
fix(playground): Bug #367

### DIFF
--- a/packages/playground/src/sidebar/runtime.ts
+++ b/packages/playground/src/sidebar/runtime.ts
@@ -3,7 +3,9 @@ import { PlaygroundPlugin, PluginFactory } from ".."
 import { createUI, UI } from "../createUI"
 import { localize } from "../localizeWithFallback"
 
-let allLogs = ""
+const allLogs: string[] = []
+let offset = 0
+let curLog = 0
 let addedClearAction = false
 
 export const runPlugin: PluginFactory = (i, utils) => {
@@ -34,7 +36,7 @@ export const runPlugin: PluginFactory = (i, utils) => {
 
       const logs = document.createElement("div")
       logs.id = "log"
-      logs.innerHTML = allLogs
+      logs.innerHTML = allLogs.join('<hr />')
       errorUL.appendChild(logs)
     },
   }
@@ -43,7 +45,8 @@ export const runPlugin: PluginFactory = (i, utils) => {
 }
 
 export const clearLogs = () => {
-  allLogs = ""
+  offset += allLogs.length
+  allLogs.length = 0
   const logs = document.getElementById("log")
   if (logs) {
     logs.textContent = ""
@@ -74,59 +77,42 @@ function rewireLoggingToElement(
   autoScroll: boolean,
   i: Function
 ) {
-  fixLoggingFunc("log", "LOG")
-  fixLoggingFunc("debug", "DBG")
-  fixLoggingFunc("warn", "WRN")
-  fixLoggingFunc("error", "ERR")
-  fixLoggingFunc("info", "INF")
-  // @ts-expect-error
-  console["oldclear"] = console.clear
-  console.clear = clearLogs
 
-  closure.then(async js => {
+  const rawConsole = console
+
+  closure.then(js => {
     try {
-      // The produced JS might well have asynchronous code in it, so await it.
-      // (Having the await fixes https://github.com/microsoft/TypeScript-Website/issues/367)
-      await eval(js)
+      const replace = {} as any
+      bindLoggingFunc(replace, rawConsole, 'log', 'LOG', curLog)
+      bindLoggingFunc(replace, rawConsole, 'debug', 'DBG', curLog)
+      bindLoggingFunc(replace, rawConsole, 'warn', 'WRN', curLog)
+      bindLoggingFunc(replace, rawConsole, 'error', 'ERR', curLog)
+      replace['clear'] = clearLogs
+      const console = Object.assign({}, rawConsole, replace)
+      eval(js)
     } catch (error) {
       console.error(i("play_run_js_fail"))
       console.error(error)
     }
-
-    allLogs = allLogs + "<hr />"
-
-    // @ts-expect-error
-    console["clear"] = console["oldclear"]
-    undoLoggingFunc("log")
-    undoLoggingFunc("debug")
-    undoLoggingFunc("warn")
-    undoLoggingFunc("error")
-    undoLoggingFunc("info")
-    undoLoggingFunc("clear")
+    curLog++
   })
 
-  function undoLoggingFunc(name: string) {
-    // @ts-ignore
-    console[name] = console["old" + name]
-  }
-
-  function fixLoggingFunc(name: string, id: string) {
-    // @ts-ignore
-    console["old" + name] = console[name]
-    // @ts-ignore
-    console[name] = function (...objs: any[]) {
+  function bindLoggingFunc(obj: any, raw: any, name: string, id: string, cur: number) {
+    obj[name] = function (...objs: any[]) {
       const output = produceOutput(objs)
       const eleLog = eleLocator()
-      const prefix = '[<span class="log-' + name + '">' + id + "</span>]: "
+      const prefix = `[<span class="log-${name}">${id}</span>]: `
       const eleContainerLog = eleOverflowLocator()
-      allLogs = allLogs + prefix + output + "<br>"
-      eleLog.innerHTML = allLogs
+      const index = cur - offset
+      if (index >= 0) {
+        allLogs[index] = (allLogs[index] ?? '') + prefix + output + "<br>"
+      }
+      eleLog.innerHTML = allLogs.join("<hr />")
       const scrollElement = eleContainerLog.parentElement
       if (autoScroll && scrollElement) {
         scrollToBottom(scrollElement)
       }
-      // @ts-ignore
-      console["old" + name].apply(undefined, objs)
+      raw[name](...objs)
     }
   }
 


### PR DESCRIPTION
Fixes #367 
Fixes #1376 
# Problem statement
The previous fix will still have problems in the following code:
```typescript
console.log("start");
pause(1000).then(() => {
    console.log("end")
});
console.log("something else"); // <== THIS LINE MAKES "end" NOT SHOW UP!

function pause(ms: number) {
    return new Promise(resolve =>
        setTimeout(resolve, ms));
}
```
# The fix
The key is to create a new `console` in the `try catch` scope instead of modifying the original one
# After fix
![show](https://user-images.githubusercontent.com/23739401/100863874-28f63c80-34d0-11eb-9cc4-7dd6a309e084.gif)

