### PR TITLE
change dark-mode playground comment color

### DIFF
--- a/packages/sandbox/src/theme.ts
+++ b/packages/sandbox/src/theme.ts
@@ -3,7 +3,7 @@ const darkerBlue = "1142AF"
 
 const grey = "6c6f2d"
 const greenDark = "0c840a"
-const green = "7caf3d" // dark mode comment color
+const green = "8cff00" // dark mode comment color
 
 export const sandboxTheme: import("monaco-editor").editor.IStandaloneThemeData = {
   base: "vs",

--- a/packages/sandbox/src/theme.ts
+++ b/packages/sandbox/src/theme.ts
@@ -3,7 +3,7 @@ const darkerBlue = "1142AF"
 
 const grey = "6c6f2d"
 const greenDark = "0c840a"
-const green = "8cff00" // dark mode comment color
+const green = "7caf3d" // dark mode comment color
 
 export const sandboxTheme: import("monaco-editor").editor.IStandaloneThemeData = {
   base: "vs",

--- a/packages/sandbox/src/theme.ts
+++ b/packages/sandbox/src/theme.ts
@@ -3,6 +3,7 @@ const darkerBlue = "1142AF"
 
 const grey = "6c6f2d"
 const greenDark = "0c840a"
+const green = "7caf3d" // dark mode comment color
 
 export const sandboxTheme: import("monaco-editor").editor.IStandaloneThemeData = {
   base: "vs",
@@ -53,7 +54,7 @@ export const sandboxThemeDark: import("monaco-editor").editor.IStandaloneThemeDa
   inherit: true,
   rules: [
     { token: "constant", foreground: "44ee11" },
-    { token: "comment", foreground: "919441" },
+    { token: "comment", foreground: green },
     { token: "regexp", foreground: "#811f3f" },
   ],
   colors: {


### PR DESCRIPTION
@orta
HI, i'm contributed on this issue : #351 

i have prepared before-after screenshots for comparison of the changes(below is before-after).

## BEFORE
![image](https://user-images.githubusercontent.com/44183111/101246062-36235d80-3754-11eb-8b30-b459d65712c0.png)


## AFTER
![Untitled](https://user-images.githubusercontent.com/44183111/101246045-1c821600-3754-11eb-9896-ee8e4007c71d.png)

i think that comments look better than before

if u have any opinion, plz feedback via "comments"