### PR TITLE
Typo error in the markdown for the code example

### DIFF
--- a/packages/documentation/copy/en/get-started/TS for the New Programmer.md
+++ b/packages/documentation/copy/en/get-started/TS for the New Programmer.md
@@ -45,7 +45,7 @@ Every language has its own _quirks_ — oddities and surprises, and JavaScript's
   ```js
   const obj = { width: 10, height: 15 };
   // Why is this NaN? Spelling is hard!
-  const area = obj.width * obj.heigth;
+  const area = obj.width * obj.height;
   ```
 
 Most programming languages would throw an error when these sorts of errors occur, some would do so during compilation — before any code is running.
@@ -64,7 +64,7 @@ Here's the error TypeScript found:
 ```ts twoslash
 // @errors: 2551
 const obj = { width: 10, height: 15 };
-const area = obj.width * obj.heigth;
+const area = obj.width * obj.height;
 ```
 
 ### A Typed Superset of JavaScript


### PR DESCRIPTION
Changed the typo errors in the markdown for the codes examples