### PR TITLE
Fix Enum reverse mapping link

### DIFF
--- a/packages/documentation/copy/en/handbook-v1/Enums.md
+++ b/packages/documentation/copy/en/handbook-v1/Enums.md
@@ -88,7 +88,7 @@ enum Direction {
 ```
 
 While string enums don't have auto-incrementing behavior, string enums have the benefit that they "serialize" well.
-In other words, if you were debugging and had to read the runtime value of a numeric enum, the value is often opaque - it doesn't convey any useful meaning on its own (though [reverse mapping](#enums-at-runtime) can often help), string enums allow you to give a meaningful and readable value when your code runs, independent of the name of the enum member itself.
+In other words, if you were debugging and had to read the runtime value of a numeric enum, the value is often opaque - it doesn't convey any useful meaning on its own (though [reverse mapping](#reverse-mappings) can often help), string enums allow you to give a meaningful and readable value when your code runs, independent of the name of the enum member itself.
 
 ## Heterogeneous enums
 


### PR DESCRIPTION
I also checked the other links (3 in total), but the other 2 are as expected

![image](https://user-images.githubusercontent.com/30693990/102122849-66e74f00-3e46-11eb-9e0d-34c85eca407e.png)
