### PR TITLE
Add default return value from getOwnPropertyDescriptor to remedy type error

### DIFF
--- a/packages/documentation/copy/en/reference/Mixins.md
+++ b/packages/documentation/copy/en/reference/Mixins.md
@@ -198,7 +198,8 @@ function applyMixins(derivedCtor: any, constructors: any[]) {
       Object.defineProperty(
         derivedCtor.prototype,
         name,
-        Object.getOwnPropertyDescriptor(baseCtor.prototype, name)
+        Object.getOwnPropertyDescriptor(baseCtor.prototype, name) ||
+          Object.create(null)
       );
     });
   });


### PR DESCRIPTION
Using TS 4.1.2 this example code had a type error. This adds a default return value if `getOwnPropertyDescriptor` returns `undefined` which satisfies the type requirement.

![Screen Shot 2020-12-17 at 10 30 29 AM](https://user-images.githubusercontent.com/532033/102515574-8901ec80-4053-11eb-9019-f3af7a150c43.png)
