### PR TITLE
docs(es) options section files were translated

### DIFF
--- a/packages/tsconfig-reference/copy/es/options/charset.md
+++ b/packages/tsconfig-reference/copy/es/options/charset.md
@@ -1,0 +1,7 @@
+---
+display: "Charset"
+oneline: "Sin soporte. En versiones anteriores, manualmente guarda la codificación del texto para leer archivos."
+---
+
+En versiones anteriores de TypeScript, esto controlaba que tipo de codificación era usada para leer archivos de texto del disco duro.
+Ahora, TypeScript asume codificación UTF-8, pero detectará correctamente UTF-16 (BE y LE) o BOMs UTF-8.

--- a/packages/tsconfig-reference/copy/es/options/checkJs.md
+++ b/packages/tsconfig-reference/copy/es/options/checkJs.md
@@ -1,0 +1,41 @@
+---
+display: "Check JS"
+oneline: "Permite el reporte de errores en archivos con extensión de JavaScript"
+---
+
+Trabaja en conjunto con `allowJs`. Cuando `checkJs` está habilitado entonces los errores son reportados en archivos JavaScript. Esto es el
+equivalente a incluir `// @ts-check` en la parte superior de todos los archivos JavaScript que están incluidos en tu proyecto.
+
+Por ejemplo, lo siguiente es incorrecto de acuerdo a la definición `parseFloat` que viene con TypeScript.
+
+```js
+// parseFloat solo toma un string
+module.exports.pi = parseFloat(3.124);
+```
+
+Cuando es importado a un modulo TypeScript:
+
+```ts twoslash
+// @allowJs
+// @filename: constants.js
+module.exports.pi = parseFloat(3.124);
+
+// @filename: index.ts
+import { pi } from "./constants";
+console.log(pi);
+```
+
+No obtendrás ningún error. De cualquier manera, si habilitas `checkJs` entonces obtendrás mensajes de error del archivo JavaScript.
+You will not get any errors. However, if you turn on `checkJs` then you will get error messages from the JavaScript file.
+
+```ts twoslash
+// @errors: 2345
+// @allowjs: true
+// @checkjs: true
+// @filename: constants.js
+module.exports.pi = parseFloat(3.124);
+
+// @filename: index.ts
+import { pi } from "./constants";
+console.log(pi);
+```

--- a/packages/tsconfig-reference/copy/es/options/checkJs.md
+++ b/packages/tsconfig-reference/copy/es/options/checkJs.md
@@ -25,8 +25,7 @@ import { pi } from "./constants";
 console.log(pi);
 ```
 
-No obtendrás ningún error. De cualquier manera, si habilitas `checkJs` entonces obtendrás mensajes de error del archivo JavaScript.
-You will not get any errors. However, if you turn on `checkJs` then you will get error messages from the JavaScript file.
+No obtendrás ningún error. Sin embargo, si habilitas `checkJs` entonces obtendrás mensajes de error del archivo JavaScript.
 
 ```ts twoslash
 // @errors: 2345

--- a/packages/tsconfig-reference/copy/es/options/composite.md
+++ b/packages/tsconfig-reference/copy/es/options/composite.md
@@ -1,0 +1,16 @@
+---
+display: "Composite"
+oneline: "Habilita restricciones que permiten a un proyecto de TypeScript ser usado con referencias de proyectos."
+---
+
+La opción `composite` aplica ciertas restricciones que hacen posible para herramientas de compilado (incluyendo al mismo TypeScript, bajo el modo `--build`) rápidamente determinar si un proyecto ya ha sido compilado.
+
+Cuando esta configuración está habilitada:
+
+- El ajuste `rootDir`, si no está explícitamente establecido, se aplica como predeterminado el directorio que contenga el archivo `tsconfig.json`.
+
+- Todos los archivos de implementación deben coincididr por un patrón `include` o ser listados en el arreglo de `archivos`. Si esta restricción es infringida, `tsc` te informará cuáles archivos no fueron especificados.
+
+- `declaration` se predetermina a `verdadero`.
+
+Puedes encontrar la documentación en proyectos de TypeScript en [the handbook](https://www.typescriptlang.org/docs/handbook/project-references.html).

--- a/packages/tsconfig-reference/copy/es/options/composite.md
+++ b/packages/tsconfig-reference/copy/es/options/composite.md
@@ -9,8 +9,8 @@ Cuando esta configuración está habilitada:
 
 - El ajuste `rootDir`, si no está explícitamente establecido, se aplica como predeterminado el directorio que contenga el archivo `tsconfig.json`.
 
-- Todos los archivos de implementación deben coincididr por un patrón `include` o ser listados en el arreglo de `archivos`. Si esta restricción es infringida, `tsc` te informará cuáles archivos no fueron especificados.
+- Todos los archivos de implementación deben coincidir por un patrón `include` o ser listados en el arreglo de `files`. Si esta restricción es infringida, `tsc` te informará cuáles archivos no fueron especificados.
 
 - `declaration` se predetermina a `verdadero`.
 
-Puedes encontrar la documentación en proyectos de TypeScript en [the handbook](https://www.typescriptlang.org/docs/handbook/project-references.html).
+Puedes encontrar la documentación en proyectos de TypeScript en [el manual](https://www.typescriptlang.org/docs/handbook/project-references.html).

--- a/packages/tsconfig-reference/copy/es/options/declaration.md
+++ b/packages/tsconfig-reference/copy/es/options/declaration.md
@@ -5,7 +5,7 @@ oneline: "Genera los archivos .d.ts de TypeScript y JavaScript en tu proyecto."
 
 Genera los archivos `.d.ts` para cada archivo TypeScript o JavaScript dentro de tu proyecto.
 Estos archivos `.d.ts` son archivos de tipo definición que describen la API externa de tu módulo.
-Con los archivos `.d.ts`, herramientas como TypeScript pueden ofrecer intellisense y un escritura precisa para código no escrito.
+Con los archivos `.d.ts`, herramientas como TypeScript pueden ofrecer intellisense (auto completado) y un escritura precisa para código no escrito.
 
 Cuando `declaration` esta establecida como `true`, al ejecutar el compilador con el siguiente código TypeScript:
 

--- a/packages/tsconfig-reference/copy/es/options/declaration.md
+++ b/packages/tsconfig-reference/copy/es/options/declaration.md
@@ -1,0 +1,32 @@
+---
+display: "Declaration"
+oneline: "Genera los archivos .d.ts de TypeScript y JavaScript en tu proyecto."
+---
+
+Genera los archivos `.d.ts` para cada archivo TypeScript o JavaScript dentro de tu proyecto.
+Estos archivos `.d.ts` son archivos de tipo definición que describen la API externa de tu módulo.
+Con los archivos `.d.ts`, herramientas como TypeScript pueden ofrecer intellisense y un escritura precisa para código no escrito.
+
+Cuando `declaration` esta establecida como `true`, al ejecutar el compilador con el siguiente código TypeScript:
+
+```ts twoslash
+export let holaMundo = "hi";
+```
+
+Generará un archivo `index.js` como el siguiente:
+
+```ts twoslash
+// @showEmit
+export let holaMundo = "hi";
+```
+
+Con su correspondiente `holaMundo.d.ts`:
+
+```ts twoslash
+// @showEmittedFile: index.d.ts
+// @showEmit
+// @declaration
+export let holaMundo = "hi";
+```
+
+Cuando se trabaja con archivos `.d.ts` para archivos JavaScript, querrás usar [`emitDeclarationOnly`](#emitDeclarationOnly) o usar [`outDir`](#outDir) para asegurarte que los archivos JavaScript no son sobre-escritos.

--- a/packages/tsconfig-reference/copy/es/options/declarationDir.md
+++ b/packages/tsconfig-reference/copy/es/options/declarationDir.md
@@ -23,7 +23,7 @@ con `tsconfig.json`:
 }
 ```
 
-Colocaría el archivo d.ts para el `index.ts` en una carpeta `types`:
+Colocaría el archivo d.ts para `index.ts` en una carpeta `types`:
 
 ```
 ejemplo

--- a/packages/tsconfig-reference/copy/es/options/declarationDir.md
+++ b/packages/tsconfig-reference/copy/es/options/declarationDir.md
@@ -1,0 +1,36 @@
+---
+display: "Declaration Dir"
+oneline: "Especifica el directorio de salida para archivos de declaración generados."
+---
+
+Ofrece una manera de configurar el directorio raíz donde los archivos de declaración son emitidos.
+
+```
+ejemplo
+├── index.ts
+├── package.json
+└── tsconfig.json
+```
+
+con `tsconfig.json`:
+
+```json tsconfig
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationDir": "./types"
+  }
+}
+```
+
+Colocaría el archivo d.ts para el `index.ts` en una carpeta `types`:
+
+```
+ejemplo
+├── index.js
+├── index.ts
+├── package.json
+├── tsconfig.json
+└── types
+    └── index.d.ts
+```

--- a/packages/tsconfig-reference/copy/es/options/declarationMap.md
+++ b/packages/tsconfig-reference/copy/es/options/declarationMap.md
@@ -1,6 +1,6 @@
 ---
 display: "Declaration Map"
-oneline: "Crea un sourcemap para archivos d.ts"
+oneline: "Crea un mapa de fuente para archivos d.ts"
 ---
 
 Genera un _source map_ para los archivos `.d.ts` que representa al archivo fuente `.ts`.

--- a/packages/tsconfig-reference/copy/es/options/declarationMap.md
+++ b/packages/tsconfig-reference/copy/es/options/declarationMap.md
@@ -1,0 +1,9 @@
+---
+display: "Declaration Map"
+oneline: "Crea un sourcemap para archivos d.ts"
+---
+
+Genera un _source map_ para los archivos `.d.ts` que representa al archivo fuente `.ts`.
+Esto permite a editores de código como VS Code ir al archivo `.ts` original cuando se usan características como _Ir a definición_.
+
+Se recomienda fuertemente que consideres habilitar esta característica si estás usando referencias de proyectos.

--- a/packages/tsconfig-reference/copy/es/options/diagnostics.md
+++ b/packages/tsconfig-reference/copy/es/options/diagnostics.md
@@ -5,4 +5,4 @@ oneline: "Información de rendimiento del compilador después de haber compilado
 
 Usado para mostrar la información de diagnóstico para depurar. Este comando es un subconjunto de [`extendedDiagnostics`](#extendedDiagnostics) que son resultados más enfocados al usuario, y más fáciles de interpretar.
 
-Si se te pide por un compilador TypeScript dar los resultados usando esta bandera en una compilación, en el cual no hay daño alguno al usar [`--extendedDiagnostics`](#extendedDiagnostics) en su lugar.
+Si un ingeniero compilador de TypeScript le ha pedido que dé los resultados usando esta bandera en una compilación, en el cual no hay daño alguno al usar [`--extendedDiagnostics`](#extendedDiagnostics) en su lugar.

--- a/packages/tsconfig-reference/copy/es/options/diagnostics.md
+++ b/packages/tsconfig-reference/copy/es/options/diagnostics.md
@@ -1,0 +1,8 @@
+---
+display: "Diagnostics"
+oneline: "Información de rendimiento del compilador después de haber compilado."
+---
+
+Usado para mostrar la información de diagnóstico para depurar. Este comando es un subconjunto de [`extendedDiagnostics`](#extendedDiagnostics) que son resultados más enfocados al usuario, y más fáciles de interpretar.
+
+Si se te pide por un compilador TypeScript dar los resultados usando esta bandera en una compilación, en el cual no hay daño alguno al usar [`--extendedDiagnostics`](#extendedDiagnostics) en su lugar.


### PR DESCRIPTION
Files : charset, checkJs, composite, declaration, declarationDir, declarationMap y diagnostics, all with extension .md were translated to Spanish.