### PR TITLE
Remove "boom!" from documentation

### DIFF
--- a/packages/documentation/copy/en/release-notes/TypeScript 3.8.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 3.8.md
@@ -161,7 +161,6 @@ class Square {
 const a = new Square(100);
 const b = { sideLength: 100 };
 
-// Boom!
 // TypeError: attempted to get private field on non-instance
 // This fails because 'b' is not an instance of 'Square'.
 console.log(a.equals(b));


### PR DESCRIPTION
I know that's a trend at the moment, but I'm convinced we can write good technical documentation without adding "boom!" all over the place.