### PR TITLE
Update compilerOptions.ts

### DIFF
--- a/packages/sandbox/src/compilerOptions.ts
+++ b/packages/sandbox/src/compilerOptions.ts
@@ -52,7 +52,7 @@ export function getDefaultSandboxCompilerOptions(config: PlaygroundConfig, monac
     module: monaco.languages.typescript.ModuleKind.ESNext,
   }
 
-  return settings
+  return { ...settings, ...config.compilerOptions };
 }
 
 /**


### PR DESCRIPTION
config.compilerOptions are not passed to the eventual compileroptions. Only `useJavaScript` is used from the passed in compilerOptions.

The only way for me to set compileroptions from consuming code was via `updateCompilerSetting`, but not via the initial config object. This should fix that