### PR TITLE
Remove auto-select from modals in the playground

### DIFF
--- a/packages/playground/src/createUI.ts
+++ b/packages/playground/src/createUI.ts
@@ -83,7 +83,11 @@ export const createUI = (): UI => {
     event?: React.MouseEvent
   ) => {
     const modal = createModalOverlay(postFocalElement)
-    const isNotMouse = event && event.screenX === 0 && event.screenY === 0
+    // I've not been able to get this to work in a way which
+    // works with every screenreader and browser combination, so
+    // instead I'm dropping the feature.
+
+    const isNotMouse = false //  event && event.screenX === 0 && event.screenY === 0
 
     if (subtitle) {
       const titleElement = document.createElement("h3")


### PR DESCRIPTION
This removes the last a11y issue on my board. It's tricky because I prefer the "select by default" style of modals like this, but I can't pull it off without the selection text-to-speech taking priority over the modal's title and subtitle.