### PR TITLE
fix: #1448

### DIFF
--- a/packages/documentation/copy/en/reference/Utility Types.md
+++ b/packages/documentation/copy/en/reference/Utility Types.md
@@ -81,7 +81,7 @@ const nav: Record<Page, PageInfo> = {
 };
 
 nav.about;
-//   ^?
+// ^?
 ```
 
 ## `Pick<Type, Keys>`


### PR DESCRIPTION
btw, the util type in `Template Literal Types` for example,  always say that can't find `Uppercase` ... 
any way to fix it ? upgrade typescript version since it's a experimental type or using fsMap  or just leave it as-is