### PR TITLE
Playground QOL fixes

### DIFF
--- a/packages/playground/src/createUI.ts
+++ b/packages/playground/src/createUI.ts
@@ -95,7 +95,6 @@ export const createUI = (): UI => {
     }
 
     const textarea = document.createElement("textarea")
-    textarea.autofocus = true
     textarea.readOnly = true
     textarea.wrap = "off"
     textarea.style.marginBottom = "20px"

--- a/packages/playground/src/exporter.ts
+++ b/packages/playground/src/exporter.ts
@@ -135,6 +135,11 @@ export const createExporter = (sandbox: Sandbox, monaco: typeof import("monaco-e
     document.body.removeChild(form)
   }
 
+  function openInBugWorkbench() {
+    const hash = `#code/${sandbox.lzstring.compressToEncodedURIComponent(sandbox.getText())}`
+    document.location.assign(`/dev/bug-workbench/${hash}`)
+  }
+
   function openInTSAST() {
     const hash = `#code/${sandbox.lzstring.compressToEncodedURIComponent(sandbox.getText())}`
     document.location.assign(`https://ts-ast-viewer.com/${hash}`)
@@ -207,30 +212,6 @@ ${codify(await sandbox.getRunnableJS(), "ts")}
 `
 
     return `
-<!-- 🚨 STOP 🚨 𝗦𝗧𝗢𝗣 🚨 𝑺𝑻𝑶𝑷 🚨
-
-Half of all issues filed here are duplicates, answered in the FAQ, or not appropriate for the bug tracker. Even if you think you've found a *bug*, please read the FAQ first, especially the Common "Bugs" That Aren't Bugs section!
-
-Please help us by doing the following steps before logging an issue:
-  * Search: https://github.com/Microsoft/TypeScript/search?type=Issues
-  * Read the FAQ: https://github.com/Microsoft/TypeScript/wiki/FAQ
-
-Please fill in the *entire* template below.
--->
-
-**TypeScript Version:**  ${typescriptVersion}
-
-<!-- Search terms you tried before logging this (so others can find this issue more easily) -->
-**Search Terms:**
-
-**Expected behavior:**
-
-**Actual behavior:**
-
-<!-- Did you find other bugs that looked similar? -->
-**Related Issues:**
-
-**Code**
 ${codify(sandbox.getText(), "ts")}
 
 ${jsSection}
@@ -244,28 +225,6 @@ ${codify(stringifiedCompilerOptions, "json")}
 **Playground Link:** [Provided](${fullURL})
       `
   }
-
-  async function reportIssue(e: React.MouseEvent) {
-    e.persist()
-
-    const body = await makeMarkdown()
-    if (body.length < 4000) {
-      window.open("https://github.com/Microsoft/TypeScript/issues/new?body=" + encodeURIComponent(body))
-    } else {
-      ui.showModal(
-        body,
-        document.getElementById("exports-dropdown")!,
-        "Issue too long to post automatically. Copy this text, then click 'Create New Issue' to begin.",
-        {
-          "Create New Issue": "https://github.com/Microsoft/TypeScript/issues/new",
-        },
-        e
-      )
-      // document.querySelector("#popover-modal pre") && (document.querySelector("#popover-modal pre") as any).focus()
-    }
-    return false
-  }
-
   async function copyAsMarkdownIssue(e: React.MouseEvent) {
     e.persist()
 
@@ -313,11 +272,11 @@ ${codify(stringifiedCompilerOptions, "json")}
   return {
     openProjectInStackBlitz,
     openProjectInCodeSandbox,
-    reportIssue,
     copyAsMarkdownIssue,
     copyForChat,
     copyForChatWithPreview,
     openInTSAST,
+    openInBugWorkbench,
     exportAsTweet,
   }
 }

--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -161,6 +161,10 @@ export const setupPlayground = (
 
   // Sets the URL and storage of the sandbox string
   const playgroundDebouncedMainFunction = () => {
+    localStorage.setItem("sandbox-history", sandbox.getText())
+  }
+
+  sandbox.editor.onDidBlurEditorText(() => {
     const alwaysUpdateURL = !localStorage.getItem("disable-save-on-type")
     if (alwaysUpdateURL) {
       if (suppressNextTextChangeForHashChange) {
@@ -170,9 +174,7 @@ export const setupPlayground = (
       const newURL = sandbox.createURLQueryWithCompilerOptions(sandbox)
       window.history.replaceState({}, "", newURL)
     }
-
-    localStorage.setItem("sandbox-history", sandbox.getText())
-  }
+  })
 
   // When any compiler flags are changed, trigger a potential change to the URL
   sandbox.setDidUpdateCompilerSettings(() => {
@@ -311,6 +313,9 @@ export const setupPlayground = (
     contextMenuOrder: 1.5,
 
     run: function () {
+      // Update the URL, then write that to the clipboard
+      const newURL = sandbox.createURLQueryWithCompilerOptions(sandbox)
+      window.history.replaceState({}, "", newURL)
       window.navigator.clipboard.writeText(location.href.toString()).then(
         () => ui.flashInfo(i("play_export_clipboard")),
         (e: any) => alert(e)

--- a/packages/typescriptlang-org/gatsby-browser.js
+++ b/packages/typescriptlang-org/gatsby-browser.js
@@ -41,13 +41,18 @@ exports.onRouteUpdate = ({ location, prevLocation }) => {
     hasLocalStorage = typeof localStorage !== `undefined`
   } catch (error) {}
 
-  // @ts-ignore
-  aisdk.trackPageView({
-    uri: locationWithoutPlaygroundCode,
-    refUri: referrerWithoutPlaygroundCode,
-    prev: previousLocationWithoutPlaygroundCode,
-    lang: document.documentElement.lang,
-    visitedPlayground:
-      hasLocalStorage && localStorage.getItem("sandbox-history") !== null,
-  })
+  try {
+    // @ts-ignore
+    aisdk.trackPageView({
+      uri: locationWithoutPlaygroundCode,
+      refUri: referrerWithoutPlaygroundCode,
+      prev: previousLocationWithoutPlaygroundCode,
+      lang: document.documentElement.lang,
+      visitedPlayground:
+        hasLocalStorage && localStorage.getItem("sandbox-history") !== null,
+    })
+  } catch (error) {
+    console.error("Error with Application Insights")
+    console.error(error)
+  }
 }

--- a/packages/typescriptlang-org/src/components/workbench/plugins/markdown.ts
+++ b/packages/typescriptlang-org/src/components/workbench/plugins/markdown.ts
@@ -10,17 +10,22 @@ export const workbenchMarkdownPlugin: PluginFactory = (i, utils) => {
     code: string
   ) => {
     ds.subtitle("Markdown for issue")
-    const url = document && document.location ? document.location.href : ""
+    ds.button({
+      label: "Copy Markdown",
+      onclick: () => navigator.clipboard.writeText(mdCode),
+    })
+    ds.p("")
 
-    ds.code(
-      `
+    const url = document && document.location ? document.location.href : ""
+    const mdCode = `
 \`\`\`ts repro
 ${code.replace(/</g, "&lt;")}
 \`\`\`
 
 [Workbench Repro](${url})
-`.trim()
-    )
+    `.trim()
+
+    ds.code(mdCode)
     ds.p(
       "Congrats! These repros make it much easier for us to keep track of bugs on the TypeScript team. You can copy & paste this into an issue or comment on the TypeScript repo to have it get hooked up."
     )

--- a/packages/typescriptlang-org/src/copy/en/playground.ts
+++ b/packages/typescriptlang-org/src/copy/en/playground.ts
@@ -45,6 +45,7 @@ export const playCopy = {
   play_export_copy_link: "Copy as Markdown Link",
   play_export_copy_link_preview: "Copy as Markdown Link with Preview",
   play_export_tsast: "Open in TypeScript AST Viewer",
+  play_export_bugworkbench: "Open in Bug Workbench",
   play_export_sandbox: "Open in CodeSandbox",
   play_export_stackblitz: "Open in StackBlitz",
   play_export_clipboard: "URL copied to clipboard",

--- a/packages/typescriptlang-org/src/copy/es/playground.ts
+++ b/packages/typescriptlang-org/src/copy/es/playground.ts
@@ -42,6 +42,7 @@ export const playCopy = {
   play_export_copy_link_preview:
     "Copiar como un enlace en formato Markdown con vista previa",
   play_export_tsast: "Abrir en el visor AST de TypeScript",
+  play_export_bugworkbench: "Abrir en Bug Workbench",
   play_export_sandbox: "Abrir en CodeSandbox",
   play_export_stackblitz: "Abrir en StackBlitz",
   play_export_clipboard: "URL copiada al portapapeles",

--- a/packages/typescriptlang-org/src/copy/id/playground.ts
+++ b/packages/typescriptlang-org/src/copy/id/playground.ts
@@ -1,56 +1,58 @@
 export const playCopy = {
-	play_subnav_title: "Area Bermain",
-	play_subnav_config: "Konfig TS",
-	play_config_language_blurb: "Bahasa mana yang akan digunakan di editor",
-	play_subnav_examples: "Contoh",
-	play_subnav_examples_close: "Tutup",
-	play_subnav_whatsnew: "Yang Baru",
-	play_subnav_settings: "Pengaturan",
-	play_settings_tabs_settings: "Tab Sidebar",
-	play_downloading_typescript: "Mengunduh TypeScript...", // ketika memuat
-	play_downloading_version: "Versi...", // ketika memuat
-	play_toolbar_run: "Jalankan",
-	play_toolbar_export: "Expor",
-	play_toolbar_share: "Bagikan",
-	play_sidebar_js: ".JS",
-	play_sidebar_dts: ".D.TS",
-	play_sidebar_errors: "Galat",
-	play_sidebar_errors_no_errors: "Tidak ada galat",
-	play_sidebar_logs: "Catatan",
-	play_sidebar_logs_no_logs: "Tidak ada catatan",
-	play_sidebar_options: "Opsi",
-	play_sidebar_options_restart_required: "Dibutuhkan Penyegaran Peramban",
-	play_sidebar_options_disable_ata: "Nonaktifkan ATA",
-	play_sidebar_options_disable_ata_copy:
-		"Nonaktifkan akuisisi dari import dan require otomatis.",
-	play_sidebar_options_disable_save: "Nonaktifkan Simpan-saat-Ketik",
-	play_sidebar_options_disable_save_copy:
-		"Nonaktifkan mengubah URL ketika Anda mengetik.",
-	play_sidebar_plugins: "Plugin",
-	play_sidebar_featured_plugins: "Plugin Unggulan",
-	play_sidebar_plugins_options_external:
-		"Plugin Pihak Ketiga <a href='https://www.npmjs.com/search?q=keywords:playground-plugin'>dari npm</a>",
-	play_sidebar_plugins_options_external_warning:
-		"Peringatan: Kode dari plugin berasal dari pihak ketiga.",
-	play_sidebar_plugins_options_modules: "Modul npm kustom",
-	play_sidebar_plugins_options_modules_placeholder: "Nama modul dari npm.",
-	play_sidebar_plugins_plugin_dev: "Plugin Dev",
-	play_sidebar_plugins_plugin_dev_option:
-		"Terhubung ke <code>localhost:5000</code>",
-	play_sidebar_plugins_plugin_dev_copy:
-		"Secara otomatis mencoba menghubungkan ke plugin Area Bermain dalam mode pengembangan. Anda dapat mulai <a href='/dev/playground-plugins/' title='Tautan ke halaman tentang Plugin Area Bermain'>membuat plugin di sini</a>.",
-	play_export_report_issue: "Laporkan GitHub isu di TypeScript",
-	play_export_copy_md: "Salin sebagai Isu Markdown",
-	play_export_copy_link: "Salin sebagai Tautan Markdown",
-	play_export_copy_link_preview: "Salin sebagai Tautan Markdown dengan Pratinjau",
-	play_export_tsast: "Buka di TypeScript Penampil AST",
-	play_export_sandbox: "Buka di CodeSandbox",
-	play_export_stackblitz: "Buka di StackBlitz",
-	play_export_clipboard: "URL disalin ke clipboard",
-	play_run_js: "Eksekusi JavaScript",
-	play_run_ts: "Eksekusi TypeScript yang di-transpile",
-	play_run_js_fail: "Eksekusi JavaScript Gagal:",
-	play_default_code_sample: `// Selamat datang di Area Bermain TypeScript, ini adalah situs web
+  play_subnav_title: "Area Bermain",
+  play_subnav_config: "Konfig TS",
+  play_config_language_blurb: "Bahasa mana yang akan digunakan di editor",
+  play_subnav_examples: "Contoh",
+  play_subnav_examples_close: "Tutup",
+  play_subnav_whatsnew: "Yang Baru",
+  play_subnav_settings: "Pengaturan",
+  play_settings_tabs_settings: "Tab Sidebar",
+  play_downloading_typescript: "Mengunduh TypeScript...", // ketika memuat
+  play_downloading_version: "Versi...", // ketika memuat
+  play_toolbar_run: "Jalankan",
+  play_toolbar_export: "Expor",
+  play_toolbar_share: "Bagikan",
+  play_sidebar_js: ".JS",
+  play_sidebar_dts: ".D.TS",
+  play_sidebar_errors: "Galat",
+  play_sidebar_errors_no_errors: "Tidak ada galat",
+  play_sidebar_logs: "Catatan",
+  play_sidebar_logs_no_logs: "Tidak ada catatan",
+  play_sidebar_options: "Opsi",
+  play_sidebar_options_restart_required: "Dibutuhkan Penyegaran Peramban",
+  play_sidebar_options_disable_ata: "Nonaktifkan ATA",
+  play_sidebar_options_disable_ata_copy:
+    "Nonaktifkan akuisisi dari import dan require otomatis.",
+  play_sidebar_options_disable_save: "Nonaktifkan Simpan-saat-Ketik",
+  play_sidebar_options_disable_save_copy:
+    "Nonaktifkan mengubah URL ketika Anda mengetik.",
+  play_sidebar_plugins: "Plugin",
+  play_sidebar_featured_plugins: "Plugin Unggulan",
+  play_sidebar_plugins_options_external:
+    "Plugin Pihak Ketiga <a href='https://www.npmjs.com/search?q=keywords:playground-plugin'>dari npm</a>",
+  play_sidebar_plugins_options_external_warning:
+    "Peringatan: Kode dari plugin berasal dari pihak ketiga.",
+  play_sidebar_plugins_options_modules: "Modul npm kustom",
+  play_sidebar_plugins_options_modules_placeholder: "Nama modul dari npm.",
+  play_sidebar_plugins_plugin_dev: "Plugin Dev",
+  play_sidebar_plugins_plugin_dev_option:
+    "Terhubung ke <code>localhost:5000</code>",
+  play_sidebar_plugins_plugin_dev_copy:
+    "Secara otomatis mencoba menghubungkan ke plugin Area Bermain dalam mode pengembangan. Anda dapat mulai <a href='/dev/playground-plugins/' title='Tautan ke halaman tentang Plugin Area Bermain'>membuat plugin di sini</a>.",
+  play_export_report_issue: "Laporkan GitHub isu di TypeScript",
+  play_export_copy_md: "Salin sebagai Isu Markdown",
+  play_export_copy_link: "Salin sebagai Tautan Markdown",
+  play_export_copy_link_preview:
+    "Salin sebagai Tautan Markdown dengan Pratinjau",
+  play_export_tsast: "Buka di TypeScript Penampil AST",
+  play_export_bugworkbench: "Buka di Bug Workbench",
+  play_export_sandbox: "Buka di CodeSandbox",
+  play_export_stackblitz: "Buka di StackBlitz",
+  play_export_clipboard: "URL disalin ke clipboard",
+  play_run_js: "Eksekusi JavaScript",
+  play_run_ts: "Eksekusi TypeScript yang di-transpile",
+  play_run_js_fail: "Eksekusi JavaScript Gagal:",
+  play_default_code_sample: `// Selamat datang di Area Bermain TypeScript, ini adalah situs web
 // yang memberi Anda kesempatan untuk menulis, berbagi, dan mempelajari TypeScript.
 
 // Anda dapat memikirkannya dengan tiga cara:
@@ -66,26 +68,26 @@ console.log(contohVariabel)
 // Mulailah dengan menghapus komentar ini dan dunia adalah area bermain Anda.
   `,
 
-	play_sidebar_js_title: "JavaScript",
-	play_sidebar_js_blurb: "Lihat JS yang telah di-transpile",
+  play_sidebar_js_title: "JavaScript",
+  play_sidebar_js_blurb: "Lihat JS yang telah di-transpile",
 
-	play_sidebar_dts_title: "Berkas Definisi",
-	play_sidebar_dts_blurb: "Lihat keluaran .d.ts dari kode Anda",
+  play_sidebar_dts_title: "Berkas Definisi",
+  play_sidebar_dts_blurb: "Lihat keluaran .d.ts dari kode Anda",
 
-	play_sidebar_err_title: "Galat Penyusun",
-	play_sidebar_err_blurb: "Lihat galat penyusun secara penuh",
+  play_sidebar_err_title: "Galat Penyusun",
+  play_sidebar_err_blurb: "Lihat galat penyusun secara penuh",
 
-	play_sidebar_run_title: "Jalankan JavaScript di peramban",
-	play_sidebar_run_blurb:
-		"Menampilkan keluaran dari menjalankan JavaScript di editor",
+  play_sidebar_run_title: "Jalankan JavaScript di peramban",
+  play_sidebar_run_blurb:
+    "Menampilkan keluaran dari menjalankan JavaScript di editor",
 
-	play_sidebar_plugins_title: "Atur Plugin Area Bermain",
-	play_sidebar_plugins_blurb:
-		"Menangani penambahan/penghapusan ekstensi pihak ketiga ke Area Bermain",
+  play_sidebar_plugins_title: "Atur Plugin Area Bermain",
+  play_sidebar_plugins_blurb:
+    "Menangani penambahan/penghapusan ekstensi pihak ketiga ke Area Bermain",
 
-	play_sidebar_ast_title: "[WIP] Penampil AST",
-	play_sidebar_ast_blurb: "Periksa TypeScript AST",
+  play_sidebar_ast_title: "[WIP] Penampil AST",
+  play_sidebar_ast_blurb: "Periksa TypeScript AST",
 
-	// Notes:
-	// Compiler flag information is all from the tsconfig reference info
+  // Notes:
+  // Compiler flag information is all from the tsconfig reference info
 }

--- a/packages/typescriptlang-org/src/copy/ja/playground.ts
+++ b/packages/typescriptlang-org/src/copy/ja/playground.ts
@@ -39,6 +39,7 @@ export const playCopy = {
   play_export_copy_link: "Markdownリンクとしてコピー",
   play_export_copy_link_preview: "プレビュー付きMarkdownリンクとしてコピー",
   play_export_tsast: "TypeScript AST Viewerで開く",
+  play_export_bugworkbench: "Bug Workbenchで開く",
   play_export_sandbox: "CodeSandboxで開く",
   play_export_stackblitz: "StackBlitzで開く",
   play_export_clipboard: "URLをクリップボードにコピーしました。",

--- a/packages/typescriptlang-org/src/copy/pt/playground.ts
+++ b/packages/typescriptlang-org/src/copy/pt/playground.ts
@@ -43,6 +43,7 @@ export const playCopy = {
   play_export_copy_link: "Copiar Como 'Link Markdown'",
   play_export_copy_link_preview: "Copiar como 'Link Markdown com visualização'",
   play_export_tsast: "Abrir no 'TypeScript AST Viewer'",
+  play_export_bugworkbench: "Abrir no 'Bug Workbench'",
   play_export_sandbox: "Abrir no CodeSandbox",
   play_export_stackblitz: "Abrir no StackBlitz",
   play_export_clipboard: "[URL copiado para a área de transferência]",

--- a/packages/typescriptlang-org/src/copy/zh/playground.ts
+++ b/packages/typescriptlang-org/src/copy/zh/playground.ts
@@ -52,6 +52,7 @@ export const playCopy = {
   play_export_copy_link: "复制为 Markdown 格式的链接",
   play_export_copy_link_preview: "复制为 Markdown 格式可预览的链接",
   play_export_tsast: "在 TypeScript AST 查看器中打开",
+  play_export_bugworkbench: "在 Bug Workbench 中打开",
   play_export_sandbox: "在 CodeSandbox 中打开",
   play_export_stackblitz: "在 StackBlitz 中打开",
   play_export_clipboard: "复制 URL 到剪贴板",

--- a/packages/typescriptlang-org/src/templates/play.scss
+++ b/packages/typescriptlang-org/src/templates/play.scss
@@ -776,6 +776,11 @@ input.good {
   display: flex;
   flex-direction: column;
 
+  textarea {
+    font-family: $font-code;
+    padding: 8px;
+  }
+
   .close {
     position: absolute;
     top: 20px;

--- a/packages/typescriptlang-org/src/templates/play.tsx
+++ b/packages/typescriptlang-org/src/templates/play.tsx
@@ -244,8 +244,6 @@ const Play: React.FC<Props> = (props) => {
                 <li className="dropdown">
                   <a href="#" id="exports-dropdown" className="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" aria-controls="export-dropdown-menu">{i("play_toolbar_export")} <span className="caret"></span></a>
                   <ul className="dropdown-menu" id='export-dropdown-menu' aria-labelledby="whatisnew-button">
-                    <li><a href="#" onClick={(e: any) => playground.exporter.reportIssue(e)} aria-label={i("play_export_report_issue")} >{i("play_export_report_issue")}</a></li>
-                    <li role="separator" className="divider"></li>
                     <li><a href="#" onClick={() => playground.exporter.exportAsTweet()} aria-label={i("play_export_tweet_md")} >{i("play_export_tweet_md")}</a></li>
                     <li role="separator" className="divider"></li>
                     <li><a href="#" onClick={(e: any) => playground.exporter.copyAsMarkdownIssue(e)} aria-label={i("play_export_copy_md")} >{i("play_export_copy_md")}</a></li>
@@ -253,6 +251,7 @@ const Play: React.FC<Props> = (props) => {
                     < li > <a href="#" onClick={(e: any) => playground.exporter.copyForChatWithPreview(e)} aria-label={i("play_export_copy_link_preview")}  >{i("play_export_copy_link_preview")}</a></li>
                     < li role="separator" className="divider" ></li>
                     <li><a href="#" onClick={() => playground.exporter.openInTSAST()} aria-label={i("play_export_tsast")}>{i("play_export_tsast")}</a></li>
+                    <li><a href="#" onClick={() => playground.exporter.openInBugWorkbench()} aria-label={i("play_export_bugworkbench")}>{i("play_export_bugworkbench")}</a></li>
                     <li role="separator" className="divider"></li>
                     <li><a href="#" onClick={() => playground.exporter.openProjectInCodeSandbox()} aria-label={i("play_export_sandbox")} >{i("play_export_sandbox")}</a></li>
                     <li><a href="#" onClick={() => playground.exporter.openProjectInStackBlitz()} aria-label={i("play_export_stackblitz")} >{i("play_export_stackblitz")}</a></li>


### PR DESCRIPTION
- Removes the report issues button in the playground (we're rethinking the process) - fixes #1444 
- Uses the monaco onblur for setting the hash in the location re:1412
- Adds an open in Bug Workshop button to the exporter
- Adds a copy button to the dev workshop markdown preview
- Removes another auto-selection ( See #1461 )
