### PR TITLE
Better Japanese font-family

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/fonts.scss
+++ b/packages/typescriptlang-org/src/components/layout/fonts.scss
@@ -484,9 +484,9 @@ body[lang^="hu"],
 body [lang^="ja"],
 body[lang^="ja"],
 [lang^="ja"] body {
-  font-family: "Yu Gothic UI", "Meiryo UI", Meiryo, "MS Pgothic", Osaka,
-    "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue",
-    sans-serif;
+  font-family: "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto,
+    "Helvetica Neue", Meiryo, "Hiragino Sans", "Source Han Sans",
+    "Noto Sans CJK JP", sans-serif;
 }
 
 body [lang^="kk"],


### PR DESCRIPTION
Updated Japanese font-family to a better one.

Before update font-family (screenshot: macOS)

![macOS Old](https://user-images.githubusercontent.com/77012577/103689302-7afe1680-4fd6-11eb-8464-f54c045312f6.png)

After update font-family (screenshot: macOS)

![macOS New](https://user-images.githubusercontent.com/77012577/103689501-c0224880-4fd6-11eb-8fce-ac3fc8142673.png)

Before update font-family (screenshot: Windows)

![Windows Old](https://user-images.githubusercontent.com/77012577/103689507-c3b5cf80-4fd6-11eb-9ae0-e7a512ea14eb.png)

After update font-family (screenshot: Windows)

![Windows New](https://user-images.githubusercontent.com/77012577/103689505-c284a280-4fd6-11eb-9dfe-97df3317213b.png)
