### PR TITLE
update permalink in pt/mixins.md

### DIFF
--- a/packages/documentation/copy/pt/reference/Mixins.md
+++ b/packages/documentation/copy/pt/reference/Mixins.md
@@ -1,7 +1,7 @@
 ---
 title: Mixins
 layout: docs
-permalink: /docs/handbook/mixins.html
+permalink: /pt/docs/handbook/mixins.html
 oneline: Usando o padrão Mixin com TypeScript
 translatable: true
 ---


### PR DESCRIPTION
I got this error while running `yarn bootstrap`

```
➤ YN0000: [documentation]: Expected /docs/handbook/mixins.html to be /pt/docs/handbook/mixins.html
```