### PR TITLE
Fix `@typescript/vfs` module path

### DIFF
--- a/packages/typescript-vfs/package.json
+++ b/packages/typescript-vfs/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@typescript/vfs",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "author": "TypeScript team",
   "homepage": "https://github.com/microsoft/TypeScript-Website/",
   "main": "./dist/index.js",
-  "module": "./dist/typescript-vsf.esm.js",
+  "module": "./dist/vsf.esm.js",
   "typings": "./dist/index.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
In `@typescript/vfs` package.json `module` points to non existing file.

This is package content when loaded from npm:

![image](https://user-images.githubusercontent.com/16621507/104295808-9337cf00-54c9-11eb-82e8-dc3a0a2bc6b4.png)

And there's no `./dist/typescript-vsf.esm.js`. Shouldn't it be pointing to `./dist/vsf.esm.js`?