### PR TITLE
Adds comment auto-complete for twoslash annotations

### DIFF
--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -9,7 +9,7 @@ import {
 import lzstring from "./vendor/lzstring.min"
 import { supportedReleases } from "./releases"
 import { getInitialCode } from "./getInitialCode"
-import { extractTwoSlashComplierOptions } from "./twoslashSupport"
+import { extractTwoSlashComplierOptions, twoslashCompletions } from "./twoslashSupport"
 import * as tsvfs from "./vendor/typescript-vfs"
 
 type CompilerOptions = import("monaco-editor").languages.typescript.CompilerOptions
@@ -168,6 +168,17 @@ export const createTypeScriptSandbox = (
   }
 
   const getTwoSlashComplierOptions = extractTwoSlashComplierOptions(ts)
+
+  // Auto-complete twoslash comments
+  if (config.supportTwoslashCompilerOptions) {
+    const langs = ["javascript", "typescript"]
+    langs.forEach(l =>
+      monaco.languages.registerCompletionItemProvider(l, {
+        triggerCharacters: ["@", "/"],
+        provideCompletionItems: twoslashCompletions(ts, monaco),
+      })
+    )
+  }
 
   const textUpdated = () => {
     const code = editor.getModel()!.getValue()

--- a/packages/sandbox/src/twoslashSupport.ts
+++ b/packages/sandbox/src/twoslashSupport.ts
@@ -109,18 +109,28 @@ export const twoslashCompletions = (ts: TS, monaco: typeof import("monaco-editor
 
   const result: import("monaco-editor").languages.CompletionItem[] = []
 
-  // @ts-ignore - optionDeclarations is not public API
-  for (const opt of ts.optionDeclarations) {
-    if (opt.name.startsWith(word.slice(1))) {
-      // @ts-ignore
+  const knowns = [
+    "noErrors",
+    "errors",
+    "showEmit",
+    "showEmittedFile",
+    "noStaticSemanticInfo",
+    "emit",
+    "noErrorValidation",
+  ]
+  // @ts-ignore - ts.optionDeclarations is private
+  const optsNames = ts.optionDeclarations.map(o => o.name)
+  knowns.concat(optsNames).forEach(name => {
+    if (name.startsWith(word.slice(1))) {
+      // @ts-ignore - somehow adding the range seems to not give autocomplete results?
       result.push({
-        label: opt.name,
+        label: name,
         kind: 14,
         detail: "Twoslash comment",
-        insertText: opt.name,
+        insertText: name,
       })
     }
-  }
+  })
 
   return {
     suggestions: result,

--- a/packages/typescriptlang-org/src/components/workbench/plugins/debug.ts
+++ b/packages/typescriptlang-org/src/components/workbench/plugins/debug.ts
@@ -46,7 +46,11 @@ export const workbenchDebugPlugin: PluginFactory = (i, utils) => {
           dtsFiles.push(filename.replace("/lib", "lib"))
         } else {
           ds.p("<code>" + filename + "</code>")
-          ds.code(dtsMap.get(filename)!.trim())
+
+          const p = ds.p("")
+          const code = document.createElement("code")
+          code.innerText = dtsMap.get(filename)!.trim()
+          p.appendChild(code)
         }
       })
       ds.subtitle("Lib files")


### PR DESCRIPTION
Generated at runtime, which means it'll run against your current build of TypeScript 

![Screen Shot 2021-01-14 at 4 38 13 PM](https://user-images.githubusercontent.com/49038/104620431-e73be280-5686-11eb-9b14-86f186db69a5.png)
