### PR TITLE
Use decoded hash values to fix errors on querySelector

### DIFF
--- a/packages/typescriptlang-org/src/templates/scripts/setupSubNavigationSidebar.ts
+++ b/packages/typescriptlang-org/src/templates/scripts/setupSubNavigationSidebar.ts
@@ -8,8 +8,10 @@ export const overrideSubNavLinksWithSmoothScroll = () => {
     link.addEventListener("click", event => {
       event.preventDefault()
 
-      let target = document.querySelector(event.target!["hash"])
-      target.scrollIntoView({ behavior: "smooth", block: "start" })
+      let target = document.querySelector(
+        decodeURIComponent(event.target!["hash"])
+      )
+      target!.scrollIntoView({ behavior: "smooth", block: "start" })
       document.location.hash = event.target!["hash"]
     })
   })
@@ -28,7 +30,9 @@ export const updateSidebarOnScroll = () => {
   // Scroll down to find the highest anchor on the screen
   subnavLinks.forEach(link => {
     try {
-      const section = document.querySelector<HTMLDivElement>(link.hash)
+      const section = document.querySelector<HTMLDivElement>(
+        decodeURIComponent(link.hash)
+      )
       if (!section) {
         return
       }


### PR DESCRIPTION
This PR fixes 2 bugs related to translated pages:

1. Cannot scroll by clicking a translated item of TOC 

repro step:
 1.1. Go to https://www.typescriptlang.org/ja/docs/handbook/nightly-builds.html
 1.2. Click "npmを使う" of TOC on the right on the page

this error raises instead of having window scroll to the "npmを使う" heading:
```
setupSubNavigationSidebar.ts:11 Uncaught DOMException: Failed to execute 'querySelector' on 'Document': '#npm%E3%82%92%E4%BD%BF%E3%81%86' is not a valid selector.
    at HTMLAnchorElement.<anonymous>
```

2. Cannot add `current` class to translated items of TOC

repro step:
 2.1. Go to https://www.typescriptlang.org/ja/docs/handbook/nightly-builds.html#npm%E3%82%92%E4%BD%BF%E3%81%86 ("npmを使う" heading)

`class="current"` does not appear on  "npmを使う" element of TOC

![image](https://user-images.githubusercontent.com/15242484/104751565-eabf8e80-5798-11eb-9efe-1a73475738f0.png)

