### PR TITLE
`create(undefined)` example is valid

### DIFF
--- a/packages/documentation/copy/en/handbook-v1/Basic Types.md
+++ b/packages/documentation/copy/en/handbook-v1/Basic Types.md
@@ -339,11 +339,11 @@ declare function create(o: object | null): void;
 // OK
 create({ prop: 0 });
 create(null);
+create(undefined); // Remember, undefined is a subtype of null 
 
 create(42);
 create("string");
 create(false);
-create(undefined);
 ```
 
 Generally, you won't need to use this.


### PR DESCRIPTION
Hey folks, first time TypeScript-er here! Loving the guide so far.

I think I found a small discrepancy in one of your examples. On line 290-291 of this guide, you say:

> By default `null` and `undefined` are subtypes of all other types.
That means you can assign `null` and `undefined` to something like `number`.

This leads me to believe that you can also assign the value `undefined` to a variable with a type of `null`.

You then introduce the `--strictNullChecks` flag in line 293, which prevents `null` and `undefined` from being assigned to anything other than `unknown`, `any`, or their respective types. With this flag enabled, I believe you can no longer assign `undefined` to something with a type of `null`. 

Amazing! I'll definitely want to use this in my code. However, you say that: 
> As a note: we encourage the use of `--strictNullChecks` when possible, but for the purposes of this handbook, we will assume it is turned off.

Here's the discrepancy I notice. In the Object section, you declare a function `create`:

```ts
declare function create(o: object | null): void;
```

You indicate that invoking the function with `undefined` would cause the compiler to error. It seems like this is only true with `--strictNullChecks`, which you said you assume is turned off for this handbook.

I've confirmed locally that `create(undefined)` does not produce an error when `--strictNullChecks` is not passed to the compiler. For this guide, I've moved `create(undefined)` into the "Ok" section, and I've added a comment clarifying that `undefined` is a subtype of `null`.

Does this change make sense to you? 

