### PR TITLE
Fix variables in equality narrowing code snippet

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Narrowing.md
+++ b/packages/documentation/copy/en/handbook-v2/Narrowing.md
@@ -212,17 +212,17 @@ TypeScript also uses `switch` statements and equality checks like `===`, `!==`, 
 For example:
 
 ```ts twoslash
-function foo(left: string | number, right: string | boolean) {
-  if (left === right) {
+function foo(x: string | number, y: string | boolean) {
+  if (x === y) {
     // We can now call any 'string' method on 'x' or 'y'.
-    left.toUpperCase();
+    x.toUpperCase();
     // ^?
-    right.toLowerCase();
+    y.toLowerCase();
     // ^?
   } else {
-    console.log(left);
+    console.log(x);
     //          ^?
-    console.log(right);
+    console.log(y);
     //          ^?
   }
 }


### PR DESCRIPTION
The explanation refers to the variables as `x` and `y` while the code snippet contained `left` and `right`.