### PR TITLE
Save the JSX params before a reload

### DIFF
--- a/packages/playground/src/createConfigDropdown.ts
+++ b/packages/playground/src/createConfigDropdown.ts
@@ -98,6 +98,8 @@ export const createConfigDropdown = (sandbox: Sandbox, monaco: Monaco) => {
     const isNowJSX = internalSwitch.selectedIndex !== 0
     const isJSX = sandbox.filepath.endsWith("x")
     if (isNowJSX !== isJSX) {
+      const newURL = sandbox.createURLQueryWithCompilerOptions(sandbox)
+      window.history.replaceState({}, "", newURL)
       setTimeout(() => document.location.reload(), 300)
     }
   })

--- a/packages/typescriptlang-org/src/pages/dev/bug-workbench.tsx
+++ b/packages/typescriptlang-org/src/pages/dev/bug-workbench.tsx
@@ -111,6 +111,7 @@ const Play: React.FC<Props> = (props) => {
             dtsMap = defaultMap
             runTwoslash()
           })
+
         }
 
         // When the compiler notices a twoslash compiler flag change, this will get triggered and reset the DTS map


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript-Website/issues/1505 by making sure we force an update of the params before reloading now that the URL isn't instantly reflected on changes