### PR TITLE
chore: Add `package.json` repository metadata

### DIFF
--- a/packages/create-typescript-playground-plugin/package.json
+++ b/packages/create-typescript-playground-plugin/package.json
@@ -4,7 +4,15 @@
   "bin": "index.js",
   "author": "TypeScript team",
   "license": "MIT",
-  "homepage": "https://github.com/microsoft/TypeScript-Website/",
+  "homepage": "https://github.com/microsoft/TypeScript-Website",
+  "repository": {
+    "url": "https://github.com/microsoft/TypeScript-Website.git",
+    "directory": "packages/create-typescript-playground-plugin",
+    "type": "git"
+  },
+  "bugs": {
+    "url": "https://github.com/microsoft/TypeScript-Website/issues"
+  },
   "scripts": {
     "build": "echo NOOP",
     "test": "echo NOOP"

--- a/packages/gatsby-remark-shiki-twoslash/package.json
+++ b/packages/gatsby-remark-shiki-twoslash/package.json
@@ -2,7 +2,15 @@
   "name": "gatsby-remark-shiki-twoslash",
   "version": "0.7.0",
   "license": "MIT",
-  "homepage": "https://github.com/microsoft/TypeScript-Website/",
+  "homepage": "https://github.com/microsoft/TypeScript-Website",
+  "repository": {
+    "url": "https://github.com/microsoft/TypeScript-Website.git",
+    "directory": "packages/create-typescript-playground-plugin",
+    "type": "git"
+  },
+  "bugs": {
+    "url": "https://github.com/microsoft/TypeScript-Website/issues"
+  },
   "description": "A remark plugin for Gatsby which adds twoslash code samples for TypeScript",
   "author": "Orta Therox",
   "main": "./dist/index.js",

--- a/packages/remark-shiki-twoslash/package.json
+++ b/packages/remark-shiki-twoslash/package.json
@@ -2,7 +2,15 @@
   "name": "remark-shiki-twoslash",
   "version": "1.0.0",
   "license": "MIT",
-  "homepage": "https://github.com/microsoft/TypeScript-Website/",
+  "homepage": "https://github.com/microsoft/TypeScript-Website",
+  "repository": {
+    "url": "https://github.com/microsoft/TypeScript-Website.git",
+    "directory": "packages/create-typescript-playground-plugin",
+    "type": "git"
+  },
+  "bugs": {
+    "url": "https://github.com/microsoft/TypeScript-Website/issues"
+  },
   "description": "A remark plugin which adds twoslash code samples for TypeScript",
   "author": "Orta Therox",
   "main": "./dist/index.js",

--- a/packages/shiki-twoslash/package.json
+++ b/packages/shiki-twoslash/package.json
@@ -2,7 +2,15 @@
   "name": "shiki-twoslash",
   "version": "0.8.1",
   "license": "MIT",
-  "homepage": "https://github.com/microsoft/TypeScript-Website/",
+  "homepage": "https://github.com/microsoft/TypeScript-Website",
+  "repository": {
+    "url": "https://github.com/microsoft/TypeScript-Website.git",
+    "directory": "packages/create-typescript-playground-plugin",
+    "type": "git"
+  },
+  "bugs": {
+    "url": "https://github.com/microsoft/TypeScript-Website/issues"
+  },
   "description": "API primitives to mix Shiki with Twoslash",
   "author": "Orta Therox",
   "main": "./dist/index.js",

--- a/packages/ts-twoslasher/package.json
+++ b/packages/ts-twoslasher/package.json
@@ -3,6 +3,15 @@
   "version": "1.1.2",
   "license": "MIT",
   "author": "TypeScript team",
+  "homepage": "https://github.com/microsoft/TypeScript-Website",
+  "repository": {
+    "url": "https://github.com/microsoft/TypeScript-Website.git",
+    "directory": "packages/create-typescript-playground-plugin",
+    "type": "git"
+  },
+  "bugs": {
+    "url": "https://github.com/microsoft/TypeScript-Website/issues"
+  },
   "main": "dist/index.js",
   "module": "dist/twoslash.esm.js",
   "typings": "dist/index.d.ts",

--- a/packages/typescript-vfs/package.json
+++ b/packages/typescript-vfs/package.json
@@ -3,7 +3,15 @@
   "version": "1.3.2",
   "license": "MIT",
   "author": "TypeScript team",
-  "homepage": "https://github.com/microsoft/TypeScript-Website/",
+  "homepage": "https://github.com/microsoft/TypeScript-Website",
+  "repository": {
+    "url": "https://github.com/microsoft/TypeScript-Website.git",
+    "directory": "packages/create-typescript-playground-plugin",
+    "type": "git"
+  },
+  "bugs": {
+    "url": "https://github.com/microsoft/TypeScript-Website/issues"
+  },
   "main": "./dist/index.js",
   "module": "./dist/vsf.esm.js",
   "typings": "./dist/index.d.ts",


### PR DESCRIPTION
This was completely missing from [`@typescript/twoslash`][npm:@typescript/twoslash], and incomplete for the other public packages.

[npm:@typescript/twoslash]: https://www.npmjs.com/package/@typescript/twoslash