### PR TITLE
fix: typo

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Keyof Type Operator.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Keyof Type Operator.md
@@ -1,7 +1,7 @@
 ---
 title: Keyof Type Operator
 layout: docs
-permalink: /docs/handbook/2/indexed-access-types.html
+permalink: /docs/handbook/2/keyof-types.html
 oneline: "Using the keyof operator in type contexts."
 beta: true
 ---


### PR DESCRIPTION
Fix one typo about permalink of the "keyof type operator" doc. 

The permalink was wrongly written as "/docs/handbook/2/indexed-access-types.html".