### PR TITLE
Add quote to property keys on tsconfig.json

### DIFF
--- a/packages/documentation/copy/en/declaration-files/Publishing.md
+++ b/packages/documentation/copy/en/declaration-files/Publishing.md
@@ -144,10 +144,10 @@ That means in the above example, even though both the `>=3.2` and the `>=3.1` ma
 
 ```json5
 {
-  name: "package-name",
-  version: "1.0",
-  types: "./index.d.ts",
-  typesVersions: {
+  "name": "package-name",
+  "version": "1.0",
+  "types": "./index.d.ts",
+  "typesVersions": {
     // NOTE: this doesn't work!
     ">=3.1": { "*": ["ts3.1/*"] },
     ">=3.2": { "*": ["ts3.2/*"] },

--- a/packages/documentation/copy/en/javascript/Creating DTS files From JS.md
+++ b/packages/documentation/copy/en/javascript/Creating DTS files From JS.md
@@ -33,21 +33,21 @@ In this case, you will want a file like the following:
 ```json5
 {
   // Change this to match your project
-  include: ["src/**/*"],
+  "include": ["src/**/*"],
 
-  compilerOptions: {
+  "compilerOptions": {
     // Tells TypeScript to read JS files, as
     // normally they are ignored as source files
-    allowJs: true,
+    "allowJs": true,
     // Generate d.ts files
-    declaration: true,
+    "declaration": true,
     // This compiler run should
     // only output d.ts files
-    emitDeclarationOnly: true,
+    "emitDeclarationOnly": true,
     // Types should go into this directory.
     // Removing this would place the .d.ts files
     // next to the .js files
-    outDir: "dist",
+    "outDir": "dist",
   },
 }
 ```

--- a/packages/documentation/copy/en/release-notes/Overview.md
+++ b/packages/documentation/copy/en/release-notes/Overview.md
@@ -885,12 +885,12 @@ As an example, the following `tsconfig.json` file tells TypeScript to transform 
 
 ```json5
 {
-  compilerOptions: {
-    target: "esnext",
-    module: "commonjs",
-    jsx: "react",
-    jsxFactory: "h",
-    jsxFragmentFactory: "Fragment",
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "commonjs",
+    "jsx": "react",
+    "jsxFactory": "h",
+    "jsxFragmentFactory": "Fragment",
   },
 }
 ```
@@ -3991,7 +3991,7 @@ TypeScript 3.2 now resolves `tsconfig.json`s from `node_modules`. When using a b
 ```json tsconfig
 {
     "extends": "@my-team/tsconfig-base",
-    "include": ["./**/*"]
+    "include": ["./**/*"],
     "compilerOptions": {
         // Override certain options on a project-by-project basis.
         "strictBindCallApply": false,

--- a/packages/documentation/copy/en/release-notes/TypeScript 3.1.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 3.1.md
@@ -122,10 +122,10 @@ That means in the above example, even though both the `>=3.2` and the `>=3.1` ma
 
 ```json5
 {
-  name: "package-name",
-  version: "1.0",
-  types: "./index.d.ts",
-  typesVersions: {
+  "name": "package-name",
+  "version": "1.0",
+  "types": "./index.d.ts",
+  "typesVersions": {
     // NOTE: this doesn't work!
     ">=3.1": { "*": ["ts3.1/*"] },
     ">=3.2": { "*": ["ts3.2/*"] }

--- a/packages/documentation/copy/en/release-notes/TypeScript 3.2.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 3.2.md
@@ -182,7 +182,7 @@ TypeScript 3.2 now resolves `tsconfig.json`s from `node_modules`. When using a b
 ```json5
 {
     "extends": "@my-team/tsconfig-base",
-    "include": ["./**/*"]
+    "include": ["./**/*"],
     "compilerOptions": {
         // Override certain options on a project-by-project basis.
         "strictBindCallApply": false,

--- a/packages/documentation/copy/en/release-notes/TypeScript 3.4.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 3.4.md
@@ -13,11 +13,11 @@ The next time TypeScript is invoked with `--incremental`, it will use that infor
 ```json5
 // tsconfig.json
 {
-  compilerOptions: {
-    incremental: true,
-    outDir: "./lib"
+  "compilerOptions": {
+    "incremental": true,
+    "outDir": "./lib"
   },
-  include: ["./src"]
+  "include": ["./src"]
 }
 ```
 
@@ -31,12 +31,12 @@ We can also name them anything that we want, and place them anywhere we want usi
 ```json5
 // front-end.tsconfig.json
 {
-  compilerOptions: {
-    incremental: true,
-    tsBuildInfoFile: "./buildcache/front-end",
-    outDir: "./lib"
+  "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": "./buildcache/front-end",
+    "outDir": "./lib"
   },
-  include: ["./src"]
+  "include": ["./src"]
 }
 ```
 

--- a/packages/documentation/copy/en/release-notes/TypeScript 3.8.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 3.8.md
@@ -391,21 +391,21 @@ Because every project might work better under different strategies, and this new
 ```json5
 {
   // Some typical compiler options
-  compilerOptions: {
-    target: "es2020",
-    moduleResolution: "node",
+  "compilerOptions": {
+    "target": "es2020",
+    "moduleResolution": "node",
     // ...
   },
 
   // NEW: Options for file/directory watching
-  watchOptions: {
+  "watchOptions": {
     // Use native file system events for files and directories
-    watchFile: "useFsEvents",
-    watchDirectory: "useFsEvents",
+    "watchFile": "useFsEvents",
+    "watchDirectory": "useFsEvents",
 
     // Poll files for updates more frequently
     // when they're updated a lot.
-    fallbackPolling: "dynamicPriority",
+    "fallbackPolling": "dynamicPriority",
   },
 }
 ```

--- a/packages/documentation/copy/en/release-notes/TypeScript 3.9.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 3.9.md
@@ -311,11 +311,11 @@ One case where this slightly fell over is when a `tsconfig.json` simply existed 
 ```json5
 // tsconfig.json
 {
-  files: [],
-  references: [
-    { path: "./tsconfig.shared.json" },
-    { path: "./tsconfig.frontend.json" },
-    { path: "./tsconfig.backend.json" },
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.shared.json" },
+    { "path": "./tsconfig.frontend.json" },
+    { "path": "./tsconfig.backend.json" },
   ],
 }
 ```

--- a/packages/documentation/copy/en/release-notes/TypeScript 4.0.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 4.0.md
@@ -505,12 +505,12 @@ As an example, the following `tsconfig.json` file tells TypeScript to transform 
 
 ```json5
 {
-  compilerOptions: {
-    target: "esnext",
-    module: "commonjs",
-    jsx: "react",
-    jsxFactory: "h",
-    jsxFragmentFactory: "Fragment",
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "commonjs",
+    "jsx": "react",
+    "jsxFactory": "h",
+    "jsxFragmentFactory": "Fragment",
   },
 }
 ```

--- a/packages/documentation/copy/id/javascript/Creating DTS files From JS.md
+++ b/packages/documentation/copy/id/javascript/Creating DTS files From JS.md
@@ -32,21 +32,21 @@ Dalam kasus ini, Anda menginginkan berkas seperti berikut:
 ```json5
 {
   // Ubah ini agar sesuai dengan proyek Anda
-  include: ["src/**/*"],
+  "include": ["src/**/*"],
 
-  compilerOptions: {
+  "compilerOptions": {
     // Memberi tahu TypeScript untuk membaca berkas JS,
     // karena biasanya berkas tersebut diabaikan sebagai berkas sumber
-    allowJs: true,
+    "allowJs": true,
     // Hasilkan berkas d.ts
-    declaration: true,
+    "declaration": true,
     // Proses kompilator ini seharusnya
     // hanya mengeluarkan berkas d.ts
-    emitDeclarationOnly: true,
+    "emitDeclarationOnly": true,
     // Tipe harus masuk ke direktori ini.
     // Menghapus ini akan menempatkan berkas .d.ts
     // di sebelah berkas .js
-    outDir: "dist",
+    "outDir": "dist",
   },
 }
 ```

--- a/packages/documentation/copy/ja/javascript/Creating DTS files From JS.md
+++ b/packages/documentation/copy/ja/javascript/Creating DTS files From JS.md
@@ -33,21 +33,21 @@ TSConfigはコンパイラのフラグを設定し、対象のファイルを宣
 ```json5
 {
   // プロジェクトに合わせて変更してください
-  include: ["src/**/*"],
+  "include": ["src/**/*"],
 
-  compilerOptions: {
+  "compilerOptions": {
     // JSファイルは通常、ソースファイルとして無視されますが、
     // ここではJSファイルを読み込むようにTypeScriptに指示します
-    allowJs: true,
+    "allowJs": true,
     // d.tsファイルを生成します
-    declaration: true,
+    "declaration": true,
     // コンパイラを実行すると
     // d.tsファイルのみ出力されます
-    emitDeclarationOnly: true,
+    "emitDeclarationOnly": true,
     // 型はこのディレクトリに出力されます
     // このオプションを削除すると
     // .jsファイルの隣に.d.tsファイルが置かれます
-    outDir: "dist",
+    "outDir": "dist",
   },
 }
 ```

--- a/packages/documentation/copy/pt/javascript/Creating DTS files From JS.md
+++ b/packages/documentation/copy/pt/javascript/Creating DTS files From JS.md
@@ -33,21 +33,21 @@ Neste caso, você vai querer um arquivo como o seguinte:
 ```json5
 {
   // Mude isso para corresponder ao seu projeto
-  include: ["src/**/*"],
+  "include": ["src/**/*"],
 
-  compilerOptions: {
+  "compilerOptions": {
     // Diz para o TypeScript ler arquivos JS.
     // Normalmente, seriam ignorados como arquivos fonte
-    allowJs: true,
+    "allowJs": true,
     // Gerar arquivos d.ts
-    declaration: true,
+    "declaration": true,
     // A compilação só gerará arquivos
     // d.ts na saída
-    emitDeclarationOnly: true,
+    "emitDeclarationOnly": true,
     // Tipos devem ir neste diretório.
     // Remover isso colocará arquivos .d.ts
     // ao lado dos arquivos .js
-    outDir: "dist",
+    "outDir": "dist",
   },
 }
 ```


### PR DESCRIPTION
Fix the error `tsconfig.json:13:5 - error TS1327: String literal with double quotes expected.` that raises when tsc runs on tsconfig.json with unquoted property keys.
