### PR TITLE
Adds a single pager for individual tsconfig options in order to showing up on DDG

### DIFF
--- a/packages/typescriptlang-org/gatsby-config.js
+++ b/packages/typescriptlang-org/gatsby-config.js
@@ -109,6 +109,13 @@ module.exports = {
       },
     },
     {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        path: `${__dirname}/../tsconfig-reference/copy/en/options`,
+        name: `tsconfig-en`,
+      },
+    },
+    {
       resolve: "gatsby-plugin-i18n",
       options: {
         langKeyDefault: "en",

--- a/packages/typescriptlang-org/lib/bootup/createPages.ts
+++ b/packages/typescriptlang-org/lib/bootup/createPages.ts
@@ -6,6 +6,7 @@ import { GatsbyNode } from "gatsby"
 import { createPlaygrounds } from "./ingestion/createPlaygrounds"
 import { createPlaygroundExamplePages } from "./ingestion/createPlaygroundExamplePages"
 import { createRootPagesLocalized } from "./ingestion/createRootPagesLocalized"
+import { createTSConfigSingleFlagPages } from "./ingestion/createTSConfigSingleFlagPages"
 
 export const createPages: GatsbyNode["createPages"] = async args => {
   // Basically this function should be passing the right
@@ -18,6 +19,7 @@ export const createPages: GatsbyNode["createPages"] = async args => {
   await createPlaygrounds(args.graphql, args.actions.createPage)
 
   await createPlaygroundExamplePages(args.graphql, args.actions.createPage)
+  await createTSConfigSingleFlagPages(args.graphql, args.actions.createPage)
   await createRootPagesLocalized(args.graphql, args.actions.createPage)
 
   return null

--- a/packages/typescriptlang-org/lib/bootup/ingestion/createTSConfigSingleFlagPages.ts
+++ b/packages/typescriptlang-org/lib/bootup/ingestion/createTSConfigSingleFlagPages.ts
@@ -1,0 +1,62 @@
+import path from "path"
+const { green } = require("chalk")
+
+import { NodePluginArgs, CreatePagesArgs, withPrefix } from "gatsby"
+
+export const createTSConfigSingleFlagPages = async (
+  graphql: CreatePagesArgs["graphql"],
+  createPage: NodePluginArgs["actions"]["createPage"]
+) => {
+  console.log(`${green("success")} Creating TSConfig One Off Pages`)
+
+  const playPage = path.resolve(`./src/templates/tsconfigOptionOnePage.tsx`)
+  const result = await graphql(`
+    query GetAllHandbookDocs {
+      allFile(
+        filter: {
+          sourceInstanceName: { eq: "tsconfig-en" }
+          extension: { eq: "md" }
+        }
+      ) {
+        nodes {
+          id
+          name
+          absolutePath
+          childMarkdownRemark {
+            html
+          }
+        }
+      }
+    }
+  `)
+
+  if (result.errors) {
+    throw result.errors
+  }
+
+  const anyData = result.data as any
+  const options = anyData.allFile.nodes
+
+  // {
+  //   "id": "419262d5-8911-5ad4-a7a2-91a318ad0e1f",
+  //   "name": "allowJs",
+  //   "absolutePath": "/Users/ortatherox/dev/typescript/new-website/packages/tsconfig-reference/copy/en/options/allowJs.md"
+  //   "html": "..."
+  // },
+
+  options.forEach(option => {
+    // Intentionally not adding addPathToSite here
+    const url = `/tsconfig/${option.name}`
+
+    createPage({
+      path: withPrefix(url + ".html"),
+      component: playPage,
+      context: {
+        title: option.name,
+        lang: "en",
+        html: option.childMarkdownRemark.html,
+        redirectHref: withPrefix(`/tsconfig#${option.name}`),
+      },
+    })
+  })
+}

--- a/packages/typescriptlang-org/lib/bootup/ingestion/createTSConfigSingleFlagPages.ts
+++ b/packages/typescriptlang-org/lib/bootup/ingestion/createTSConfigSingleFlagPages.ts
@@ -49,13 +49,13 @@ export const createTSConfigSingleFlagPages = async (
     const url = `/tsconfig/${option.name}`
 
     createPage({
-      path: withPrefix(url + ".html"),
+      path: url + ".html",
       component: playPage,
       context: {
         title: option.name,
         lang: "en",
         html: option.childMarkdownRemark.html,
-        redirectHref: withPrefix(`/tsconfig#${option.name}`),
+        redirectHref: `/tsconfig#${option.name}`,
       },
     })
   })

--- a/packages/typescriptlang-org/src/templates/tsconfigOptionOnePage.tsx
+++ b/packages/typescriptlang-org/src/templates/tsconfigOptionOnePage.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect } from "react"
+import { Layout } from "../components/layout"
+
+import "./play.scss"
+
+import { useIntl } from "react-intl";
+import { createInternational } from "../lib/createInternational"
+import { headCopy } from "../copy/en/head-seo"
+import { Intl } from "../components/Intl"
+import { withPrefix } from "gatsby";
+
+type Props = {
+  pageContext: {
+    lang: string
+    html: string
+    name: string
+    title: string
+    redirectHref: string
+  }
+}
+
+const Play = (props: Props) => {
+  const i = createInternational<typeof headCopy>(useIntl())
+  useEffect(() => {
+    // Keep this page around so it is indexed on search engines
+    const isBot = /bot|google|baidu|bing|msn|duckduckbot|teoma|slurp|yandex/i.test(navigator.userAgent)
+    if (!isBot) {
+      // @ts-ignore - this is allowed in the DOM
+      document.location = withPrefix(props.pageContext.redirectHref)
+    }
+  }, [])
+
+  return (
+    <Layout title={"TSConfig Option: " + props.pageContext.title} description="How this setting affects your build." lang={props.pageContext.lang}>
+      <div className="raised main-content-block markdown">
+        <h2>{props.pageContext.title}</h2>
+        <div style={{ maxWidth: "800px", margin: "0 auto", padding: "80px" }}>
+          <p dangerouslySetInnerHTML={{ __html: props.pageContext.html! }} />
+        </div>
+      </div>
+    </Layout>
+  )
+}
+
+
+
+export default (props: Props) => <Intl locale={props.pageContext.lang}><Play {...props} /></Intl>


### PR DESCRIPTION
Same pattern as the playground examples, this creates a page which just shows the single page to search bots and to everyone else they get forwarded to the main tsconfig site via JS.

![Screen Shot 2021-01-25 at 11 56 16 AM](https://user-images.githubusercontent.com/49038/105703927-e405e980-5f05-11eb-9157-a7682141cb2d.png)
