### PR TITLE
Make code snippets colors dimmer for dark theme enabled

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/main.scss
+++ b/packages/typescriptlang-org/src/components/layout/main.scss
@@ -152,3 +152,8 @@ html,
   display: flex;
   flex-direction: column;
 }
+
+.dark-theme pre {
+  mix-blend-mode: difference;
+  filter: invert(98%) hue-rotate(180deg);
+}

--- a/packages/typescriptlang-org/src/components/layout/main.scss
+++ b/packages/typescriptlang-org/src/components/layout/main.scss
@@ -152,8 +152,3 @@ html,
   display: flex;
   flex-direction: column;
 }
-
-.dark-theme pre {
-  mix-blend-mode: difference;
-  filter: invert(98%) hue-rotate(180deg);
-}

--- a/packages/typescriptlang-org/src/templates/markdown-twoslash.scss
+++ b/packages/typescriptlang-org/src/templates/markdown-twoslash.scss
@@ -185,6 +185,12 @@ pre {
   }
 }
 
+.dark-theme pre {
+  background-color: #d8d8d8;
+  border-color: #ddd;
+  filter: invert(98%) hue-rotate(180deg);
+}
+
 // Extracted from vscode
 
 // .monaco-editor .squiggly-warning { background: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23428226'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E") repeat-x bottom left; }


### PR DESCRIPTION
A possible solution for #342

![bef-vs-after](https://user-images.githubusercontent.com/49038/106380957-92e67180-63ad-11eb-8f43-da332d52b68b.png)
