### PR TITLE
Fix community page

### DIFF
--- a/packages/typescriptlang-org/src/templates/pages/community.tsx
+++ b/packages/typescriptlang-org/src/templates/pages/community.tsx
@@ -188,7 +188,7 @@ export const Comm: React.FC<Props> = props => {
                   <h4 className="community-callout-headline">{meetup.title}</h4>
                   <div className="text">{meetup.country}<br />
                     <a rel="noopener" target="blank" href={meetup.url} title={"Website for " + meetup.title}>Website</a>
-                    {meetup.twitter ? <a rel="noopener" target="blank" href={meetup.twitter} title={"Twitter page for " + meetup.title}>Twitter</a> : null}
+                    {" "}{meetup.twitter ? <a rel="noopener" target="blank" href={meetup.twitter} title={"Twitter page for " + meetup.title}>Twitter</a> : null}
                   </div>
                 </div>
               </Col>

--- a/packages/typescriptlang-org/src/templates/pages/community.tsx
+++ b/packages/typescriptlang-org/src/templates/pages/community.tsx
@@ -181,8 +181,8 @@ export const Comm: React.FC<Props> = props => {
         <div className="events">
 
           <div className="callouts">
-            {meetups.map(({ meetup }) => (
-              <Col className="callout">
+            {meetups.map(({ meetup }, index) => (
+              <Col className="callout" key={index}>
                 <img src={require("../../assets/community/meetup-logos/" + meetup.image)} className="icon img-square" alt={"logo of " + meetup.title} />
                 <div>
                   <h4 className="community-callout-headline">{meetup.title}</h4>

--- a/packages/typescriptlang-org/src/templates/pages/css/community.scss
+++ b/packages/typescriptlang-org/src/templates/pages/css/community.scss
@@ -36,10 +36,6 @@
       width: 48%;
       display: flex;
       line-height: 1.4rem;
-
-      a {
-        margin-right: 8px;
-      }
     }
 
     h3 {


### PR DESCRIPTION
Fixes #1540.

Also, this fix makes spaces around StackOverflow, GitHub, Blog, etc. images even, just like it's done for the Meetups section images - so now the page is more consistent.

![comunity-page-after-changes](https://user-images.githubusercontent.com/859638/106534680-4c079180-64fd-11eb-9db0-6c1e30db7dbc.png)
