### PR TITLE
Add anchor links to JSDoc reference

### DIFF
--- a/packages/documentation/copy/en/javascript/JSDoc Reference.md
+++ b/packages/documentation/copy/en/javascript/JSDoc Reference.md
@@ -11,16 +11,16 @@ when using JSDoc annotations to provide type information in JavaScript files.
 
 Note any tags which are not explicitly listed below (such as `@async`) are not yet supported.
 
-- `@type`
-- `@param` (or `@arg` or `@argument`)
-- `@returns` (or `@return`)
-- `@typedef`
-- `@callback`
-- `@template`
-- `@class` (or `@constructor`)
-- `@this`
-- `@extends` (or `@augments`)
-- `@enum`
+- [`@type`](#type)
+- [`@param`](#param-and-returns) (or [`@arg`](#param-and-returns) or [`@argument`](#param-and-returns))
+- [`@returns`](#param-and-returns) (or [`@return`](#param-and-returns))
+- [`@typedef`](#typedef-callback-and-param)
+- [`@callback`](#typedef-callback-and-param)
+- [`@template`](#template)
+- [`@class`](#constructor) (or [`@constructor`](#constructor))
+- [`@this`](#this)
+- [`@extends`](#extends) (or [`@augments`](#extends))
+- [`@enum`](#enum)
 
 #### `class` extensions
 


### PR DESCRIPTION
Links the listed JSDoc tags to their sections within the document.