### PR TITLE
Update Basic Types.md

### DIFF
--- a/packages/documentation/copy/en/handbook-v1/Basic Types.md
+++ b/packages/documentation/copy/en/handbook-v1/Basic Types.md
@@ -339,7 +339,7 @@ declare function create(o: object | null): void;
 // OK
 create({ prop: 0 });
 create(null);
-create(undefined); // Remember, undefined is a not subtype of null
+create(undefined); // Remember, undefined is not a subtype of null
 
 create(42);
 create("string");

--- a/packages/documentation/copy/en/handbook-v1/Basic Types.md
+++ b/packages/documentation/copy/en/handbook-v1/Basic Types.md
@@ -339,7 +339,7 @@ declare function create(o: object | null): void;
 // OK
 create({ prop: 0 });
 create(null);
-create(undefined); // Remember, undefined is a subtype of null
+create(undefined); // Remember, undefined is a not subtype of null
 
 create(42);
 create("string");


### PR DESCRIPTION
On line 342, the comment stated  Remember, undefined is a subtype of null.
However, if that is the case, why does it throw an error that "Argument of type 'undefined' is not assignable to parameter of type 'object | null'."
Surely, a subtype is assignable to its base type.