### PR TITLE
Playground sample updates for 4.2

### DIFF
--- a/packages/documentation/copy/en/reference/Advanced Types.md
+++ b/packages/documentation/copy/en/reference/Advanced Types.md
@@ -114,10 +114,8 @@ const zoo: (Fish | Bird)[] = [getSmallPet(), getSmallPet(), getSmallPet()];
 const underWater1: Fish[] = zoo.filter(isFish);
 // or, equivalently
 const underWater2: Fish[] = zoo.filter<Fish>(isFish);
-const underWater3: Fish[] = zoo.filter<Fish>(pet => isFish(pet));
+const underWater3: Fish[] = zoo.filter<Fish>((pet) => isFish(pet));
 ```
-
-
 
 ### Using the `in` operator
 
@@ -1074,8 +1072,7 @@ type T4 = NonFunctionProperties<Part>;
 //   ^?
 ```
 
-Similar to union and intersection types, conditional types are not permitted to reference themselves recursively.
-For example the following is an error.
+Note, conditional types are not permitted to reference themselves recursively. For example the following is an error.
 
 #### Example
 

--- a/packages/playground-examples/copy/en/4-2/Fixits/Create Function from Call.ts
+++ b/packages/playground-examples/copy/en/4-2/Fixits/Create Function from Call.ts
@@ -1,0 +1,23 @@
+//// { compiler: { ts: "4.2.0-beta" } }
+// In 4.2 a community member (@a-tarasyuk) added the ability to generate functions
+// from calls which aren't defined. For example if you select all the code on line 5,
+// then click "Quick Fix", you will see the option to have the missing function generated.
+
+const id = generateUUID();
+
+// The fixit will take into account contextual information like the potential
+// return type for the function. For example, TypeScript knows the return type
+// because it is annotated at the variable declaration.
+
+const idStr: string = generateUUID1();
+
+// The fixit will keep the same number of generics arguments when they are used:
+
+const idObj = generateUUID3<{ id: string }>();
+
+// Parameters also act as you would expect:
+
+const complexUUID = generateUUID4("SHA32", 5, { namespace: "typescriptlang.org" });
+
+// It's not possible to show in the playground, but the codefix can create stubbed
+// functions across different modules too - lots to use.

--- a/packages/playground-examples/copy/en/4-2/New TS Features/Abstract Class Constructors.ts
+++ b/packages/playground-examples/copy/en/4-2/New TS Features/Abstract Class Constructors.ts
@@ -1,0 +1,48 @@
+//// { compiler: { ts: "4.2.0-beta" } }
+// TypeScript has supported abstract classes since 2015, which
+// provides compiler errors if you try to instantiate that class.
+
+// TypeScript 4.2 adds support for declaring that the constructor
+// function is abstract. This is mostly used by people who use
+// the mixin pattern ( example:mixins )
+
+// The mixin pattern involves having classes dynamically wrapping
+// each other to "mixing in" certain features to the end result.
+
+// This pattern is represented in TypeScript via a chain of constructor
+// functions of the classes, and by declaring one as abstract you can use
+// abstract classes inside your mixins.
+
+// All mixins start with a generic constructor to pass the T through, now
+// these can be abstract.
+type AbstractConstructor<T> = abstract new (...args: any[]) => T
+
+// We'll create an abstract class "Animal" where
+// the subclasses must override 'walk' 
+abstract class Animal {
+  abstract walk(): void;
+  breath() {}
+}
+
+// A mixin which adds a new function (in this case, animate)
+function animatableAnimal<T extends AbstractConstructor<object>>(Ctor: T) {
+  abstract class StopWalking extends Ctor {
+      animate() { }
+  }
+  return StopWalking;
+}
+
+// A subclass of the Animal, through the mixins, must still
+// handle the abstract contract for Animal. Which means it
+// needs to implement 'walk' below. Try deleting the function
+// to see what happens.
+
+class Dog extends animatableAnimal(Animal) {
+  walk() {}
+}
+
+
+const dog = new Dog()
+dog.breath()
+dog.walk()
+dog.animate()

--- a/packages/playground-examples/copy/en/4-2/New TS Features/Rest Elements in Tuple Types.ts
+++ b/packages/playground-examples/copy/en/4-2/New TS Features/Rest Elements in Tuple Types.ts
@@ -1,0 +1,37 @@
+//// { compiler: { ts: "4.2.0-beta" } }
+// Tuple types are a feature where the position of a type in an
+// array is important. For example, in string[] (array) you know that all
+// elements in the array are a string, in [string] (tuple) you know that
+// only the first element is a string. According to the type system, a
+// [string] is an array with only one element, of string.
+
+const stringArray: string[] = ["sugar", "tea", "rum"];
+const singleStringTuple: [string] = ["sugar", "tea", "rum"];
+
+// Tuples allow TypeScript to describe arrays like: [string, number] - which
+// means that only a string and a number can be used in the first and second
+// positions respectively.
+
+const stringNumberTuple: [string, number] = ["Weeks from shore", 2];
+
+// Under the hood, TypeScript uses Tuples to describe parameters for functions
+// which you can learn more from in:
+//
+// - example:tuples
+// - example:named-tuples
+
+// What was added in TypeScript 4.2 is the ability to describe functions which
+// take an unknown number of parameters but that have a particular start,
+// middle or end. This is done via the spread operator ... in a tuple to
+// indicate that the number varies (aka: variadic)
+
+// This type represents an unknown number of strings in the array but always
+// finishes with an object.
+type StringsThenConfig = [...string[], { huh: boolean }];
+
+const firstChorus: StringsThenConfig = ["Blow", "Me Bully boys", "blow", { huh: true }];
+const secondChorus: StringsThenConfig = ["We'll take our leave and go", { huh: false }];
+const thirdChorus: StringsThenConfig = ["When she dived down below", { huh: true }];
+
+// You can learn more about how the feature has evolved in the beta blog post:
+// https://devblogs.microsoft.com/typescript/announcing-typescript-4-2-beta/

--- a/packages/playground-examples/copy/en/4-2/New TS Features/Smarter Type Alias Preservation.ts
+++ b/packages/playground-examples/copy/en/4-2/New TS Features/Smarter Type Alias Preservation.ts
@@ -1,0 +1,30 @@
+//// { compiler: { ts: "4.2.0-beta" } }
+// Type aliases differ from interfaces in that they aren't guaranteed to
+// keep their name as they are used throughout the compiler. In part, this
+// is a trade-off on what gives them their flexibility, but the downside
+// is that sometimes TypeScript shows an object instead of the name.
+
+// In 4.2, the compiler keeps track of the original name for a type alias
+// in more places. Reducing the size of error messages and hover hints.
+
+type Shape =
+  | { kind: "circle"; radius: number }
+  | { kind: "square"; size: number }
+  | { kind: "rectangle"; width: number; height: number };
+
+type Named = { name: string };
+
+// Previously: Shape
+declare let shape: Shape;
+
+// No change there, but if you took the existing shape union and extend it,
+// then TypeScript used to 'lose' the original name:
+
+// Previously: { kind: "circle"; radius: number; | { kind: "square"; size: number; | { kind: "rectangle"; width: number; height: number; | undefined
+declare let optionalShape: Shape | undefined;
+
+// Previously: { kind: "circle"; radius: number; | { kind: "square"; size: number; | { kind: "rectangle"; width: number; height: number; | undefined
+declare let namedShape: Shape & Named;
+
+// Previously: ({ kind: "circle"; radius: number; Named) | ({ kind: "square"; size: number; Named) | ({ kind: "rectangle"; width: number; height: number; Named) | undefined
+declare let optionalNamedShape: (Shape & Named) | undefined; // (Shape & Named) | undefined

--- a/packages/playground-examples/copy/en/4-2/New TS Features/Use Index Accessors for Index Signatures.ts
+++ b/packages/playground-examples/copy/en/4-2/New TS Features/Use Index Accessors for Index Signatures.ts
@@ -1,0 +1,46 @@
+//// { compiler: { ts: "4.2.0-beta", noPropertyAccessFromIndexSignature: true } }
+// JavaScript has two ways to access an object on a property, the first is via
+// the dot operator x.y, the other is via square brackets x["y"] - the second
+// syntax x["y"] is called index accessors.
+
+// This syntax is reflected in the type system, where you can add an index
+// signature to a type, meaning any unknown property will have a particular type.
+
+// This type uses an index signature to indicate that you can ask
+// for any string and you will either get a string of undefined back.
+
+type ENV = {
+  [envVar: string]: string | undefined;
+};
+
+// In 4.2, there is a compiler flag to ensure consistency with how the
+// syntax for accessing the variable is consistent with how the variable
+// was declared.
+
+// For example, we can have a game ratings object, where games are
+// given a rank from 1 to 5. There are known games ahead of time,
+// but you could get back a lot of different objects
+
+type Rating = 1 | 2 | 3 | 4 | 5;
+
+interface GameRatingLibrary {
+  hades: Rating;
+  ringFitAdventures: Rating;
+  discoElysium: Rating;
+
+  // Unknown properties are covered by this index signature.
+  [propName: string]: Rating;
+}
+
+declare const getYearRatings: (year: string) => GameRatingLibrary;
+const ratings = getYearRatings("2020");
+
+// These are known in above, and so you can safely use
+// the dot syntax.
+const hadesScore = ratings.hades;
+const ringFitScore = ratings.ringFitAdventures;
+
+// This game is not declared above, and the index signature
+// is used instead, this means you cannot use the dot
+// operator and must access via ratings["oriAndTheBlindForest"]
+const nodeEnv = ratings.oriAndTheBlindForest;

--- a/packages/playground-examples/copy/en/README.md
+++ b/packages/playground-examples/copy/en/README.md
@@ -1,6 +1,6 @@
 # TypeScript Example Code
 
-These samples are built for hyperlinking between each-other 
+These samples are built for hyperlinking between each-other
 in a sandboxed environment like the TypeScript Playground.
 
 Each example aims to cover one or two specific features to
@@ -9,10 +9,10 @@ TypeScript has added to the language.
 
 An example should make assumptions that the reader is in a
 monaco/IDE-like environment which has a TSServer running for
-to provide extra analysis. As well as a minor fluency in 
+to provide extra analysis. As well as a minor fluency in
 JavaScript.
 
-These examples are not set in stone, and we're open to new 
+These examples are not set in stone, and we're open to new
 ideas. If you'd like to help out and speak more than one
 language, we'd love to see translations.
 
@@ -20,6 +20,6 @@ language, we'd love to see translations.
 
 Create a folder in this repo, then sub-folders per section. Next,
 edit `generateTOC.js` with at the set of folders it should grab
-at around line 30, then edit the `const toc` further down to 
-add a new section. If you need custom ordering then use the 
-`sortedSubSections` array to set your order. 
+at around line 30, then edit the `const toc` further down to
+add a new section. If you need custom ordering then use the
+`sortedSubSections` array to set your order.

--- a/packages/playground-examples/copy/en/sections.json
+++ b/packages/playground-examples/copy/en/sections.json
@@ -28,7 +28,12 @@
     {
       "name": "4.1",
       "id": "4.1",
-      "subtitle": "See the <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-4-1-beta/'>Release notes</a>."
+      "subtitle": "See the <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/'>Release notes</a>."
+    },
+    {
+      "name": "4.2",
+      "id": "4.2",
+      "subtitle": "See the <a href='https://devblogs.microsoft.com/typescript/announcing-typescript-4-2-beta/'>Release notes</a>."
     },
     {
       "name": "Playground V3",

--- a/packages/playground/src/createConfigDropdown.ts
+++ b/packages/playground/src/createConfigDropdown.ts
@@ -79,17 +79,11 @@ export const createConfigDropdown = (sandbox: Sandbox, monaco: Monaco) => {
   const dropdownContainer = document.getElementById("compiler-dropdowns")!
 
   const target = optionsSummary.find(sum => sum.id === "target")!
-  const targetSwitch = createSelect(
-    target.display,
-    "target",
-    target.oneliner,
-    sandbox,
-    monaco.languages.typescript.ScriptTarget
-  )
+  const targetSwitch = createSelect(target.display, "target", target.oneliner, sandbox, sandbox.ts.ScriptTarget)
   dropdownContainer.appendChild(targetSwitch)
 
   const jsx = optionsSummary.find(sum => sum.id === "jsx")!
-  const jsxSwitch = createSelect(jsx.display, "jsx", jsx.oneliner, sandbox, monaco.languages.typescript.JsxEmit)
+  const jsxSwitch = createSelect(jsx.display, "jsx", jsx.oneliner, sandbox, sandbox.ts.JsxEmit)
   dropdownContainer.appendChild(jsxSwitch)
 
   // When switching between a .ts and a .tsx file - refresh the playground
@@ -105,13 +99,7 @@ export const createConfigDropdown = (sandbox: Sandbox, monaco: Monaco) => {
   })
 
   const modSum = optionsSummary.find(sum => sum.id === "module")!
-  const moduleSwitch = createSelect(
-    modSum.display,
-    "module",
-    modSum.oneliner,
-    sandbox,
-    monaco.languages.typescript.ModuleKind
-  )
+  const moduleSwitch = createSelect(modSum.display, "module", modSum.oneliner, sandbox, sandbox.ts.ModuleKind)
   dropdownContainer.appendChild(moduleSwitch)
 }
 

--- a/packages/typescriptlang-org/src/components/layout/TopNav.tsx
+++ b/packages/typescriptlang-org/src/components/layout/TopNav.tsx
@@ -79,7 +79,7 @@ export const SiteNav = (props: Props) => {
           <nav role="navigation">
             <ul>
               <li className="nav-item hide-small"><IntlLink to="/download">{i("nav_download")}</IntlLink></li>
-              <li className="nav-item"><IntlLink to="/docs"><span>{i("nav_documentation_short")}</span></IntlLink></li>
+              <li className="nav-item"><IntlLink to="/docs/"><span>{i("nav_documentation_short")}</span></IntlLink></li>
               <li className="nav-item show-only-large"><IntlLink to="/docs/handbook/intro.html">{i("nav_handbook")}</IntlLink></li>
               <li className="nav-item"><IntlLink to="/community">{i("nav_community")}</IntlLink></li>
               <li className="nav-item show-only-largest"><IntlLink to="/play">{i("nav_playground")}</IntlLink></li>

--- a/packages/typescriptlang-org/src/templates/play.tsx
+++ b/packages/typescriptlang-org/src/templates/play.tsx
@@ -219,7 +219,7 @@ const Play: React.FC<Props> = (props) => {
             <a href="#" id="whatisnew-button" className="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="menu" aria-expanded="false" aria-controls="whatisnew">{i("play_subnav_whatsnew")} <span className="caret"></span></a>
             <ul className="examples-dropdown" id="whatisnew" aria-labelledby="whatisnew-button">
               <button role="button" aria-label="Close dropdown" className="examples-close">{i("play_subnav_examples_close")}</button>
-              <RenderExamples defaultSection="4.1" sections={["4.1", "4.0", "3.8", "3.7", "Playground"]} examples={props.pageContext.examplesTOC} locale={props.pageContext.lang} />
+              <RenderExamples defaultSection="4.2" sections={["4.2", "4.1", "4.0", "3.8", "3.7", "Playground"]} examples={props.pageContext.examplesTOC} locale={props.pageContext.lang} />
             </ul>
           </li>
         </ul>


### PR DESCRIPTION
Also fixes the dropdown o the playground using the _TypeScript_ version of some enums and not the monaco ones.