### PR TITLE
Change `Number` to `Numbers`

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/isolatedModules.md
+++ b/packages/tsconfig-reference/copy/en/options/isolatedModules.md
@@ -71,5 +71,5 @@ declare const enum Numbers {
 console.log(Numbers.Zero + Numbers.One);
 ```
 
-Without knowledge of the values of these members, other transpilers can't replace the references to `Number`, which would be a runtime error if left alone (since there are no `Numbers` object at runtime).
+Without knowledge of the values of these members, other transpilers can't replace the references to `Numbers`, which would be a runtime error if left alone (since there are no `Numbers` object at runtime).
 Because of this, when `isolatedModules` is set, it is an error to reference an ambient `const enum` member.


### PR DESCRIPTION
This PR fixes a typo in [isolatedModules.md](https://github.com/microsoft/TypeScript-Website/blob/958a75963a9c48d1d6ae25556ed5b8fe8b8a707e/packages/tsconfig-reference/copy/en/options/isolatedModules.md).