### PR TITLE
Log thrown errors in playground

### DIFF
--- a/packages/playground/src/sidebar/runtime.ts
+++ b/packages/playground/src/sidebar/runtime.ts
@@ -81,14 +81,14 @@ function rewireLoggingToElement(
   const rawConsole = console
 
   closure.then(js => {
+    const replace = {} as any
+    bindLoggingFunc(replace, rawConsole, 'log', 'LOG', curLog)
+    bindLoggingFunc(replace, rawConsole, 'debug', 'DBG', curLog)
+    bindLoggingFunc(replace, rawConsole, 'warn', 'WRN', curLog)
+    bindLoggingFunc(replace, rawConsole, 'error', 'ERR', curLog)
+    replace['clear'] = clearLogs
+    const console = Object.assign({}, rawConsole, replace)
     try {
-      const replace = {} as any
-      bindLoggingFunc(replace, rawConsole, 'log', 'LOG', curLog)
-      bindLoggingFunc(replace, rawConsole, 'debug', 'DBG', curLog)
-      bindLoggingFunc(replace, rawConsole, 'warn', 'WRN', curLog)
-      bindLoggingFunc(replace, rawConsole, 'error', 'ERR', curLog)
-      replace['clear'] = clearLogs
-      const console = Object.assign({}, rawConsole, replace)
       eval(js)
     } catch (error) {
       console.error(i("play_run_js_fail"))


### PR DESCRIPTION
Currently, nothing shows in the playground's "Logs" tab when I run the code below.

[Playground Link](https://www.typescriptlang.org/play?#code/C4CwTg9g7gBAdgU1gUTJMAKA5KSU4wJoRhYCUQA)

```ts
throw new Error('thrown error')
```

This PR fixes this to log thrown errors.

![image](https://user-images.githubusercontent.com/15242484/107908381-38e2d000-6f99-11eb-8603-c1ad288def48.png)

