### PR TITLE
Fix install commands of package managers `yarn` and `pnpm`

### DIFF
--- a/packages/typescriptlang-org/src/components/search/constants.ts
+++ b/packages/typescriptlang-org/src/components/search/constants.ts
@@ -8,8 +8,8 @@ export type Installer = [string, string]
 
 export const Installers: Record<PackageSource, Installer> = {
     [PackageSource.Npm]: ["npm i", "--save-dev"],
-    [PackageSource.Yarn]: ["yarn add", "--save-dev"],
-    [PackageSource.Pnpm]: ["pnpm add", "--dev"],
+    [PackageSource.Yarn]: ["yarn add", "--dev"],
+    [PackageSource.Pnpm]: ["pnpm add", "--save-dev"],
 }
 
 export const installerOptions = [


### PR DESCRIPTION
Fix the install commands of the package managers `yarn` and `pnpm`.

- Install a package as a dev-dependency with `yarn`:
https://classic.yarnpkg.com/en/docs/cli/add#toc-yarn-add-dev-d

- Install a package as a dev-dependency with `pnpm`:
https://pnpm.js.org/en/cli/add#save-dev-d

Fix https://github.com/DefinitelyTyped/DefinitelyTyped/issues/49187