### PR TITLE
Use scoped packages for private deps

### DIFF
--- a/packages/create-typescript-playground-plugin/template/scripts/getDTS.js
+++ b/packages/create-typescript-playground-plugin/template/scripts/getDTS.js
@@ -42,7 +42,7 @@ const go = async () => {
 
   // Util funcs
   await getFileAndStoreLocally(host + "/js/playground/pluginUtils.d.ts", join(vendor, "pluginUtils.d.ts"), text => {
-    const renameImport = text.replace('from "typescript-sandbox"', 'from "./sandbox"')
+    const renameImport = text.replace('from "@typescript/sandbox"', 'from "./sandbox"')
     return renameImport
   })
 

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "typescript-playground",
+  "name": "@typescript/playground",
   "version": "0.1.0",
   "main": "dist/index.js",
   "license": "MIT",
@@ -14,7 +14,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "typescript-sandbox": "0.1.0"
+    "@typescript/sandbox": "0.1.0"
   },
   "devDependencies": {
     "@types/jest": "^25.1.3",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "private": true,
-  "typings": "../typescriptlang-org/static/js/playground/index.d.ts",
+  "types": "../../typescriptlang-org/static/js/playground/index.d.ts",
   "files": [
     "dist"
   ],

--- a/packages/playground/src/createConfigDropdown.ts
+++ b/packages/playground/src/createConfigDropdown.ts
@@ -1,4 +1,4 @@
-type Sandbox = import("typescript-sandbox").Sandbox
+type Sandbox = import("@typescript/sandbox").Sandbox
 type Monaco = typeof import("monaco-editor")
 
 type OptionsSummary = {

--- a/packages/playground/src/createElements.ts
+++ b/packages/playground/src/createElements.ts
@@ -1,6 +1,6 @@
 import { PlaygroundPlugin } from "."
 
-type Sandbox = import("typescript-sandbox").Sandbox
+type Sandbox = import("@typescript/sandbox").Sandbox
 
 export const createDragBar = () => {
   const sidebar = document.createElement("div")

--- a/packages/playground/src/exporter.ts
+++ b/packages/playground/src/exporter.ts
@@ -1,6 +1,6 @@
 import { UI } from "./createUI"
 
-type Sandbox = import("typescript-sandbox").Sandbox
+type Sandbox = import("@typescript/sandbox").Sandbox
 type CompilerOptions = import("monaco-editor").languages.typescript.CompilerOptions
 
 export const createExporter = (sandbox: Sandbox, monaco: typeof import("monaco-editor"), ui: UI) => {

--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -1,4 +1,4 @@
-type Sandbox = import("typescript-sandbox").Sandbox
+type Sandbox = import("@typescript/sandbox").Sandbox
 type Monaco = typeof import("monaco-editor")
 
 declare const window: any

--- a/packages/playground/src/pluginUtils.ts
+++ b/packages/playground/src/pluginUtils.ts
@@ -1,4 +1,4 @@
-import type { Sandbox } from "typescript-sandbox"
+import type { Sandbox } from "@typescript/sandbox"
 import type React from "react"
 import { createDesignSystem } from "./ds/createDesignSystem"
 

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "typescript-sandbox",
+  "name": "@typescript/sandbox",
   "version": "0.1.0",
   "main": "dist/index.js",
   "private": true,

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "private": true,
   "license": "MIT",
-  "typings": "../typescriptlang-org/static/js/sandbox/index.d.ts",
+  "types": "../../typescriptlang-org/static/js/sandbox/index.d.ts",
   "files": [
     "dist"
   ],

--- a/packages/typescriptlang-org/package.json
+++ b/packages/typescriptlang-org/package.json
@@ -22,6 +22,8 @@
     "@formatjs/intl-relativetimeformat": "^4.5.15",
     "@types/node-fetch": "^2.5.3",
     "@types/react-helmet": "^5.0.15",
+    "@typescript/playground": "0.1.0",
+    "@typescript/sandbox": "0.1.0",
     "@typescript/twoslash": "1.1.4",
     "canvas": "^2.6.1",
     "gatsby": "^2.24.85",
@@ -56,8 +58,6 @@
     "ts-debounce": "^2.2.0",
     "ts-node": "^8.6.2",
     "typescript": "*",
-    "typescript-playground": "0.1.0",
-    "typescript-sandbox": "0.1.0",
     "xml-js": "^1.6.11"
   },
   "devDependencies": {

--- a/packages/typescriptlang-org/src/pages/dev/bug-workbench.tsx
+++ b/packages/typescriptlang-org/src/pages/dev/bug-workbench.tsx
@@ -60,15 +60,15 @@ const Play: React.FC<Props> = (props) => {
       re.config({
         paths: {
           vs: `https://typescript.azureedge.net/cdn/${tsVersionParam}/monaco/min/vs`,
-          "typescript-sandbox": withPrefix('/js/sandbox'),
-          "typescript-playground": withPrefix('/js/playground'),
+          "@typescript/sandbox": withPrefix('/js/sandbox'),
+          "@typescript/playground": withPrefix('/js/playground'),
           "unpkg": "https://unpkg.com/",
           "local": "http://localhost:5000"
         },
         ignoreDuplicateModules: ["vs/editor/editor.main"],
       });
 
-      re(["vs/editor/editor.main", "vs/language/typescript/tsWorker", "typescript-sandbox/index", "typescript-playground/index"], async (main: typeof import("monaco-editor"), tsWorker: any, sandbox: typeof import("typescript-sandbox"), playground: typeof import("typescript-playground")) => {
+      re(["vs/editor/editor.main", "vs/language/typescript/tsWorker", "typescript-sandbox/index", "typescript-playground/index"], async (main: typeof import("monaco-editor"), tsWorker: any, sandbox: typeof import("@typescript/sandbox"), playground: typeof import("@typescript/playground")) => {
         // Importing "vs/language/typescript/tsWorker" will set ts as a global
         const ts = (global as any).ts
         const isOK = main && ts && sandbox && playground

--- a/packages/typescriptlang-org/src/pages/dev/sandbox.tsx
+++ b/packages/typescriptlang-org/src/pages/dev/sandbox.tsx
@@ -41,7 +41,7 @@ const Index: React.FC<Props> = props => {
         async (
           main: typeof import("monaco-editor"),
           ts: typeof import("typescript"),
-          sandboxEnv: typeof import("typescript-sandbox")
+          sandboxEnv: typeof import("@typescript/sandbox")
         ) => {
           const initialCode = `import {markdown, danger} from "danger"
 
@@ -156,7 +156,7 @@ export default async function () {
               </p>
               <p>
                 You can find the code for the TypeScript Sandbox inside the{" "}
-                <a href="https://github.com/microsoft/TypeScript-Website/tree/v2/packages/sandbox#typescript-sandbox">
+                <a href="https://github.com/microsoft/TypeScript-Website/tree/v2/packages/sandbox#@typescript/sandbox">
                   microsoft/TypeScript-Website
                 </a>{" "}
                 mono-repo.

--- a/packages/typescriptlang-org/src/pages/dev/twoslash.tsx
+++ b/packages/typescriptlang-org/src/pages/dev/twoslash.tsx
@@ -51,7 +51,7 @@ const Index: React.FC<Props> = props => {
         async (
           main: typeof import("monaco-editor"),
           ts: typeof import("typescript"),
-          sandboxEnv: typeof import("typescript-sandbox")
+          sandboxEnv: typeof import("@typescript/sandbox")
         ) => {
           // This triggers making "ts" available in the global scope
           re(["vs/language/typescript/lib/typescriptServices"], async _ts => {

--- a/packages/typescriptlang-org/src/templates/play.tsx
+++ b/packages/typescriptlang-org/src/templates/play.tsx
@@ -17,7 +17,7 @@ import { Intl } from "../components/Intl"
 import playgroundReleases from "../../../sandbox/src/releases.json"
 
 // This gets set by the playground
-declare const playground: ReturnType<typeof import("typescript-playground").setupPlayground>
+declare const playground: ReturnType<typeof import("@typescript/playground").setupPlayground>
 
 type Props = {
   pageContext: {
@@ -109,8 +109,8 @@ const Play: React.FC<Props> = (props) => {
       re.config({
         paths: {
           vs: urlForMonaco,
-          "typescript-sandbox": withPrefix('/js/sandbox'),
-          "typescript-playground": withPrefix('/js/playground'),
+          "@typescript/sandbox": withPrefix('/js/sandbox'),
+          "@typescript/playground": withPrefix('/js/playground'),
           "unpkg": "https://unpkg.com/",
           "local": "http://localhost:5000"
         },
@@ -127,7 +127,7 @@ const Play: React.FC<Props> = (props) => {
         }
       });
 
-      re(["vs/editor/editor.main", "vs/language/typescript/tsWorker", "typescript-sandbox/index", "typescript-playground/index"], async (main: typeof import("monaco-editor"), tsWorker: any, sandbox: typeof import("typescript-sandbox"), playground: typeof import("typescript-playground")) => {
+      re(["vs/editor/editor.main", "vs/language/typescript/tsWorker", "typescript-sandbox/index", "typescript-playground/index"], async (main: typeof import("monaco-editor"), tsWorker: any, sandbox: typeof import("@typescript/sandbox"), playground: typeof import("@typescript/playground")) => {
         // Importing "vs/language/typescript/tsWorker" will set ts as a global
         const ts = (global as any).ts
         const isOK = main && ts && sandbox && playground

--- a/yarn.lock
+++ b/yarn.lock
@@ -5290,6 +5290,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript/playground@0.1.0, @typescript/playground@workspace:packages/playground":
+  version: 0.0.0-use.local
+  resolution: "@typescript/playground@workspace:packages/playground"
+  dependencies:
+    "@types/jest": ^25.1.3
+    "@typescript/sandbox": 0.1.0
+    jest: "*"
+    monaco-editor: ~0.20.0
+    monaco-typescript: ^3.7.0
+    typescript: "*"
+  languageName: unknown
+  linkType: soft
+
+"@typescript/sandbox@0.1.0, @typescript/sandbox@workspace:packages/sandbox":
+  version: 0.0.0-use.local
+  resolution: "@typescript/sandbox@workspace:packages/sandbox"
+  dependencies:
+    "@types/jest": ^25.1.3
+    "@typescript/vfs": 1.3.2
+    jest: "*"
+    monaco-editor: ~0.20.0
+    monaco-typescript: ^3.7.0
+    ts-jest: ^26.4.4
+    typescript: "*"
+  languageName: unknown
+  linkType: soft
+
 "@typescript/twoslash@1.1.4, @typescript/twoslash@workspace:packages/ts-twoslasher":
   version: 0.0.0-use.local
   resolution: "@typescript/twoslash@workspace:packages/ts-twoslasher"
@@ -13955,7 +13982,7 @@ fsevents@~2.1.2:
     "@typescript/vfs": 1.3.2
     rehype-stringify: ^6.0.1
     shiki: ^0.9.1
-    shiki-twoslash: 1.0.0
+    shiki-twoslash: 1.1.0
     tsdx: ^0.14.1
     tslib: ^1.10.0
     typescript: "*"
@@ -24851,7 +24878,7 @@ fsevents@~2.1.2:
     mdx: "*"
     rehype-stringify: ^6.0.1
     shiki: ^0.9.1
-    shiki-twoslash: 1.0.0
+    shiki-twoslash: 1.1.0
     tsdx: ^0.14.1
     tslib: ^1.10.0
     typescript: "*"
@@ -26184,7 +26211,7 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
-"shiki-twoslash@1.0.0, shiki-twoslash@workspace:packages/shiki-twoslash":
+"shiki-twoslash@1.1.0, shiki-twoslash@workspace:packages/shiki-twoslash":
   version: 0.0.0-use.local
   resolution: "shiki-twoslash@workspace:packages/shiki-twoslash"
   dependencies:
@@ -28515,33 +28542,6 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
-"typescript-playground@0.1.0, typescript-playground@workspace:packages/playground":
-  version: 0.0.0-use.local
-  resolution: "typescript-playground@workspace:packages/playground"
-  dependencies:
-    "@types/jest": ^25.1.3
-    jest: "*"
-    monaco-editor: ~0.20.0
-    monaco-typescript: ^3.7.0
-    typescript: "*"
-    typescript-sandbox: 0.1.0
-  languageName: unknown
-  linkType: soft
-
-"typescript-sandbox@0.1.0, typescript-sandbox@workspace:packages/sandbox":
-  version: 0.0.0-use.local
-  resolution: "typescript-sandbox@workspace:packages/sandbox"
-  dependencies:
-    "@types/jest": ^25.1.3
-    "@typescript/vfs": 1.3.2
-    jest: "*"
-    monaco-editor: ~0.20.0
-    monaco-typescript: ^3.7.0
-    ts-jest: ^26.4.4
-    typescript: "*"
-  languageName: unknown
-  linkType: soft
-
 "typescript@npm:4.2.0-dev.20210112":
   version: 4.2.0-dev.20210112
   resolution: "typescript@npm:4.2.0-dev.20210112"
@@ -28573,6 +28573,8 @@ resolve@1.1.7:
     "@types/react": ^16.9.20
     "@types/react-dom": ^16.9.5
     "@types/react-helmet": ^5.0.15
+    "@typescript/playground": 0.1.0
+    "@typescript/sandbox": 0.1.0
     "@typescript/twoslash": 1.1.4
     canvas: ^2.6.1
     concurrently: ^5.1.0
@@ -28611,8 +28613,6 @@ resolve@1.1.7:
     ts-jest: ^26.4.4
     ts-node: ^8.6.2
     typescript: "*"
-    typescript-playground: 0.1.0
-    typescript-sandbox: 0.1.0
     xml-js: ^1.6.11
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
`typescript-sandbox` and `typescript-playground` aren't published to npm, so move them to `@typescript/x` to avoid any potential issues