### PR TITLE
Fix typo: "it's declaration" -> "its declaration"

### DIFF
--- a/packages/playground-examples/copy/en/TypeScript/Language Extensions/Types vs Interfaces.ts
+++ b/packages/playground-examples/copy/en/TypeScript/Language Extensions/Types vs Interfaces.ts
@@ -62,7 +62,7 @@ interface Kitten {
 }
 
 // In the other case a type cannot be changed outside of
-// it's declaration.
+// its declaration.
 
 type Puppy = {
   color: string;


### PR DESCRIPTION
I was on the playground and saw a typo: https://www.typescriptlang.org/play?q=252#example/types-vs-interfaces

![image](https://user-images.githubusercontent.com/723109/108441694-abff7700-7223-11eb-9e79-d8b616dcfaeb.png)
