### PR TITLE
Add z-index: 2 to #language-recommendation

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/TopNav.scss
+++ b/packages/typescriptlang-org/src/components/layout/TopNav.scss
@@ -156,6 +156,7 @@ form.search {
 }
 
 #language-recommendation {
+  z-index: 2;
   position: fixed;
   right: 20px;
   bottom: 20px;


### PR DESCRIPTION
playground-sidebar has `z-index: 1`
Added `z-index: 2` to #language-recommendation

before| z-index: 2
---|---
![image](https://user-images.githubusercontent.com/15242484/108677271-c6d83100-752c-11eb-9e87-664c1208387b.png)|![image](https://user-images.githubusercontent.com/15242484/108677304-d35c8980-752c-11eb-9b03-6bd36da4c636.png)