### PR TITLE
Update Typo in Mapped Types.md

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Mapped Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Mapped Types.md
@@ -142,5 +142,6 @@ type DBFields = {
   name: { type: string; pii: true };
 };
 
-type ObjectsNeedingGDPRDeletion = CreateMutable<DBFields>;
+type ObjectsNeedingGDPRDeletion = ExtractPII<DBFields>;
+//   ^?
 ```


### PR DESCRIPTION
Fixed Typo in 'Further Exploration' section - The wrong type was being called on the final example.