### PR TITLE
Added "missing" return type declaration

### DIFF
--- a/packages/documentation/copy/en/handbook-v1/Interfaces.md
+++ b/packages/documentation/copy/en/handbook-v1/Interfaces.md
@@ -313,7 +313,7 @@ interface SearchFunc {
 // ---cut---
 let mySearch: SearchFunc;
 
-mySearch = function (source: string, subString: string) {
+mySearch = function (source: string, subString: string): boolean {
   let result = source.search(subString);
   return result > -1;
 };


### PR DESCRIPTION
I have added a "missing" return type declaration (even though it is not in fact mandatory) because the part of the docs explaining that it is not mandatory is just below, and I don't want beginners to be disturbed before the explaination