### PR TITLE
fix "later" by "earlier"

### DIFF
--- a/packages/documentation/copy/en/reference/Variable Declarations.md
+++ b/packages/documentation/copy/en/reference/Variable Declarations.md
@@ -630,7 +630,7 @@ function f({ a = "", b = 0 } = {}): void {
 f();
 ```
 
-> The snippet above is an example of type inference, explained later in the handbook.
+> The snippet above is an example of type inference, explained earlier in the handbook.
 
 Then, you need to remember to give a default for optional properties on the destructured property instead of the main initializer.
 Remember that `C` was defined with `b` optional:


### PR DESCRIPTION
I think it should be written "earlier", or nothing at all, since the chapter about Type Inference is the one just before this chapter