### PR TITLE
New PDF Renderer for Handbook v2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      - uses: microsoft/playwright-github-action@v1
+
       # Install, should be absically instant if cached
       - run: yarn install
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,10 +23,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      # Get dependencies for building the ebooks
-      - run: sudo apt-get update
-      - run: sudo apt install calibre
-
       # Install, should be absically instant if cached
       - run: yarn install
         env:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -14,10 +14,6 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
 
-      # For epub -> PDF conversion
-      - run: sudo apt-get update
-      - run: sudo apt install calibre
-
       # Build v2
       - name: Build website v2
         run: |

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
+      - uses: microsoft/playwright-github-action@v1
 
       # Build v2
       - name: Build website v2

--- a/.github/workflows/v2-merged-staging.yml
+++ b/.github/workflows/v2-merged-staging.yml
@@ -19,9 +19,6 @@ jobs:
 
       # For Azure uploads
       - run: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-      # For epub -> PDF conversion
-      - run: sudo apt-get update
-      - run: sudo apt install calibre
 
       - name: Prepare website v2
         run: |

--- a/.github/workflows/v2-merged-staging.yml
+++ b/.github/workflows/v2-merged-staging.yml
@@ -19,6 +19,7 @@ jobs:
 
       # For Azure uploads
       - run: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      - uses: microsoft/playwright-github-action@v1
 
       - name: Prepare website v2
         run: |

--- a/docs/Deprecating a page.md
+++ b/docs/Deprecating a page.md
@@ -1,0 +1,61 @@
+## Deprecating a documentation page
+
+Start with this question: are you deprecating or deleting? Ideally you're never deleting because [Cool URIs Dont Change](https://www.w3.org/Provider/Style/URI.html) but for something which intentionally had a limited self-life, that's OK.
+
+### Keep or Redirect?
+
+If you don't want the keep the content at all, remove the `.md` file from the repo and add the URI to [setupRedirects.ts](https://github.com/microsoft/TypeScript-website/blob/v2/packages/typescriptlang-org/src/redirects/setupRedirects.ts).
+
+### Keep it
+
+There are two new attributes you can add to the yml at the top of the markdown doc to indicate a page is deprecated:
+
+```md
+---
+title: Advanced Types
+layout: docs
+permalink: /docs/handbook/advanced-types.html
+oneline: Advanced concepts around types in TypeScript
+deprecated_by: /docs/handbook/2/types-from-types.html
+
+# prettier-ignore
+deprecation_redirects: [
+  type-guards-and-differentiating-types, /docs/handbook/2/narrowing.html,
+  user-defined-type-guards, /docs/handbook/2/narrowing.html#using-type-predicates,
+  typeof-type-guards, "/docs/handbook/2/narrowing.html#typeof-type-guards",
+  instanceof-type-guards, /docs/handbook/2/narrowing.html#instanceof-narrowing,
+  nullable-types, /docs/handbook/2/everyday-types.html#null-and-undefined,
+  type-aliases, /docs/handbook/2/everyday-types.html#type-aliases,
+  interfaces-vs-type-aliases, /docs/handbook/2/everyday-types.html#differences-between-type-aliases-and-interfaces,
+  enum-member-types, /docs/handbook/enums.html,
+  polymorphic-this-types, /docs/handbook/2/classes.html,
+  index-types, /docs/handbook/2/indexed-access-types.html,
+  index-types-and-index-signatures, /docs/handbook/2/indexed-access-types.html,
+  mapped-types, /docs/handbook/2/mapped-types.html,
+  inference-from-mapped-types, /docs/handbook/2/mapped-types.html,
+  conditional-types, /docs/handbook/2/conditional-types.html,
+  distributive-conditional-types, /docs/handbook/2/conditional-types.html#distributive-conditional-types,
+  type-inference-in-conditional-types, /docs/handbook/2/conditional-types.html#inferring-within-conditional-types,
+  predefined-conditional-types, /docs/handbook/utility-types.html,
+]
+---
+
+This page lists some of the more advanced ways in which you can model types, it works in tandem with the [Utility Types](/docs/handbook/utility-types.html) doc which includes types which are included in TypeScript and available globally.
+
+## Type Guards and Differentiating Types
+
+Union types are useful for modeling situations when values can overlap in the types they can take on.
+What happens when we need to know specifically whether we have a `Fish`?
+```
+
+Including the `deprecated_by` tag will mark the pages visually as deprecated, and tell search engines to consider that other page the canonical source instead. That should be enough for simple pages.
+
+If it's a page which people are linking to a lot, and you want to _really_ carry someone to their right location then you can make a map of query hashes to new pages.
+
+If you load the old page in your browser and run this JS in the web inspector:
+
+```js
+document.querySelectorAll(".markdown h2, .markdown h3").forEach(h => console.log(h.id))
+```
+
+It will print out all the of header's anchors, and that is the left hand side of your array couplets. The site has client-side code to override the `deprecated_by` url at runtime if it detects a user has a matching hash in the URL.

--- a/packages/handbook-epub/assets/.gitignore
+++ b/packages/handbook-epub/assets/.gitignore
@@ -1,0 +1,1 @@
+all.html

--- a/packages/handbook-epub/package.json
+++ b/packages/handbook-epub/package.json
@@ -13,7 +13,9 @@
   },
   "dependencies": {
     "fs-jetpack": "^2.4.0",
+    "playwright": "^1.9.1",
     "streampub": "https://github.com/orta/streampub-1.git#ibooks",
-    "ts-node": "*"
+    "ts-node": "*",
+    "sass": "*"
   }
 }

--- a/packages/handbook-epub/package.json
+++ b/packages/handbook-epub/package.json
@@ -14,8 +14,8 @@
   "dependencies": {
     "fs-jetpack": "^2.4.0",
     "playwright": "^1.9.1",
+    "sass": "*",
     "streampub": "https://github.com/orta/streampub-1.git#ibooks",
-    "ts-node": "*",
-    "sass": "*"
+    "ts-node": "*"
   }
 }

--- a/packages/handbook-epub/script/createEpub.ts
+++ b/packages/handbook-epub/script/createEpub.ts
@@ -6,61 +6,29 @@
 
 const jetpack = require("fs-jetpack");
 const { createReadStream } = jetpack;
-
 const Streampub = require("streampub");
-const toHAST = require(`mdast-util-to-hast`);
-const hastToHTML = require(`hast-util-to-html`);
-const {
-  recursiveReadDirSync,
-} = require("../../typescriptlang-org/lib/utils/recursiveReadDirSync");
 
-import {
-  readdirSync,
-  readFileSync,
-  lstatSync,
-  copyFileSync,
-  mkdirSync,
-} from "fs";
-import runTwoSlashAcrossDocument from "gatsby-remark-shiki-twoslash";
-const remark = require("remark");
+import { copyFileSync, mkdirSync } from "fs";
 import { join } from "path";
-import { read as readMarkdownFile } from "gray-matter";
-
-import { getDocumentationNavForLanguage } from "../../typescriptlang-org/src/lib/documentationNavigation";
 import { exists } from "fs-jetpack";
+import {
+  generateV2Markdowns,
+  getGitSHA,
+  getHTML,
+  getReleaseInfo,
+  replaceAllInString,
+} from "./setupPages";
+import { getDocumentationNavForLanguage } from "../../typescriptlang-org/src/lib/documentationNavigation";
 
 // Reference: https://github.com/AABoyles/LessWrong-Portable/blob/master/build.js
 
-const markdowns = new Map<string, ReturnType<typeof readMarkdownFile>>();
-const handbookNavigation = getDocumentationNavForLanguage("en");
-
-// Grab all the md + yml info from the handbook files on disk
-// and add them to ^
-// prettier-ignore
-const handbookPath = join( __dirname, "..", "..", "documentation", "copy", "en", "handbook-v2");
-
-recursiveReadDirSync(handbookPath).forEach((path) => {
-  const filePath = join(__dirname, "..", "..", path);
-  if (lstatSync(filePath).isDirectory() || !filePath.endsWith("md")) {
-    return;
-  }
-
-  const md = readMarkdownFile(filePath);
-  // prettier-ignore
-  if (!md.data.permalink) {
-    throw new Error(
-      `${filePath} in the handbook did not have a permalink in the yml header`,
-    );
-  }
-  const id = md.data.permalink;
-  markdowns.set(id, md);
-});
+const markdowns = generateV2Markdowns();
 
 // Grab the handbook nav, and use that to pull out the order
 
 const bookMetadata = {
   title: "TypeScript Handbook",
-  author: "TypeScript Contributors",
+  author: "TypeScript Team and Open Source Contributors",
   authorUrl: "https://www.typescriptlang.org/",
   modified: new Date(),
   source: "https://www.typescriptlang.org",
@@ -77,6 +45,8 @@ if (!exists(dist)) mkdirSync(dist);
 const epubPath = join(dist, "handbook.epub");
 
 const startEpub = async () => {
+  const handbookNavigation = getDocumentationNavForLanguage("en");
+
   const handbook = handbookNavigation.find((i) => i.title === "Handbook");
   const epub = new Streampub(bookMetadata);
 
@@ -124,26 +94,12 @@ const startEpub = async () => {
   epub.end();
 };
 
-// The epub generation is async-y, so just wait till everything is
-// done to move over the file into the website's static assets.
-process.once("exit", () => {
-  copyFileSync(
-    epubPath,
-    join(
-      __dirname,
-      "../../typescriptlang-org/static/assets/typescript-handbook.epub"
-    )
-  );
-});
-
 const addHandbookPage = async (epub: any, id: string, index: number) => {
   const md = markdowns.get(id);
   if (!md)
-    throw new Error(
-      "Could not get markdown for " +
-        id +
-        `\n\nAll MDs: ${Array.from(markdowns.keys())}`
-    );
+    // prettier-ignore
+    throw new Error("Could not get markdown for " + id + `\n\nAll MDs: ${Array.from(markdowns.keys())}`);
+
   const title = md.data.title;
   const prefix = `<link href="style.css" type="text/css" rel="stylesheet" /><h1>${title}</h1><div class='section'>`;
   const suffix = "</div>";
@@ -155,57 +111,14 @@ const addHandbookPage = async (epub: any, id: string, index: number) => {
   epub.write(Streampub.newChapter(title, prefix + edited + suffix, index));
 };
 
-const getHTML = async (code: string, settings?: any) => {
-  const markdownAST: Node = remark().parse(code);
-
-  // Basically, only run with twoslash during prod builds
-  if (process.env.CI) {
-    await runTwoSlashAcrossDocument(
-      { markdownAST },
-      {
-        theme: require("../../typescriptlang-org/lib/themes/typescript-beta-light.json"),
-      },
-      // @ts-ignore
-      {}
-    );
-  }
-
-  const hAST = toHAST(markdownAST, { allowDangerousHTML: true });
-  return hastToHTML(hAST, { allowDangerousHTML: true });
-};
-
-function replaceAllInString(_str: string, obj: any) {
-  let str = _str;
-
-  Object.keys(obj).forEach((before) => {
-    str = str.replace(new RegExp(before, "g"), obj[before]);
-  });
-  return str;
-}
-
-const getGitSHA = () => {
-  const gitRoot = join(__dirname, "..", "..", "..", ".git");
-  const rev = readFileSync(join(gitRoot, "HEAD"), "utf8").trim();
-  if (rev.indexOf(":") === -1) {
-    return rev;
-  } else {
-    return readFileSync(join(gitRoot, rev.substring(5)), "utf8");
-  }
-};
-
-const getReleaseInfo = () => {
-  // prettier-ignore
-  const releaseInfo = join(
-    __dirname,
-    "..",
-    "..",
-    "typescriptlang-org",
-    "src",
-    "lib",
-    "release-info.json",
-  );
-  const info = JSON.parse(readFileSync(releaseInfo, "utf8"));
-  return info;
-};
-
 startEpub();
+
+// The epub generation is async-y, so just wait till everything is
+// done to move over the file into the website's static assets.
+process.once("exit", () => {
+  copyFileSync(
+    epubPath,
+    // prettier-ignore
+    join(__dirname, "../../typescriptlang-org/static/assets/typescript-handbook.epub")
+  );
+});

--- a/packages/handbook-epub/script/createPDF.ts
+++ b/packages/handbook-epub/script/createPDF.ts
@@ -145,5 +145,9 @@ const addHandbookPage = async (id: string, index: number) => {
   return content;
 };
 
-generateHTML();
-generatePDF();
+const go = async () => {
+  await generateHTML();
+  await generatePDF();
+};
+
+go();

--- a/packages/handbook-epub/script/createPDF.ts
+++ b/packages/handbook-epub/script/createPDF.ts
@@ -1,20 +1,149 @@
 #!/usr/bin/env ts-node
 
-import { execSync } from "child_process";
 import { join } from "path";
-import { copyFileSync } from "fs";
+import { writeFileSync, readFileSync } from "fs";
+import { generateV2Markdowns, getHTML, replaceAllInString } from "./setupPages";
+import { getDocumentationNavForLanguage } from "../../typescriptlang-org/src/lib/documentationNavigation";
+const { chromium } = require("playwright");
+const sass = require("sass");
 
-try {
-  execSync("which ebook-convert", { encoding: "utf8" });
-} catch (e) {
-  console.log("Skipping converting to pdf because calibre is not installed");
-  process.exit(0);
+const markdowns = generateV2Markdowns();
+
+// Grab the handbook nav, and use that to pull out the order
+
+const bookMetadata = {
+  title: "TypeScript Handbook",
+  author: "TypeScript Team and Open Source Contributors",
+  authorUrl: "https://www.typescriptlang.org/",
+  modified: new Date(),
+  source: "https://www.typescriptlang.org",
+  description: "An offline guide to learning TypeScript.",
+  publisher: "Microsoft",
+  subject: "Non-fiction",
+  includeTOC: true,
+  ibooksSpecifiedFonts: true,
+};
+
+// Convert the important SCSS files to JS for the book:
+
+const generateCSS = () => {
+  console.log("Generating CSS from SCSS files");
+
+  const scssFiles = [
+    "../../typescriptlang-org/src/components/layout/main.scss",
+    "../../typescriptlang-org/src/templates/documentation.scss",
+    "../../typescriptlang-org/src/templates/markdown.scss",
+    "../../typescriptlang-org/src/templates/markdown-twoslash.scss",
+  ];
+
+  const css = scssFiles
+    .map((path) => {
+      const scss = sass.renderSync({
+        file: join(__dirname, path),
+      });
+      return scss.css.toString();
+    })
+    .join("\n\n");
+
+  const thisCSS = `
+body {
+  margin-top: 5rem;
 }
 
-const distPath = join(__dirname, "..", "dist");
+article {
+  page-break-after: always;
+  margin-bottom: 4rem;
+}
 
-// prettier-ignore
-execSync(`ebook-convert ${join(distPath, "handbook.epub")} ${join(distPath, "handbook.pdf")}`);
+pre {
+  page-break-inside:avoid
+}
 
-// prettier-ignore
-copyFileSync(join(distPath, "handbook.pdf"), join(__dirname, "..", "..", "typescriptlang-org", "static", "assets", "typescript-handbook.pdf"))
+#handbook-content .whitespace, #handbook-content .whitespace-tight {
+  margin: 0;
+}
+
+.raised {
+  box-shadow: none;
+}
+
+pre.twoslash span.error {
+  color: #bf1818;
+}
+
+data-err {
+  text-decoration: underline;
+  text-decoration-color: #bf1818;
+}
+    `;
+  return css + thisCSS;
+};
+
+const generateHTML = async () => {
+  const handbookNavigation = getDocumentationNavForLanguage("en");
+  const handbook = handbookNavigation.find((i) => i.title === "Handbook");
+  let counter = 0;
+  let html = "<html>";
+
+  const css = generateCSS();
+
+  // prettier-ignore
+  // const style = readFileSync(join(__dirname, "..", "assets", "ebook-style.css"), "utf8");
+  html += `<head><style type='text/css'>${css}</style></head>`;
+
+  html += "<body><div id='handbook-content'>";
+  for (const item of handbook!.items!) {
+    if (item.permalink) {
+      html += await addHandbookPage(item.permalink, counter);
+      counter++;
+    }
+    if (item.items) {
+      for (const subitem of item.items) {
+        html += await addHandbookPage(subitem.permalink!, counter);
+        counter++;
+      }
+    }
+  }
+
+  writeFileSync(join(__dirname, "..", "assets", "all.html"), html);
+};
+
+const generatePDF = async () => {
+  console.log("Starting up Chromium");
+  const browser = await chromium.launch(); // Or 'firefox' or 'webkit'.
+  const page = await browser.newPage();
+  console.log("Loading the html");
+  await page.goto("file://" + join(__dirname, "..", "assets", "all.html"));
+
+  console.log("Rendering the PDF");
+  await page.emulateMedia({ media: "screen" });
+  await page.pdf({
+    path: join(__dirname, "..", "dist", "handbook.pdf"),
+    margin: { top: 40, bottom: 60 },
+  });
+
+  console.log("Done");
+  await browser.close();
+};
+
+const addHandbookPage = async (id: string, index: number) => {
+  const md = markdowns.get(id);
+  if (!md)
+    // prettier-ignore
+    throw new Error("Could not get markdown for " + id + `\n\nAll MDs: ${Array.from(markdowns.keys())}`);
+
+  const title = md.data.title;
+  const prefix = `<h1>${title}</h1><article><div class="whitespace raised"><div class="markdown">`;
+  const suffix = "</div></div></article>";
+
+  const html = await getHTML(md.content, {});
+  const edited = replaceAllInString(html, {
+    'a href="/': 'a href="https://www.typescriptlang.org/',
+  });
+
+  const content = prefix + edited + suffix;
+  return content;
+};
+
+generateHTML();
+generatePDF();

--- a/packages/handbook-epub/script/createPDF.ts
+++ b/packages/handbook-epub/script/createPDF.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env ts-node
 
 import { join } from "path";
-import { writeFileSync, readFileSync } from "fs";
+import { writeFileSync, copyFileSync } from "fs";
 import { generateV2Markdowns, getHTML, replaceAllInString } from "./setupPages";
 import { getDocumentationNavForLanguage } from "../../typescriptlang-org/src/lib/documentationNavigation";
 const { chromium } = require("playwright");
@@ -148,6 +148,11 @@ const addHandbookPage = async (id: string, index: number) => {
 const go = async () => {
   await generateHTML();
   await generatePDF();
+  copyFileSync(
+    join(__dirname, "..", "dist", "handbook.pdf"),
+    // prettier-ignore
+    join( __dirname, "..", "..", "typescriptlang-org", "static", "assets", "typescript-handbook.pdf")
+  );
 };
 
 go();

--- a/packages/handbook-epub/script/setupPages.ts
+++ b/packages/handbook-epub/script/setupPages.ts
@@ -1,0 +1,104 @@
+#!/usr/bin/env ts-node
+
+/* With twoslash
+   env CI=213 yarn workspace handbook-epub build
+*/
+
+const jetpack = require("fs-jetpack");
+const { createReadStream } = jetpack;
+
+const toHAST = require(`mdast-util-to-hast`);
+const hastToHTML = require(`hast-util-to-html`);
+const {
+  recursiveReadDirSync,
+} = require("../../typescriptlang-org/lib/utils/recursiveReadDirSync");
+
+import {
+  readdirSync,
+  readFileSync,
+  lstatSync,
+  copyFileSync,
+  mkdirSync,
+} from "fs";
+import runTwoSlashAcrossDocument from "gatsby-remark-shiki-twoslash";
+const remark = require("remark");
+import { join } from "path";
+import { read as readMarkdownFile } from "gray-matter";
+
+import { getDocumentationNavForLanguage } from "../../typescriptlang-org/src/lib/documentationNavigation";
+import { exists } from "fs-jetpack";
+
+// Reference: https://github.com/AABoyles/LessWrong-Portable/blob/master/build.js
+
+export const generateV2Markdowns = () => {
+  const markdowns = new Map<string, ReturnType<typeof readMarkdownFile>>();
+
+  // Grab all the md + yml info from the handbook files on disk
+  // and add them to ^
+  // prettier-ignore
+  const handbookPath = join( __dirname, "..", "..", "documentation", "copy", "en", "handbook-v2");
+
+  recursiveReadDirSync(handbookPath).forEach((path) => {
+    const filePath = join(__dirname, "..", "..", path);
+    if (lstatSync(filePath).isDirectory() || !filePath.endsWith("md")) {
+      return;
+    }
+
+    const md = readMarkdownFile(filePath);
+    // prettier-ignore
+    if (!md.data.permalink) {
+      throw new Error(
+        `${filePath} in the handbook did not have a permalink in the yml header`,
+      );
+    }
+    const id = md.data.permalink;
+    markdowns.set(id, md);
+  });
+
+  return markdowns;
+};
+
+export const getHTML = async (code: string, settings?: any) => {
+  const markdownAST: Node = remark().parse(code);
+
+  // Basically, only run with twoslash during prod builds
+  if (process.env.CI) {
+    await runTwoSlashAcrossDocument(
+      { markdownAST },
+      {
+        theme: require("../../typescriptlang-org/lib/themes/typescript-beta-light.json"),
+      },
+      // @ts-ignore
+      {}
+    );
+  }
+
+  const hAST = toHAST(markdownAST, { allowDangerousHTML: true });
+  return hastToHTML(hAST, { allowDangerousHTML: true });
+};
+
+export function replaceAllInString(_str: string, obj: any) {
+  let str = _str;
+
+  Object.keys(obj).forEach((before) => {
+    str = str.replace(new RegExp(before, "g"), obj[before]);
+  });
+  return str;
+}
+
+export const getGitSHA = () => {
+  const gitRoot = join(__dirname, "..", "..", "..", ".git");
+  const rev = readFileSync(join(gitRoot, "HEAD"), "utf8").trim();
+  if (rev.indexOf(":") === -1) {
+    return rev;
+  } else {
+    return readFileSync(join(gitRoot, rev.substring(5)), "utf8");
+  }
+};
+
+export const getReleaseInfo = () => {
+  // prettier-ignore
+  const releaseInfo = join(__dirname, "..", "..", "typescriptlang-org", "src", "lib", "release-info.json");
+  const info = JSON.parse(readFileSync(releaseInfo, "utf8"));
+  return info;
+};

--- a/packages/typescriptlang-org/src/templates/documentation.tsx
+++ b/packages/typescriptlang-org/src/templates/documentation.tsx
@@ -55,10 +55,10 @@ const HandbookTemplate: React.FC<Props> = (props) => {
       const redirects = post.frontmatter?.deprecation_redirects || []
       const indexOfHash = redirects.indexOf(document.location.hash.slice(1))
       if (indexOfHash !== -1) {
-        setDeprecationURL(redirects[indexOfHash + 1])  
+        setDeprecationURL(redirects[indexOfHash + 1])
       }
     }
-    
+
     overrideSubNavLinksWithSmoothScroll()
 
     // Handles setting the scroll 
@@ -113,26 +113,26 @@ const HandbookTemplate: React.FC<Props> = (props) => {
 
         <Sidebar navItems={navigation} selectedID={selectedID} />
         <div id="handbook-content" role="article">
-         { deprecationURL && 
-          <>
-            <Helmet>
-              <link rel="canonical" href={`https://www.typescriptlang.org${post.frontmatter.deprecated_by}`} />
-            </Helmet>
-            <div id="deprecated">
-              <div id="deprecated-content">
-                <div id="deprecated-icon">
-                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="8" cy="8" r="7.5" stroke="black"/><path d="M8 3V9" stroke="black"/><path d="M8 11L8 13" stroke="black"/></svg>
+          {deprecationURL &&
+            <>
+              <Helmet>
+                <link rel="canonical" href={`https://www.typescriptlang.org${post.frontmatter.deprecated_by}`} />
+              </Helmet>
+              <div id="deprecated">
+                <div id="deprecated-content">
+                  <div id="deprecated-icon">
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="8" cy="8" r="7.5" stroke="black" /><path d="M8 3V9" stroke="black" /><path d="M8 11L8 13" stroke="black" /></svg>
+                  </div>
+                  <div>
+                    <h3>{i("handb_deprecated_title")}</h3>
+                    <p>{i("handb_deprecated_subtitle")}<IntlLink className="deprecation-redirect-link" to={deprecationURL}>{i("handb_deprecated_subtitle_link")}</IntlLink></p>
+                  </div>
                 </div>
-                <div>
-                  <h3>{i("handb_deprecated_title")}</h3>
-                  <p>{i("handb_deprecated_subtitle")}<IntlLink className="deprecation-redirect-link" to={deprecationURL}>{i("handb_deprecated_subtitle_link")}</IntlLink></p>
+                <div id="deprecated-action">
+                  <IntlLink className="deprecation-redirect-link" to={deprecationURL}>{i("handb_deprecated_subtitle_action")}</IntlLink>
                 </div>
               </div>
-              <div id="deprecated-action">
-                <IntlLink className="deprecation-redirect-link" to={deprecationURL}>{i("handb_deprecated_subtitle_action")}</IntlLink>.
-              </div>
-            </div>
-          </>
+            </>
           }
 
           <h2>{post.frontmatter.title}</h2>
@@ -143,7 +143,7 @@ const HandbookTemplate: React.FC<Props> = (props) => {
             </div>
             {showSidebar &&
               <aside className="handbook-toc">
-                <nav className={deprecationURL ? "deprecated": ""}>
+                <nav className={deprecationURL ? "deprecated" : ""}>
                   {showSidebarHeadings && <>
                     <h5>{i("handb_on_this_page")}</h5>
                     <ul>

--- a/packages/typescriptlang-org/src/templates/markdown-twoslash.scss
+++ b/packages/typescriptlang-org/src/templates/markdown-twoslash.scss
@@ -1,3 +1,5 @@
+@import "../style/globals.scss";
+
 /* Code blocks look like: 
 
 <pre class='shiki lsp twoslash'>

--- a/packages/typescriptlang-org/src/templates/markdown.scss
+++ b/packages/typescriptlang-org/src/templates/markdown.scss
@@ -1,5 +1,4 @@
 @import "../style/globals.scss";
-
 @import "./markdown-twoslash.scss";
 
 .markdown {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5145,6 +5145,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/yauzl@npm:^2.9.1":
+  version: 2.9.1
+  resolution: "@types/yauzl@npm:2.9.1"
+  dependencies:
+    "@types/node": "*"
+  checksum: de89460f6bc272f9169013f1b8add1b46e4f0740b74700d6b3422078a2f3b38de7993c24e4752312f549406898451f4de8598b4168d2a4a6f546fa9bdc09c959
+  languageName: node
+  linkType: hard
+
 "@types/yoga-layout@npm:1.9.2":
   version: 1.9.2
   resolution: "@types/yoga-layout@npm:1.9.2"
@@ -5747,6 +5756,15 @@ __metadata:
   dependencies:
     es6-promisify: ^5.0.0
   checksum: b40b7d9675c475202afac88c31d5ce42f041e50d2028bd4ad0cfc25b60abe4aedf6b976d9f653641663cbf45295539282d0cf7d50ece7f7c1dd0c05dc99a8112
+  languageName: node
+  linkType: hard
+
+"agent-base@npm:6":
+  version: 6.0.2
+  resolution: "agent-base@npm:6.0.2"
+  dependencies:
+    debug: 4
+  checksum: e77eff83e1308883118c7b6a866974dd4ef6be32ef7c91625d5337b13addb5699075c338942f5ecf598d7e5d179b81bf9c9fc644dfb9ca2db0facd9e6bf1238d
   languageName: node
   linkType: hard
 
@@ -8753,6 +8771,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^6.1.0":
+  version: 6.2.1
+  resolution: "commander@npm:6.2.1"
+  checksum: 47856aae6f194404122e359d8463e5e1a18f7cbab26722ce69f1379be8514bd49a160ef81a983d3d2091e3240022643354101d1276c797dcdd0b5bfc3c3f04a3
+  languageName: node
+  linkType: hard
+
 "comment-json@npm:^1.1.3":
   version: 1.1.3
   resolution: "comment-json@npm:1.1.3"
@@ -10265,6 +10290,18 @@ __metadata:
   dependencies:
     ms: 2.0.0
   checksum: 1295acd5e0531761255661d325cd0a80ac8c5f6de8942a53bb23c2197ccb97526972de662ed0e5d9393be83f3428a298a6e7185ecb02f0da6282019cd2ffb4a8
+  languageName: node
+  linkType: hard
+
+"debug@npm:4":
+  version: 4.3.2
+  resolution: "debug@npm:4.3.2"
+  dependencies:
+    ms: 2.1.2
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 5543570879e2274f6725d4285a034d6e0822d35faefc6f55965933fb440e8c21eb3a0bef934e66f4b6b491f898ee2de37cab980e9d4fd61372136c19d3ce4527
   languageName: node
   linkType: hard
 
@@ -12560,6 +12597,23 @@ __metadata:
     snapdragon: ^0.8.1
     to-regex: ^3.0.1
   checksum: ce23be772ff536976902aa0193a6d167abad229ca40fb4c1de2fd71c0116eeae168a02f6508d41382eb918fcbafb66dba61d498754051964a167c98210c62b28
+  languageName: node
+  linkType: hard
+
+"extract-zip@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "extract-zip@npm:2.0.1"
+  dependencies:
+    "@types/yauzl": ^2.9.1
+    debug: ^4.1.1
+    get-stream: ^5.1.0
+    yauzl: ^2.10.0
+  dependenciesMeta:
+    "@types/yauzl":
+      optional: true
+  bin:
+    extract-zip: cli.js
+  checksum: 1217e48d659bf589a7ffaf6fa01fd868d619d1be46ef3dd6526cd17614a2d3a7d1bd5d5ebef81461000cd86fb32a0c9827b466650e98d55efc1fb5ee85f4716a
   languageName: node
   linkType: hard
 
@@ -14978,6 +15032,7 @@ fsevents@~2.1.2:
   resolution: "handbook-epub@workspace:packages/handbook-epub"
   dependencies:
     fs-jetpack: ^2.4.0
+    playwright: ^1.9.1
     streampub: "https://github.com/orta/streampub-1.git#ibooks"
     ts-node: "*"
   languageName: unknown
@@ -15803,6 +15858,16 @@ fsevents@~2.1.2:
     agent-base: ^4.3.0
     debug: ^3.1.0
   checksum: 4e42bed005d75debcfd6d3901edbd391dd72cda32a2ece4584443eb7025ac0a0f85fb01f45d385608a380f6bf2d659c632776ac17b898c6d991fd9ec1d32a1f0
+  languageName: node
+  linkType: hard
+
+"https-proxy-agent@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "https-proxy-agent@npm:5.0.0"
+  dependencies:
+    agent-base: 6
+    debug: 4
+  checksum: 18aa04ea08cc069fa0c83d03475d1bc43e13bfa43d5cffc0c3a07430f755e1ac914049570302775adac82aa5a779643ef2c6c270c057d7a8523a7f6f46b4866a
   languageName: node
   linkType: hard
 
@@ -18396,6 +18461,13 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"jpeg-js@npm:^0.4.2":
+  version: 0.4.3
+  resolution: "jpeg-js@npm:0.4.3"
+  checksum: c882ae02b8639d92b0004520dc949363dd1ff9dcfbadbb93f1760c9a3aab894fdca66af2ff57bcdb85a2741dba51cbaf748745eb3165bf2b73bdef2cfd639442
+  languageName: node
+  linkType: hard
+
 "jpjs@npm:^1.2.1":
   version: 1.2.1
   resolution: "jpjs@npm:1.2.1"
@@ -20686,7 +20758,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"ms@npm:^2.1.1":
+"ms@npm:2.1.2, ms@npm:^2.1.1":
   version: 2.1.2
   resolution: "ms@npm:2.1.2"
   checksum: 9b65fb709bc30c0c07289dcbdb61ca032acbb9ea5698b55fa62e2cebb04c5953f1876a1f3f7f4bc2e91d4bf4d86003f3e207c3bc6ee2f716f99827e62389cd0e
@@ -22719,6 +22791,29 @@ fsevents@~2.1.2:
   languageName: unknown
   linkType: soft
 
+"playwright@npm:^1.9.1":
+  version: 1.9.1
+  resolution: "playwright@npm:1.9.1"
+  dependencies:
+    commander: ^6.1.0
+    debug: ^4.1.1
+    extract-zip: ^2.0.1
+    https-proxy-agent: ^5.0.0
+    jpeg-js: ^0.4.2
+    mime: ^2.4.6
+    pngjs: ^5.0.0
+    progress: ^2.0.3
+    proper-lockfile: ^4.1.1
+    proxy-from-env: ^1.1.0
+    rimraf: ^3.0.2
+    stack-utils: ^2.0.3
+    ws: ^7.3.1
+  bin:
+    playwright: lib/cli/cli.js
+  checksum: 68737690f5f331b995a6634719d7e20ffc03ed365396275c79249a6dcd233bf4cf5af01864ec6709c738a9244b7f07661a788b00b5918ddaba3d46a6f4ee3ff6
+  languageName: node
+  linkType: hard
+
 "please-upgrade-node@npm:^3.2.0":
   version: 3.2.0
   resolution: "please-upgrade-node@npm:3.2.0"
@@ -22756,6 +22851,13 @@ fsevents@~2.1.2:
   version: 3.4.0
   resolution: "pngjs@npm:3.4.0"
   checksum: aa6d2cb4dd770cab9b06d9169aa94f134d7ff7dae3a73310709f0f0b4cdbcca2a8bfa7fa6f4d610719d5a3aa848447e6a755730e5dc911a38e8ec4d7a64dc214
+  languageName: node
+  linkType: hard
+
+"pngjs@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "pngjs@npm:5.0.0"
+  checksum: 2b8d7eeafd947449b7dc3908e1a983d366a7c98ea01f44e9b42a9608f60faa6667f55b342739746ead810d6909e8fd0d994f0a59502d43f39d93e85214259652
   languageName: node
   linkType: hard
 
@@ -23599,6 +23701,13 @@ fsevents@~2.1.2:
     forwarded: ~0.1.2
     ipaddr.js: 1.9.0
   checksum: 432cb36057d71b4c97cf293e874db34c4358a2505085d5d7a99962c4b59d3d94bd99e1cc246f5664c5bc98e97504fa77ed451b66899c2d118ebe1fb29779900c
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "proxy-from-env@npm:1.1.0"
+  checksum: 6459372a57f3e8ef5211f7847ca2fffabcdd6490005892fcc0dcd62fe2b3551900c8a07fad7df9de3897547b1ab4ac7a7197964cd6fa7e76303caa4936bfaf32
   languageName: node
   linkType: hard
 
@@ -25467,6 +25576,17 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
+"rimraf@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "rimraf@npm:3.0.2"
+  dependencies:
+    glob: ^7.1.3
+  bin:
+    rimraf: bin.js
+  checksum: f0de3e445581e64a8a077af476cc30708e659f5779ec2ca2a161556d0792aa318a685923798ae22055b4ecd02b9aff444ef619578f7af53cf8e0e248031e3dee
+  languageName: node
+  linkType: hard
+
 "ripemd160@npm:^2.0.0, ripemd160@npm:^2.0.1":
   version: 2.0.2
   resolution: "ripemd160@npm:2.0.2"
@@ -26872,6 +26992,15 @@ resolve@1.1.7:
   dependencies:
     escape-string-regexp: ^2.0.0
   checksum: a9fa702767defa95a14fe7a78083eadfc254c5e12e105b034242b47cc4e9ba4ba345b54b7218b8abbbf8f38d6a327b20aa0fdebb582eae5118f2cd004e7bace5
+  languageName: node
+  linkType: hard
+
+"stack-utils@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "stack-utils@npm:2.0.3"
+  dependencies:
+    escape-string-regexp: ^2.0.0
+  checksum: 65fe92891beee90473708c119e8d55473996aa11ff073cc59c3f6a0b199b44c1cc7c51425b64a8d0761d1c7c3d9ab8350a6bebff4d32720492cdfb00ee3096f8
   languageName: node
   linkType: hard
 
@@ -30328,6 +30457,21 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
+"ws@npm:^7.3.1":
+  version: 7.4.3
+  resolution: "ws@npm:7.4.3"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 493655b7c4589d09ff3c2b6e8870b9ad7f7aea0aff34034e2dbb9a2e13f6868a47b06b423bc2365aec6143500b04ad24fdaecfbd9a6752f8eab2d339182c9884
+  languageName: node
+  linkType: hard
+
 "ws@npm:~6.1.0":
   version: 6.1.4
   resolution: "ws@npm:6.1.4"
@@ -30670,7 +30814,7 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
-"yauzl@npm:^2.4.2":
+"yauzl@npm:^2.10.0, yauzl@npm:^2.4.2":
   version: 2.10.0
   resolution: "yauzl@npm:2.10.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -15033,6 +15033,7 @@ fsevents@~2.1.2:
   dependencies:
     fs-jetpack: ^2.4.0
     playwright: ^1.9.1
+    sass: "*"
     streampub: "https://github.com/orta/streampub-1.git#ibooks"
     ts-node: "*"
   languageName: unknown
@@ -25832,6 +25833,17 @@ resolve@1.1.7:
   peerDependencies:
     webpack: ^3.0.0 || ^4.0.0
   checksum: 9fbd7ff88a0402a730abd3be090deccf4eea48f9b58547b1cb20fd54b0871af10441969f6f4b46e42b9f86c1bf03bdccd966161c6dceb38a14120485d196af85
+  languageName: node
+  linkType: hard
+
+"sass@npm:*":
+  version: 1.32.8
+  resolution: "sass@npm:1.32.8"
+  dependencies:
+    chokidar: ">=2.0.0 <4.0.0"
+  bin:
+    sass: sass.js
+  checksum: d319b3d7459451b6532b492984e3cbb37381e6c6379622f668900b196c0d545f5a2c32819cf02b5405fb2ef79720fe1f8f16b7614a2fef3fb7af8dfec83a6597
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Switches from using calibre which converts the Pub -> PDF to using a Playwright with the chromium pdf renderer ( /cc @arjunattam) - it was always a hack-job and now we have full control over the rendering process. We generate a single HTML file from all of the handbook pages, a subset of the site's CSS and mix in some print-specific CSS to customize it.

- TODO: An intro page with the TS version, commit and TOC.
- Long-term TODO: Change links to work internally, instead of always going to the site

### Before

https://www.typescriptlang.org/assets/typescript-handbook-beta.pdf

![Screen Shot 2021-03-05 at 12 40 42 PM](https://user-images.githubusercontent.com/49038/110116857-06660f00-7db0-11eb-94f8-82662e8f7295.png)
![Screen Shot 2021-03-05 at 12 40 35 PM](https://user-images.githubusercontent.com/49038/110116862-07973c00-7db0-11eb-81c0-81a37facdf80.png)
![Screen Shot 2021-03-05 at 12 40 31 PM](https://user-images.githubusercontent.com/49038/110116863-082fd280-7db0-11eb-84bd-c235341d294d.png)
![Screen Shot 2021-03-05 at 12 41 10 PM](https://user-images.githubusercontent.com/49038/110116896-141b9480-7db0-11eb-9a42-5f03aaa87e15.png)


### After 

[handbook.pdf](https://github.com/microsoft/TypeScript-Website/files/6090524/handbook.pdf)

- Correct fonts
- More consistent page margins
- Code samples don't cross pages
- Handbook sections don't 

![Screen Shot 2021-03-05 at 12 41 53 PM](https://user-images.githubusercontent.com/49038/110116970-2b5a8200-7db0-11eb-835c-0238cfe08627.png)
![Screen Shot 2021-03-05 at 12 42 26 PM](https://user-images.githubusercontent.com/49038/110117035-40371580-7db0-11eb-87cb-f6bd3f8a26cd.png)
![Screen Shot 2021-03-05 at 12 42 52 PM](https://user-images.githubusercontent.com/49038/110117082-4e853180-7db0-11eb-9b71-ef2b3d22789b.png)
![Screen Shot 2021-03-05 at 12 43 27 PM](https://user-images.githubusercontent.com/49038/110117156-6361c500-7db0-11eb-9368-d58d56fab119.png)

