### PR TITLE
Add Clear Logs Button

### DIFF
--- a/packages/playground/src/sidebar/runtime.ts
+++ b/packages/playground/src/sidebar/runtime.ts
@@ -64,9 +64,19 @@ export const runPlugin: PluginFactory = (i, utils) => {
       filterTextBox.id = "filter-logs"
       filterTextBox.placeholder = i("play_sidebar_tools_filter_placeholder")
       filterTextBox.addEventListener("input", (e: any) => {
+        const inputText = e.target.value
+
         const eleLog = document.getElementById("log")!
-        console.log(allLogs)
-        eleLog.innerHTML = allLogs.filter(log => log.substring(log.indexOf(":") + 1, log.indexOf("&nbsp;<br>")).includes(e.target.value)).join("<hr />")
+        eleLog.innerHTML = allLogs
+          .filter(log => {
+            const userLoggedText = log.substring(log.indexOf(":") + 1, log.indexOf("&nbsp;<br>"))
+            return userLoggedText.includes(inputText)
+          }).join("<hr />")
+
+        if (inputText === "") {
+          const logContainer = document.getElementById("log-container")!
+          logContainer.scrollTop = logContainer.scrollHeight
+        }
       })
       logToolsContainer.appendChild(filterTextBox)
 
@@ -152,19 +162,10 @@ function rewireLoggingToElement(
       const eleContainerLog = eleOverflowLocator()
       allLogs.push(`${prefix}${output}<br>`);
       eleLog.innerHTML = allLogs.join("<hr />")
-      const scrollElement = eleContainerLog.parentElement
-      if (autoScroll && scrollElement) {
-        scrollToBottom(scrollElement)
+      if (autoScroll && eleContainerLog) {
+        eleContainerLog.scrollTop = eleContainerLog.scrollHeight
       }
       raw[name](...objs)
-    }
-  }
-
-  function scrollToBottom(element: Element) {
-    const overflowHeight = element.scrollHeight - element.clientHeight
-    const atBottom = element.scrollTop >= overflowHeight
-    if (!atBottom) {
-      element.scrollTop = overflowHeight
     }
   }
 

--- a/packages/playground/src/sidebar/runtime.ts
+++ b/packages/playground/src/sidebar/runtime.ts
@@ -57,6 +57,9 @@ export const runPlugin: PluginFactory = (i, utils) => {
       clearLogsButton.onclick = e => {
         e.preventDefault();
         clearLogsAction.run();
+
+        const filterTextBox: any = document.getElementById("filter-logs")
+        filterTextBox!.value = ""
       }
       logToolsContainer.appendChild(clearLogsButton)
 

--- a/packages/playground/src/sidebar/runtime.ts
+++ b/packages/playground/src/sidebar/runtime.ts
@@ -13,11 +13,37 @@ export const runPlugin: PluginFactory = (i, utils) => {
     id: "logs",
     displayName: i("play_sidebar_logs"),
     willMount: (sandbox, container) => {
+      const ui = createUI()
+
+      const clearLogsAction = {
+        id: "clear-logs-play",
+        label: "Clear Playground Logs",
+        keybindings: [sandbox.monaco.KeyMod.CtrlCmd | sandbox.monaco.KeyCode.KEY_K],
+
+        contextMenuGroupId: "run",
+        contextMenuOrder: 1.5,
+
+        run: function () {
+          clearLogs()
+          ui.flashInfo(i("play_clear_logs"))
+        },
+      }
+
+      const clearLogsButton = document.createElement("button")
+      clearLogsButton.id = "clear-logs-button"
+      clearLogsButton.innerHTML = "Clear Logs"
+      clearLogsButton.onclick = e => {
+        e.preventDefault();
+        clearLogsAction.run();
+      }
+
+      container.appendChild(clearLogsButton)
+
       if (!addedClearAction) {
-        const ui = createUI()
-        addClearAction(sandbox, ui, i)
+        sandbox.editor.addAction(clearLogsAction);
         addedClearAction = true
       }
+
 
       if (allLogs.length === 0) {
         const noErrorsMessage = document.createElement("div")
@@ -160,22 +186,4 @@ function rewireLoggingToElement(
       return output + textRep + comma + "&nbsp;"
     }, "")
   }
-}
-
-const addClearAction = (sandbox: Sandbox, ui: UI, i: any) => {
-  const clearLogsAction = {
-    id: "clear-logs-play",
-    label: "Clear Playground Logs",
-    keybindings: [sandbox.monaco.KeyMod.CtrlCmd | sandbox.monaco.KeyCode.KEY_K],
-
-    contextMenuGroupId: "run",
-    contextMenuOrder: 1.5,
-
-    run: function () {
-      clearLogs()
-      ui.flashInfo(i("play_clear_logs"))
-    },
-  }
-
-  sandbox.editor.addAction(clearLogsAction)
 }

--- a/packages/typescriptlang-org/src/copy/en/playground.ts
+++ b/packages/typescriptlang-org/src/copy/en/playground.ts
@@ -89,6 +89,7 @@ console.log(anExampleVariable)
   play_sidebar_ast_title: "[WIP] AST Viewer",
   play_sidebar_ast_blurb: "Inspect the TypeScript AST",
 
+  play_sidebar_tools_filter_placeholder: "Filter",
   // Notes:
   // Compiler flag information is all from the tsconfig reference info
 }

--- a/packages/typescriptlang-org/src/templates/play.scss
+++ b/packages/typescriptlang-org/src/templates/play.scss
@@ -471,6 +471,10 @@ main #editor-toolbar {
     line-height: 1.5rem;
     white-space: pre-wrap;
 
+    #log {
+      margin-top: 1rem;
+    }
+
     .log-warn {
       color: orange;
     }

--- a/packages/typescriptlang-org/src/templates/play.scss
+++ b/packages/typescriptlang-org/src/templates/play.scss
@@ -465,11 +465,27 @@ main #editor-toolbar {
 
 /** Design System Tweaks **/
 .playground-plugin-container {
+  #log-tools {
+    display: flex;
+    border-top: 1px var(--playground-dragbar-border) solid;
+    border-bottom: 1px var(--playground-dragbar-border) solid;
+    margin-top: 2px;
+    padding: 3px;
+    align-items: center;
+
+    svg {
+      stroke: var(--text-color);
+      cursor: pointer;
+      padding-right: 5px;
+    }
+  }
+
   #log-container {
     overflow: auto;
     font-family: $font-code;
     line-height: 1.5rem;
     white-space: pre-wrap;
+    height: 95%;
 
     #log {
       margin-top: 1rem;


### PR DESCRIPTION
In regards to https://github.com/microsoft/TypeScript-Website/issues/450 , I've added a clear log button to make it more clear that functionality is present. We would still be missing the `Filter` option as mentioned in the issue.

**Before**
![image](https://user-images.githubusercontent.com/17804942/110196849-41e6f480-7e15-11eb-9361-7eb2aa81ac9f.png)

**After**
![image](https://user-images.githubusercontent.com/17804942/110196858-4d3a2000-7e15-11eb-9fff-1775220c7433.png)

