### PR TITLE
Correct 'an state' to be 'a state'

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Narrowing.md
+++ b/packages/documentation/copy/en/handbook-v2/Narrowing.md
@@ -654,7 +654,7 @@ They're good for representing any sort of messaging scheme in JavaScript, like w
 # The `never` type
 
 When narrowing, you can reduce the options of a union to a point where you have removed all possibilities and have nothing left.
-In those cases, TypeScript will use a `never` type to represent an state which shouldn't exist.
+In those cases, TypeScript will use a `never` type to represent a state which shouldn't exist.
 
 # Exhaustiveness checking
 


### PR DESCRIPTION
Small correction