### PR TITLE
Add FoalTS framework to bootstrap page

### DIFF
--- a/packages/typescriptlang-org/src/copy/en/documentation.ts
+++ b/packages/typescriptlang-org/src/copy/en/documentation.ts
@@ -46,6 +46,7 @@ export const docCopy = {
   doc_apis_loopback_blurb:
     "A highly extensible Node.js and TypeScript framework for building APIs and microservices",
   doc_apis_fastify_blurb: "A fast and low overhead web framework for Node.js",
+  doc_apis_foal_blurb: "Elegant and complete Node.js framework for building web applications.",
   doc_react: "React Projects",
   doc_react_create_blurb: "Set up a modern web app by running one command",
   doc_react_gatsby_blurb:

--- a/packages/typescriptlang-org/src/templates/pages/docs/bootstrap.tsx
+++ b/packages/typescriptlang-org/src/templates/pages/docs/bootstrap.tsx
@@ -138,6 +138,11 @@ const Index: React.FC<Props> = (props) => {
               blurb: i("doc_apis_fastify_blurb"),
               title: "Fastify",
             },
+            {
+              href: "https://foalts.org/",
+              blurb: i("doc_apis_foal_blurb"),
+              title: "Foal TS",
+            },
           ]}
         />
 


### PR DESCRIPTION
This PR adds a link to [FoalTS website](https://foalts.org/) on the page `https://www.typescriptlang.org/docs/bootstrap`.