### PR TITLE
docs: fix typo handbook v2 functions inference

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -134,7 +134,7 @@ function map<E, O>(arr: E[], func: (arg: E) => O): O[] {
   return arr.map(func);
 }
 
-// Parameter 'n' is of type 'number'
+// Parameter 'n' is of type 'string'
 // 'parsed' is of type 'number[]'
 const parsed = map(["1", "2", "3"], (n) => parseInt(n));
 ```


### PR DESCRIPTION
This commit fixes a typo in the section "Inference" of the chapter
"More on functions" of the hanbook v2.

closes #1627