### PR TITLE
Adds a mention for this-based type guards in the handbook v2

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -1022,6 +1022,55 @@ const derived = new DerivedBox();
 derived.sameAs(base);
 ```
 
+### `this`-based type guards
+
+You can use `this is Type` in the return position for methods in classes and interfaces.
+When mixed with a type narrowing (e.g. `if` statements) the type of the target object would be narrowed to the specified `Type`.
+
+<!-- prettier-ignore -->
+```ts twoslash
+// @strictPropertyInitialization: false
+class FileSystemObject {
+  isFile(): this is FileRep {
+    return this instanceof FileRep;
+  }
+  isDirectory(): this is Directory {
+    return this instanceof Directory;
+  }
+  isNetworked(): this is Networked & this {
+    return this.networked;
+  }
+  constructor(public path: string, private networked: boolean) {}
+}
+
+class FileRep extends FileSystemObject {
+  constructor(path: string, public content: string) {
+    super(path, false);
+  }
+}
+
+class Directory extends FileSystemObject {
+  children: FileSystemObject[];
+}
+
+interface Networked {
+  host: string;
+}
+
+const fso: FileSystemObject = new FileRep("foo/bar.txt", "foo");
+
+if (fso.isFile()) {
+  fso.content;
+// ^?
+} else if (fso.isDirectory()) {
+  fso.children;
+// ^?
+} else if (fso.isNetworked()) {
+  fso.host;
+// ^?
+}
+```
+
 ## Parameter Properties
 
 TypeScript offers special syntax for turning a constructor parameter into a class property with the same name and value.

--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -1071,6 +1071,29 @@ if (fso.isFile()) {
 }
 ```
 
+A common use-case for a this-based type guard is to allow for lazy validation of a particular field. For example, this case removes an `undefined` from the value held inside box when `hasValue` has been verified to be true:
+
+```ts twoslash
+class Box<T> {
+  value?: T;
+
+  hasValue(): this is { value: T } {
+    return this.value !== undefined;
+  }
+}
+
+const box = new Box();
+box.value = "Gameboy";
+
+box.value;
+//  ^?
+
+if (box.hasValue()) {
+  box.value;
+  //  ^?
+}
+```
+
 ## Parameter Properties
 
 TypeScript offers special syntax for turning a constructor parameter into a class property with the same name and value.
@@ -1079,7 +1102,7 @@ The resulting field gets those modifier(s):
 
 ```ts twoslash
 // @errors: 2341
-class A {
+class Params {
   constructor(
     public readonly x: number,
     protected y: number,
@@ -1088,7 +1111,7 @@ class A {
     // No body necessary
   }
 }
-const a = new A(1, 2, 3);
+const a = new Params(1, 2, 3);
 console.log(a.x);
 //            ^?
 console.log(a.z);

--- a/packages/documentation/copy/en/handbook-v2/Modules.md
+++ b/packages/documentation/copy/en/handbook-v2/Modules.md
@@ -27,7 +27,7 @@ Conversely, to consume a variable, function, class, interface, etc. exported fro
 Before we start, it's important to understand what TypeScript considers a module.
 The JavaScript specification declares that any JavaScript files without an `export` or top-level `await` should be considered a script and not a module.
 
-Inside a script file variables are declared to be in the shared global scope, and it's assumed that you'll either use the [`--outFile`](/tsconfig#outFile) compiler option to join multiple input files into one output file, or use multiple `<script>` tags in your HTML to load these files (in the correct order!).
+Inside a script file variables and types are declared to be in the shared global scope, and it's assumed that you'll either use the [`--outFile`](/tsconfig#outFile) compiler option to join multiple input files into one output file, or use multiple `<script>` tags in your HTML to load these files (in the correct order!).
 
 If you have a file that doesn't currently have any `import`s or `export`s, but you want to be treated as a module, add the line:
 
@@ -35,7 +35,7 @@ If you have a file that doesn't currently have any `import`s or `export`s, but y
 export {};
 ```
 
-to make the file be a module exporting nothing. This syntax works regardless of your module target.
+which will change the file be a module exporting nothing. This syntax works regardless of your module target.
 
 ## Modules in TypeScript
 

--- a/packages/documentation/copy/en/handbook-v2/Narrowing.md
+++ b/packages/documentation/copy/en/handbook-v2/Narrowing.md
@@ -433,6 +433,8 @@ const underWater2: Fish[] = zoo.filter<Fish>(isFish);
 const underWater3: Fish[] = zoo.filter<Fish>((pet) => isFish(pet));
 ```
 
+In addition, classes can [use `this is Type`](/docs/handbook/2/classes.html#this-based-type-guards) to narrow their type.
+
 # Discriminated unions
 
 Most of the examples we've looked at so far have focused around narrowing single variables with simple types like `string`, `boolean`, and `number`.


### PR DESCRIPTION
This was only mentioned in the 1.8 release notes, now it gets a re-direct in the narrowing section and lives in the classes one.