### PR TITLE
Update Narrowing.md

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Narrowing.md
+++ b/packages/documentation/copy/en/handbook-v2/Narrowing.md
@@ -430,6 +430,8 @@ const zoo: (Fish | Bird)[] = [getSmallPet(), getSmallPet(), getSmallPet()];
 const underWater1: Fish[] = zoo.filter(isFish);
 // or, equivalently
 const underWater2: Fish[] = zoo.filter<Fish>(isFish);
+
+However, the following will throw an error.
 const underWater3: Fish[] = zoo.filter<Fish>((pet) => isFish(pet));
 ```
 

--- a/packages/documentation/copy/en/handbook-v2/Narrowing.md
+++ b/packages/documentation/copy/en/handbook-v2/Narrowing.md
@@ -431,7 +431,7 @@ const underWater1: Fish[] = zoo.filter(isFish);
 // or, equivalently
 const underWater2: Fish[] = zoo.filter<Fish>(isFish);
 
-However, the following will throw an error.
+// However, the following will throw an error.
 const underWater3: Fish[] = zoo.filter<Fish>((pet) => isFish(pet));
 ```
 


### PR DESCRIPTION
On line 435, the last example (const underWater3: Fish[] = zoo.filter<Fish>((pet) => isFish(pet));) throws an error. It does not mention it will throw an error, nor does it say why is the error there.