### PR TITLE
Classes.md: Perhaps the term needs to be clarified

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -596,7 +596,7 @@ g.getName();
 
 #### Exposure of `protected` members
 
-Derived classes need to follow their base class contracts, but may choose to expose a more general type with more capabilities.
+Derived classes need to follow their base class contracts, but may choose to expose a subtype of base class with more capabilities.
 This includes making `protected` members `public`:
 
 ```ts twoslash


### PR DESCRIPTION
Doesn't _more general type_ mean supertype? In such a case, can the type of the derived class be called a more general type of base class?
It seems that adding a new field narrows the derived type (makes it a subtype of the base type).
Perhaps my edit is not appropriate (maybe it could be called a more specific type), but I just wanted to draw attention to this place.