### PR TITLE
docs(mapped types): fixe variables naming

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Mapped Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Mapped Types.md
@@ -114,8 +114,8 @@ You can filter out keys by producing `never` via a conditional type:
 
 ```ts twoslash
 // Remove the 'kind' property
-type RemoveKindField<T> = {
-    [K in keyof T as Exclude<K, "kind">]: T[K]
+type RemoveKindField<Type> = {
+    [Property in keyof Type as Exclude<Property, "kind">]: Type[Property]
 };
 
 interface Circle {


### PR DESCRIPTION
This commit renames varialbes K and T to follow the renaming applied
during the documentation re-write (from v1 to v2).

closes #1658