### PR TITLE
Add Omit example, document Keys type

### DIFF
--- a/packages/documentation/copy/en/reference/Utility Types.md
+++ b/packages/documentation/copy/en/reference/Utility Types.md
@@ -105,7 +105,7 @@ cats.boris;
 
 ## `Pick<Type, Keys>`
 
-Constructs a type by picking the set of properties `Keys` from `Type`.
+Constructs a type by picking the set of properties `Keys` (string literal or union of string literals) from `Type`.
 
 ##### Example
 
@@ -129,7 +129,7 @@ todo;
 
 ## `Omit<Type, Keys>`
 
-Constructs a type by picking all properties from `Type` and then removing `Keys`.
+Constructs a type by picking all properties from `Type` and then removing `Keys` (string literal or union of string literals).
 
 ##### Example
 
@@ -138,6 +138,7 @@ interface Todo {
   title: string;
   description: string;
   completed: boolean;
+  createdAt: number;
 }
 
 type TodoPreview = Omit<Todo, "description">;
@@ -145,9 +146,20 @@ type TodoPreview = Omit<Todo, "description">;
 const todo: TodoPreview = {
   title: "Clean room",
   completed: false,
+  createdAt: 1615544252770,
 };
 
 todo;
+// ^?
+
+type TodoInfo = Omit<Todo, "completed" | "createdAt">;
+
+const todoInfo: TodoInfo = {
+  title: "Pick up kids",
+  description: "Kindergarten closes at 5pm",
+};
+
+todoInfo;
 // ^?
 ```
 


### PR DESCRIPTION
Hey @orta! 👋 Hope you are well.

A quick PR to:

- document the type of `Keys` (allows for a single string literal but also a union of string literals)
- add an `Omit` example that uses a union of string literals

If this doesn't fit the style correctly or needs to be modified in some way, let me know, happy to do so!