### PR TITLE
Fixes wrong generator reference

### DIFF
--- a/packages/documentation/copy/en/release-notes/TypeScript 4.2.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 4.2.md
@@ -553,7 +553,7 @@ function* g3() {
 function* g4(): Generator<number, void, string> {
   // No error.
   // TypeScript can figure out the type of `yield 1`
-  // from the explicit return type of `g3`.
+  // from the explicit return type of `g4`.
   const value = yield 1;
 }
 ```


### PR DESCRIPTION
Hey there, seems like the last example in the [`noImplicitAny` Errors Apply to Loose `yield` Expressions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-2.html#noimplicitany-errors-apply-to-loose-yield-expressions) section of 4.2 release notes actually meant to refer to the `g4` generator function, if I understood this snippet correctly.


I'll also use this tiny PR as an opportunity to express my gratitude to the TypeScript team. You rock!