### PR TITLE
Local Doc Search

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/TopNav.tsx
+++ b/packages/typescriptlang-org/src/components/layout/TopNav.tsx
@@ -23,7 +23,7 @@ export const SiteNav = (props: Props) => {
       apiKey: '3c2db2aef0c7ff26e8911267474a9b2c',
       indexName: 'typescriptlang',
       inputSelector: '.search input',
-      handleSelected: function (input, event, suggestion, datasetNumber, context) {
+      handleSelected: (input, event, suggestion, datasetNumber, context) => {
         let urlToOpen = suggestion.url;
         if (window.location.href.includes("localhost:8000")) {
           urlToOpen = suggestion.url.replace("www.typescriptlang.org", "localhost:8000").replace("https", "http")

--- a/packages/typescriptlang-org/src/components/layout/TopNav.tsx
+++ b/packages/typescriptlang-org/src/components/layout/TopNav.tsx
@@ -24,7 +24,7 @@ export const SiteNav = (props: Props) => {
     if (isDev) {
       customHandleSelected = (input, event, suggestion, datasetNumber, context) => {
         const urlToOpen = suggestion.url.replace("www.typescriptlang.org", "localhost:8000").replace("https", "http")
-        window.open(urlToOpen);
+        window.open(urlToOpen)
       }
     }
 

--- a/packages/typescriptlang-org/src/components/layout/TopNav.tsx
+++ b/packages/typescriptlang-org/src/components/layout/TopNav.tsx
@@ -17,22 +17,30 @@ import { OpenInMyLangQuickJump } from "./LanguageRecommendation";
 export const SiteNav = (props: Props) => {
   const i = createInternational<typeof navCopy>(useIntl())
   const IntlLink = createIntlLink(props.lang)
-
+  const loadDocSearch = () => {
+    // @ts-ignore - this comes from the script above
+    docsearch({
+      apiKey: '3c2db2aef0c7ff26e8911267474a9b2c',
+      indexName: 'typescriptlang',
+      inputSelector: '.search input',
+      handleSelected: function (input, event, suggestion, datasetNumber, context) {
+        let urlToOpen = suggestion.url;
+        if (window.location.href.includes("localhost:8000")) {
+          urlToOpen = suggestion.url.replace("www.typescriptlang.org", "localhost:8000").replace("https", "http")
+        }
+        window.open(urlToOpen);
+      },
+    });
+  }
   // This extra bit of mis-direction ensures that non-essential code runs after
   // the page is loaded
   useEffect(() => {
     setupStickyNavigation()
 
-    // @ts-ignore - this could come from a previous page load
-    if (typeof docsearch !== 'undefined') {
-      // @ts-ignore - just been validate
-      docsearch({
-        apiKey: '3c2db2aef0c7ff26e8911267474a9b2c',
-        indexName: 'typescriptlang',
-        inputSelector: '.search input',
-      });
+    // @ts-ignore - this comes from the script above
+    if (window.docsearch) {
+      loadDocSearch();
     }
-
     if (document.getElementById("algolia-search")) return
 
     const searchScript = document.createElement('script');
@@ -43,13 +51,8 @@ export const SiteNav = (props: Props) => {
     searchScript.async = true;
     searchScript.onload = () => {
       // @ts-ignore - this comes from the script above
-      if (typeof docsearch !== 'undefined') {
-        // @ts-ignore - this comes from the script above
-        docsearch({
-          apiKey: '3c2db2aef0c7ff26e8911267474a9b2c',
-          indexName: 'typescriptlang',
-          inputSelector: '.search input'
-        });
+      if (window.docsearch) {
+        loadDocSearch();
 
         searchCSS.rel = 'stylesheet';
         searchCSS.href = withPrefix('/css/docsearch.css');

--- a/packages/typescriptlang-org/src/components/layout/TopNav.tsx
+++ b/packages/typescriptlang-org/src/components/layout/TopNav.tsx
@@ -18,18 +18,23 @@ export const SiteNav = (props: Props) => {
   const i = createInternational<typeof navCopy>(useIntl())
   const IntlLink = createIntlLink(props.lang)
   const loadDocSearch = () => {
+    const isDev = document.location.host.includes('localhost')
+    let customHandleSelected;
+
+    if (isDev) {
+      customHandleSelected = (input, event, suggestion, datasetNumber, context) => {
+        const urlToOpen = suggestion.url.replace("www.typescriptlang.org", "localhost:8000").replace("https", "http")
+        window.open(urlToOpen);
+      }
+    }
+
+
     // @ts-ignore - this comes from the script above
     docsearch({
       apiKey: '3c2db2aef0c7ff26e8911267474a9b2c',
       indexName: 'typescriptlang',
       inputSelector: '.search input',
-      handleSelected: (input, event, suggestion, datasetNumber, context) => {
-        let urlToOpen = suggestion.url;
-        if (window.location.href.includes("localhost:8000")) {
-          urlToOpen = suggestion.url.replace("www.typescriptlang.org", "localhost:8000").replace("https", "http")
-        }
-        window.open(urlToOpen);
-      },
+      handleSelected: customHandleSelected,
     });
   }
   // This extra bit of mis-direction ensures that non-essential code runs after


### PR DESCRIPTION
No issues but this came out of personal frustration where docsearch would use `typescriptlang.org` instead of my localhost. I kept having to copy the url and paste it in my browser and replace it to localhost to go where I wanted. SO I looked up docsearch docs and made it so if your on localhost, it will use localhost instead of typescriptlang.org.

