### PR TITLE
Update links on the generics page to handbook v2

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Generics.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Generics.md
@@ -248,7 +248,7 @@ console.log(stringNumeric.add(stringNumeric.zeroValue, "test"));
 
 Just as with interface, putting the type parameter on the class itself lets us make sure all of the properties of the class are working with the same type.
 
-As we covered in [our section on classes](/docs/handbook/classes.html), a class has two sides to its type: the static side and the instance side.
+As we covered in [our section on classes](/docs/handbook/2/classes.html), a class has two sides to its type: the static side and the instance side.
 Generic classes are only generic over their instance side rather than their static side, so when working with classes, static members can not use the class's type parameter.
 
 ## Generic Constraints
@@ -373,4 +373,4 @@ createInstance(Lion).keeper.nametag;
 createInstance(Bee).keeper.hasMask;
 ```
 
-This pattern is used to power the [mixins](/docs/handbook/mixins.html) design pattern.
+This pattern is used to power the [mixins](/docs/handbook/2/mixins.html) design pattern.


### PR DESCRIPTION
This pull request updates links on the generics page to point to the new v2 handbook page.