### PR TITLE
Docs: Fix last example of "Using type predicates"

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Narrowing.md
+++ b/packages/documentation/copy/en/handbook-v2/Narrowing.md
@@ -430,7 +430,7 @@ const zoo: (Fish | Bird)[] = [getSmallPet(), getSmallPet(), getSmallPet()];
 const underWater1: Fish[] = zoo.filter(isFish);
 // or, equivalently
 const underWater2: Fish[] = zoo.filter<Fish>(isFish);
-const underWater3: Fish[] = zoo.filter<Fish>((pet) => isFish(pet));
+const underWater3: Fish[] = zoo.filter<Fish>((pet): pet is Fish => isFish(pet));
 ```
 
 # Discriminated unions

--- a/packages/documentation/copy/en/handbook-v2/Narrowing.md
+++ b/packages/documentation/copy/en/handbook-v2/Narrowing.md
@@ -418,9 +418,8 @@ it also knows that in the `else` branch, you _don't_ have a `Fish`, so you must 
 You may use the type guard `isFish` to filter an array of `Fish | Bird` and obtain an array of `Fish`:
 
 ```ts twoslash
-// @errors: 2345
-type Fish = { swim: () => void };
-type Bird = { fly: () => void };
+type Fish = { swim: () => void; name: string };
+type Bird = { fly: () => void; name: string };
 declare function getSmallPet(): Fish | Bird;
 function isFish(pet: Fish | Bird): pet is Fish {
   return (pet as Fish).swim !== undefined;
@@ -429,8 +428,13 @@ function isFish(pet: Fish | Bird): pet is Fish {
 const zoo: (Fish | Bird)[] = [getSmallPet(), getSmallPet(), getSmallPet()];
 const underWater1: Fish[] = zoo.filter(isFish);
 // or, equivalently
-const underWater2: Fish[] = zoo.filter<Fish>(isFish);
-const underWater3: Fish[] = zoo.filter<Fish>((pet): pet is Fish => isFish(pet));
+const underWater2: Fish[] = zoo.filter(isFish) as Fish[];
+
+// The predicate may need repeating for more complex examples
+const underWater3: Fish[] = zoo.filter((pet): pet is Fish => {
+  if (pet.name === "sharkey") return false;
+  return isFish(pet);
+});
 ```
 
 # Discriminated unions


### PR DESCRIPTION
In the handbook the last example of ["Using type predicates"](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) is described as equivalent to the previous 2 examples but it causes an error making it different to the previous ones:

#
![Screenshot_20210317_175206](https://user-images.githubusercontent.com/6059188/111506021-80e84480-8749-11eb-9d57-605a2ba78911.png)

#
Have a look at the code [before](https://www.typescriptlang.org/play/#code/PTAEAEFMCdoe2gZwFygEwGYAsBWAUAC4CeADpKAGICWiAFqALygDeoiA7lQLaoAUAlIwB8oAG5wqAE1ABfANyFS5AEJVo0pqwBmAGyJ9BDEeKmyFkyAGMdAQ2jktAVwB2lglTjPQAc0gEAylw2OjoACn4CqNR0oAA+oKrqCk6u7p6gNNG0vGQEUTT08YmS-Ki5GYiUBSx4oKD2BI7QXjl+oDaVWfwAdBzcoACEDEwuFlpUzpCSCjJ4IKAAtEuWjgRLC3iWnogEoABecHB8WXEJaiUA2gC6jKAXvgFBIeEEAgA0Pn6BwWER-B8Pb7PP5XBRbZw7UCjGAAdRsBBgAEZ8nRrrcDnBuuMdAjoLxMgV+Ap5ggPpAAI6OKiiYKQZwEPSbba7aHQOG4tAo2hopgYrFUHEwAA8WSE+MQXTBzKhzgsbPhMAwXJ5+0O-MF0BFBTFrQIhhEBLouv4RKAA) and [after](https://www.typescriptlang.org/play?#code/PTAEAEFMCdoe2gZwFygEwGYAsBWAUAC4CeADpKAGICWiAFqALygDeoiA7lQLaoAUAlIwB8oAG5wqAE1ABfANyFS5AEJVo0pqwBmAGyJ9BDEeKmyFkyAGMdAQ2jktAVwB2lglTjPQAc0gEAylw2OjoACn4CqNR0oAA+oKrqCk6u7p6gNNG0vGQEUTT08YmS-Ki5GYiUBSx4oKD2BI7QXjl+oDaVWfwAdBzcoACEDEwuFlpUzpCSCjJ4IKAAtEuWjgRLC3iWnogEoABecHB8WXEJaiUA2gC6jKAXvgFBIeEEAgA0Pn6BwWER-B8Pb7PP5XBRbZw7UCjGAAdRsBBgAEZ8nRrrcDnBuuMdAjoLxMgV+Ap5ggPpAAI6OKiiYKQZwEPSbba7aHQOG4tAo2hopgYrFUHEwAA8WSE+MQXTBzKhzgsbPhMAwXJ5+0O-MF0BFBTFrQIpVA5RoVRiRgqWV1-CJQA) in the Typescript playground.
