### PR TITLE
Upper case file name fails

### DIFF
--- a/packages/documentation/copy/en/reference/Iterators and Generators.md
+++ b/packages/documentation/copy/en/reference/Iterators and Generators.md
@@ -8,7 +8,7 @@ translatable: true
 
 ## Iterables
 
-An object is deemed iterable if it has an implementation for the [`Symbol.iterator`](Symbols.html#symboliterator) property.
+An object is deemed iterable if it has an implementation for the [`Symbol.iterator`](symbols.html#symboliterator) property.
 Some built-in types like `Array`, `Map`, `Set`, `String`, `Int32Array`, `Uint32Array`, etc. have their `Symbol.iterator` property already implemented.
 `Symbol.iterator` function on an object is responsible for returning the list of values to iterate on.
 


### PR DESCRIPTION
If link is clicked and is loaded - I am assuming - by Javascript, the upper case makes the page fail to load. Changing the leading character to lower-case makes it work (tested in dev tools). Opening the link in a new window also works, as that uses browser-native HTML fetch which is not case-sensitive.

There is the same problem in the search index (when searching for any Symbol's methods), but I don't know how to fix that.