### PR TITLE
Fixes GH-1693

### DIFF
--- a/packages/playground/src/sidebar/runtime.ts
+++ b/packages/playground/src/sidebar/runtime.ts
@@ -165,6 +165,11 @@ function rewireLoggingToElement(
       const prefix = `[<span class="log-${name}">${id}</span>]: `
       const eleContainerLog = eleOverflowLocator()
       allLogs.push(`${prefix}${output}<br>`)
+
+      if (output.includes("Unexpected token 'export'")) {
+        allLogs.push(`[<span class="log-warn">WRN</span>]: Please consider changing your Module to \"CommonJS\" in the TS Config settings`)
+      }
+
       eleLog.innerHTML = allLogs.join("<hr />")
       if (autoScroll && eleContainerLog) {
         eleContainerLog.scrollTop = eleContainerLog.scrollHeight

--- a/packages/playground/src/sidebar/runtime.ts
+++ b/packages/playground/src/sidebar/runtime.ts
@@ -155,6 +155,10 @@ function rewireLoggingToElement(
     } catch (error) {
       console.error(i("play_run_js_fail"))
       console.error(error)
+
+      if (error instanceof SyntaxError && /\bexport\b/u.test(error.message)) {
+        console.warn('Tip: Change the Module setting to "CommonJS" in TS Config settings to allow top-level exports to work in the Playground')
+      }
     }
   })
 
@@ -165,11 +169,6 @@ function rewireLoggingToElement(
       const prefix = `[<span class="log-${name}">${id}</span>]: `
       const eleContainerLog = eleOverflowLocator()
       allLogs.push(`${prefix}${output}<br>`)
-
-      if (output.includes("Unexpected token 'export'")) {
-        allLogs.push('[<span class="log-warn">WRN</span>]: Tip: Change the Module setting to "CommonJS" in TS Config settings to allow top-level exports to work in the Playground')
-      }
-
       eleLog.innerHTML = allLogs.join("<hr />")
       if (autoScroll && eleContainerLog) {
         eleContainerLog.scrollTop = eleContainerLog.scrollHeight

--- a/packages/playground/src/sidebar/runtime.ts
+++ b/packages/playground/src/sidebar/runtime.ts
@@ -167,7 +167,7 @@ function rewireLoggingToElement(
       allLogs.push(`${prefix}${output}<br>`)
 
       if (output.includes("Unexpected token 'export'")) {
-        allLogs.push(`[<span class="log-warn">WRN</span>]: Please consider changing your Module to \"CommonJS\" in the TS Config settings`)
+        allLogs.push('[<span class="log-warn">WRN</span>]: Tip: Change the Module setting to "CommonJS" in TS Config settings to allow top-level exports to work in the Playground')
       }
 
       eleLog.innerHTML = allLogs.join("<hr />")

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -140,7 +140,6 @@ export const createTypeScriptSandbox = (
   const element = "domID" in config ? document.getElementById(config.domID) : (config as any).elementToAppend
 
   const model = monaco.editor.createModel(defaultText, language, filePath)
-  const modelToEmitForTS = monaco.editor.createModel("", "typescript", monaco.Uri.file("/inputToEmit.ts"))
   monaco.editor.defineTheme("sandbox", sandboxTheme)
   monaco.editor.defineTheme("sandbox-dark", sandboxThemeDark)
   monaco.editor.setTheme("sandbox")
@@ -267,10 +266,9 @@ export const createTypeScriptSandbox = (
   /** Gets the results of compiling your editor's code */
   const getEmitResult = async () => {
     const model = editor.getModel()!
-    const client = await getWorkerProcess()
 
-    modelToEmitForTS.setValue(`namespace playground { ${model.getValue()} }`)
-    return await client.getEmitOutput(modelToEmitForTS.uri.toString())
+    const client = await getWorkerProcess()
+    return await client.getEmitOutput(model.uri.toString())
   }
 
   /** Gets the JS  of compiling your editor's code */

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -269,12 +269,8 @@ export const createTypeScriptSandbox = (
     const model = editor.getModel()!
     const client = await getWorkerProcess()
 
-    if (language === "typescript") {
-      modelToEmitForTS.setValue(`namespace playground { ${model.getValue()} }`)
-      return await client.getEmitOutput(modelToEmitForTS.uri.toString())
-    }
-
-    return await client.getEmitOutput(model.uri.toString())
+    modelToEmitForTS.setValue(`namespace playground { ${model.getValue()} }`)
+    return await client.getEmitOutput(modelToEmitForTS.uri.toString())
   }
 
   /** Gets the JS  of compiling your editor's code */


### PR DESCRIPTION
Fixes GH-1693

Create a duplicate model that is only purpose is to wrap code in the model inside a namespace then have it emitted. This way the text displayed to user doesn't change while solving the original problem.


![image](https://user-images.githubusercontent.com/17804942/112084055-889b5500-8b5e-11eb-9201-a57c38e0e42c.png)

