### PR TITLE
Fixes 1680, 1669 - Module: tsvsf - Does not normalize paths

### DIFF
--- a/packages/typescript-vfs/src/index.ts
+++ b/packages/typescript-vfs/src/index.ts
@@ -19,7 +19,14 @@ const debugLog = shouldDebug ? console.log : (_message?: any, ..._optionalParams
 const directorySeparator = "/"
 const backslashRegExp = /\\/g
 const normalizeSlashes = (path: string): string => path.replace(backslashRegExp, directorySeparator)
-const normalizeFsMap = (fsMap: Map<string, string>): Map<string, string> => new Map([...fsMap.entries()].map(([filepath, content]) => [normalizeSlashes(filepath), content] as const))
+const normalizeFsMap = (fsMap: Map<string, string>) => {
+  for (const [fileName, content] of fsMap) {
+    const normalizedFileName = normalizeSlashes(fileName);
+    if (fileName !== normalizedFileName) {
+      fsMap.set(fileName, content);
+    }
+  }
+}
 
 export interface VirtualTypeScriptEnvironment {
   sys: System
@@ -416,7 +423,7 @@ export function createFSBackedSystem(files: Map<string, string>, _projectRoot: s
   const nodeSys = ts.sys
   const tsLib = path.dirname(require.resolve("typescript"))
 
-  files = normalizeFsMap(files)
+  normalizeFsMap(files)
 
   return {
     // @ts-ignore

--- a/packages/typescript-vfs/src/index.ts
+++ b/packages/typescript-vfs/src/index.ts
@@ -19,13 +19,13 @@ const debugLog = shouldDebug ? console.log : (_message?: any, ..._optionalParams
 const directorySeparator = "/"
 const backslashRegExp = /\\/g
 const normalizeSlashes = (path: string): string => path.replace(backslashRegExp, directorySeparator)
-const normalizeFsMap = (fsMap: Map<string, string>) => {
+const normalizeFsMap = (fsMap: Map<string, string>): Map<string, string> => {
+  const map = new Map()
   for (const [fileName, content] of fsMap) {
-    const normalizedFileName = normalizeSlashes(fileName);
-    if (fileName !== normalizedFileName) {
-      fsMap.set(fileName, content);
-    }
+    const normalizedFileName = normalizeSlashes(fileName)
+    map.set(normalizedFileName, content)
   }
+  return map
 }
 
 export interface VirtualTypeScriptEnvironment {
@@ -423,7 +423,8 @@ export function createFSBackedSystem(files: Map<string, string>, _projectRoot: s
   const nodeSys = ts.sys
   const tsLib = path.dirname(require.resolve("typescript"))
 
-  normalizeFsMap(files)
+  // creates a copy, old references to files will not propegate changes to the returned `ts.System`
+  files = normalizeFsMap(files)
 
   return {
     // @ts-ignore

--- a/packages/typescript-vfs/src/index.ts
+++ b/packages/typescript-vfs/src/index.ts
@@ -9,7 +9,7 @@ type TS = typeof import("typescript")
 let hasLocalStorage = false
 try {
   hasLocalStorage = typeof localStorage !== `undefined`
-} catch (error) {}
+} catch (error) { }
 
 const hasProcess = typeof process !== `undefined`
 const shouldDebug = (hasLocalStorage && localStorage.getItem("DEBUG")) || (hasProcess && process.env.DEBUG)
@@ -19,7 +19,7 @@ const debugLog = shouldDebug ? console.log : (_message?: any, ..._optionalParams
 const directorySeparator = "/"
 const backslashRegExp = /\\/g
 const normalizeSlashes = (path: string): string => path.replace(backslashRegExp, directorySeparator)
-const normalizedFsMap = (fsMap: Map<string, string>): Map<string, string> => new Map([...fsMap.entries()].map(([filepath, content]) => [normalizeSlashes(filepath), content] as const))
+const normalizeFsMap = (fsMap: Map<string, string>): Map<string, string> => new Map([...fsMap.entries()].map(([filepath, content]) => [normalizeSlashes(filepath), content] as const))
 
 export interface VirtualTypeScriptEnvironment {
   sys: System
@@ -416,7 +416,7 @@ export function createFSBackedSystem(files: Map<string, string>, _projectRoot: s
   const nodeSys = ts.sys
   const tsLib = path.dirname(require.resolve("typescript"))
 
-  files = normalizedFsMap(files)
+  files = normalizeFsMap(files)
 
   return {
     // @ts-ignore

--- a/packages/typescript-vfs/src/index.ts
+++ b/packages/typescript-vfs/src/index.ts
@@ -506,12 +506,11 @@ export function createVirtualCompilerHost(sys: System, compilerOptions: Compiler
       getDirectories: () => [],
       getNewLine: () => sys.newLine,
       getSourceFile: fileName => {
-        const normalizedFileName = normalizeSlashes(fileName)
         return (
-          sourceFiles.get(normalizedFileName) ||
+          sourceFiles.get(fileName) ||
           save(
             ts.createSourceFile(
-              normalizedFileName,
+              fileName,
               sys.readFile(fileName)!,
               compilerOptions.target || defaultCompilerOptions(ts).target!,
               false

--- a/packages/typescript-vfs/src/index.ts
+++ b/packages/typescript-vfs/src/index.ts
@@ -9,12 +9,11 @@ type TS = typeof import("typescript")
 let hasLocalStorage = false
 try {
   hasLocalStorage = typeof localStorage !== `undefined`
-} catch (error) { }
+} catch (error) {}
 
 const hasProcess = typeof process !== `undefined`
 const shouldDebug = (hasLocalStorage && localStorage.getItem("DEBUG")) || (hasProcess && process.env.DEBUG)
 const debugLog = shouldDebug ? console.log : (_message?: any, ..._optionalParams: any[]) => ""
-
 
 const directorySeparator = "/"
 const backslashRegExp = /\\/g
@@ -30,7 +29,7 @@ const normalizeFsMap = (fsMap: Map<string, string>): Map<string, string> => {
 
 export interface VirtualTypeScriptEnvironment {
   sys: System
-  host: LanguageServiceHost,
+  host: LanguageServiceHost
   languageService: import("typescript").LanguageService
   getSourceFile: (fileName: string) => import("typescript").SourceFile | undefined
   createFile: (fileName: string, content: string) => void
@@ -384,7 +383,7 @@ const libize = (path: string) => path.replace("/", "/lib.").toLowerCase()
  * is what provides read/write aspects of the virtual fs
  */
 export function createSystem(files: Map<string, string>): System {
-  files = normalizeFsMap(files);
+  files = normalizeFsMap(files)
   return {
     args: [],
     createDirectory: () => notImplemented("createDirectory"),
@@ -394,7 +393,7 @@ export function createSystem(files: Map<string, string>): System {
     }),
     exit: () => notImplemented("exit"),
     fileExists: audit("fileExists", fileName => {
-      const normalizedFileName = normalizeSlashes(fileName);
+      const normalizedFileName = normalizeSlashes(fileName)
       return files.has(normalizedFileName) || files.has(libize(normalizedFileName))
     }),
     getCurrentDirectory: () => "/",
@@ -402,8 +401,8 @@ export function createSystem(files: Map<string, string>): System {
     getExecutingFilePath: () => notImplemented("getExecutingFilePath"),
     readDirectory: audit("readDirectory", directory => (directory === "/" ? Array.from(files.keys()) : [])),
     readFile: audit("readFile", fileName => {
-      const normalizedFileName = normalizeSlashes(fileName);
-      return files.get(normalizedFileName) || files.get(libize(normalizedFileName));
+      const normalizedFileName = normalizeSlashes(fileName)
+      return files.get(normalizedFileName) || files.get(libize(normalizedFileName))
     }),
     resolvePath: path => path,
     newLine: "\n",
@@ -442,7 +441,10 @@ export function createFSBackedSystem(files: Map<string, string>, _projectRoot: s
     // TODO: could make a real file tree
     directoryExists: audit("directoryExists", directory => {
       const normalizedDirectory = normalizeSlashes(directory)
-      return Array.from(files.keys()).some(path => path.startsWith(normalizedDirectory)) || nodeSys.directoryExists(directory)
+      return (
+        Array.from(files.keys()).some(path => path.startsWith(normalizedDirectory)) ||
+        nodeSys.directoryExists(directory)
+      )
     }),
     exit: nodeSys.exit,
     fileExists: audit("fileExists", fileName => {
@@ -461,7 +463,7 @@ export function createFSBackedSystem(files: Map<string, string>, _projectRoot: s
     getExecutingFilePath: () => notImplemented("getExecutingFilePath"),
     readDirectory: audit("readDirectory", (...args) => {
       if (normalizeSlashes(args[0]) === root) {
-        return Array.from(files.keys()).filter(file => file.startsWith(root));
+        return Array.from(files.keys()).filter(file => file.startsWith(root))
       } else {
         return nodeSys.readDirectory(...args)
       }
@@ -538,7 +540,7 @@ export function createVirtualCompilerHost(sys: System, compilerOptions: Compiler
       useCaseSensitiveFileNames: () => sys.useCaseSensitiveFileNames,
     },
     updateFile: sourceFile => {
-      const normalizedFileName = normalizeSlashes(sourceFile.fileName);
+      const normalizedFileName = normalizeSlashes(sourceFile.fileName)
       const alreadyExists = sourceFiles.has(normalizedFileName)
       sys.writeFile(normalizedFileName, sourceFile.text)
       sourceFiles.set(normalizedFileName, sourceFile)
@@ -590,7 +592,7 @@ export function createVirtualLanguageServiceHost(
     languageServiceHost,
     updateFile: sourceFile => {
       projectVersion++
-      const normalizedFileName = normalizeSlashes(sourceFile.fileName);
+      const normalizedFileName = normalizeSlashes(sourceFile.fileName)
       fileVersions.set(normalizedFileName, projectVersion.toString())
       if (!fileNames.includes(normalizedFileName)) {
         fileNames.push(normalizedFileName)

--- a/packages/typescript-vfs/test/fsbacked.test.ts
+++ b/packages/typescript-vfs/test/fsbacked.test.ts
@@ -41,7 +41,7 @@ it("can import files in the virtual fs using posix directory seperators", () => 
   const fsMap = new Map<string, string>()
 
   // Have to replace the windows directory seperator in __dirname or else path.join will silently fail
-  const monorepoRoot = path.posix.join(__dirname.replace(/\\/g, '/'), "..", "..", "..")
+  const monorepoRoot = path.posix.join(__dirname.replace(/\\/g, "/"), "..", "..", "..")
   const fakeFolder = path.posix.join(monorepoRoot, "fake")
   const exporter = path.posix.join(fakeFolder, "file-with-export.ts")
   const index = path.posix.join(fakeFolder, "index.ts")


### PR DESCRIPTION
This PR attempts to fix #1680 (and fix #1669) with the following changes:
- adds tests for both the `\` and `/` directory seperators and patches the `ts.System` returned by `createFSBackedSystem` to normalize paths when interacting with the underlying FS `Map<string, string>`.

I tried to figure out how the typescript compiler does this and it seems that the compiler internally uses `/` for every path. It assumes the `host` can deal with those slashes. This requires `vfs` to normalise any `\` to `/` in the `Map` representing the virtual file system to account for this internal behaviour. The normalisation is only applied when interacting with the `Map`. Any calls delegates to `nodeSys` are not touched because both posix and win32 can deal with `/` seperated paths just fine.

~~I haven't touched the interactions that pass around `ts.SourceFile` instances. I currently assume that those are made with the `ts` api and therefore already have normalized paths.~~
After checking the TypeScript source code creating `SourceFile` instances will have their paths normalized. So its best no to touch these. We could add path normalisation when retrieving a source file with `host.getSourceFile`, but its probably better to fail and have the caller be responsible to pass in normalized paths.

It additionally:
- exposes the `ts.LanguageServiceHost` when calling `createVirtualTypeScriptEnvironment`. It is annoying not to have a reference to the `host` being used. It can be used to implement custom module resolution by implementing `resolveModuleNames`.
- fixes `system.readDirectory` on the `system` returned by `createFSBackedSystem`.

