### PR TITLE
Fix broken link to tsconfig reference in Creating DTS files From JS.md

### DIFF
--- a/packages/documentation/copy/en/javascript/Creating DTS files From JS.md
+++ b/packages/documentation/copy/en/javascript/Creating DTS files From JS.md
@@ -52,7 +52,7 @@ In this case, you will want a file like the following:
 }
 ```
 
-You can learn more about the options in the [tsconfig reference](/reference).
+You can learn more about the options in the [tsconfig reference](/tsconfig).
 An alternative to using a TSConfig file is the CLI, this is the same behavior as a CLI command.
 
 ```sh


### PR DESCRIPTION
While exploring the documentation site [here](https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html), I noticed a broken link that should point to the correct location (`/tsconfig`). This pull request fixes that.

Please let me know if anything else is required of me in order to have this fix merged.

All the best!