### PR TITLE
Fixed the masked link for mixins

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Generics.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Generics.md
@@ -373,4 +373,4 @@ createInstance(Lion).keeper.nametag;
 createInstance(Bee).keeper.hasMask;
 ```
 
-This pattern is used to power the [mixins](/docs/handbook/2/mixins.html) design pattern.
+This pattern is used to power the [mixins](/docs/handbook/mixins.html) design pattern.


### PR DESCRIPTION
The link for the mixins page in generics.html was invalid