### PR TITLE
fix header code tag margin right

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/main.scss
+++ b/packages/typescriptlang-org/src/components/layout/main.scss
@@ -161,6 +161,7 @@ html.font-open-dyslexic {
     font-size: 0.8em;
     margin-top: 0.2em;
     margin-left: 0.2em;
+    margin-right: 0.2em;
     padding: 2px 4px;
   }
 


### PR DESCRIPTION
I propose to add a margin on the right of a code element, because otherwise there in no space between the background color of a code element and the following text

Before : 
<img width="329" alt="image" src="https://user-images.githubusercontent.com/47030586/113336950-6906e800-9327-11eb-9e8a-395691f0e37f.png">


After : 
<img width="329" alt="image" src="https://user-images.githubusercontent.com/47030586/113336930-5be9f900-9327-11eb-8875-85ca4d2aa4d3.png">
