### PR TITLE
An example implementation

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Conditional Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Conditional Types.md
@@ -54,8 +54,12 @@ interface NameLabel {
 function createLabel(id: number): IdLabel;
 function createLabel(name: string): NameLabel;
 function createLabel(nameOrId: string | number): IdLabel | NameLabel;
+
 function createLabel(nameOrId: string | number): IdLabel | NameLabel {
-  throw "unimplemented";
+  if (typeof nameOrId === 'string') {
+      return {name: nameOrId};
+    } else
+    return {id: nameOrId};
 }
 ```
 


### PR DESCRIPTION
An example implementation is easier to understand than just throwing an "unimplemented".