### PR TITLE
Clarification, direct vs. indirectly settable vals

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/lib.md
+++ b/packages/tsconfig-reference/copy/en/options/lib.md
@@ -66,4 +66,6 @@ You may want to change these for a few reasons:
 | `ESNext.Intl`             |
 | `ESNext.Symbol`           |
 
-This list may be out of date, you can see the full list in the [TypeScript source code](https://github.com/microsoft/TypeScript/tree/master/lib).
+This list may be out of date, you can see the full list in the [TypeScript source code](https://github.com/microsoft/TypeScript/tree/master/lib). Some options cannot be set directly, see `libEntries` in [src/compiler/commandLineParser.ts](https://github.com/microsoft/TypeScript/blob/master/src/compiler/commandLineParser.ts) for a list of accepted `lib` values.
+
+Options ending in `.Full` are default values, which can only be selected indirectly, by setting [`target`](#target) to the corresponding value, e.g. if `target` is set to `ESLint`, and `lib` is not set, `lib` will default to `ESLint.Full`.


### PR DESCRIPTION
Tried to shed a little light on which values can be set directly, and which cannot.

I linked to `commandLineParser.ts` for `libEntries`, because the other options are all too big for GitHub:
https://github.com/microsoft/TypeScript/blob/master/lib/tsc.js
https://github.com/microsoft/TypeScript/blob/master/lib/tsserver.js
https://github.com/microsoft/TypeScript/blob/master/lib/tsserverlibrary.js
https://github.com/microsoft/TypeScript/blob/master/lib/typescript.js
https://github.com/microsoft/TypeScript/blob/master/lib/typescriptServices.js
https://github.com/microsoft/TypeScript/blob/master/lib/typingsInstaller.js

If you'd like to double-check my conclusions about mapping from `target` to default `lib` values, try searching the Typescript codebase (ideally locally, as GitHub will not show you results from the larger files) for `getDefaultLibFileName` & `targetOptionDeclaration`.