### PR TITLE
Fix link in Object Types doc

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Object Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Object Types.md
@@ -519,7 +519,7 @@ interface Apple {
 type AppleBox = Box<Apple>;
 ```
 
-This also means that we can avoid overloads entirely by instead using [generic functions](./More on Functions.md#generic-functions).
+This also means that we can avoid overloads entirely by instead using [generic functions](<./More on Functions.md#generic-functions>).
 
 ```ts twoslash
 interface Box<Type> {

--- a/packages/documentation/copy/en/handbook-v2/Object Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Object Types.md
@@ -519,7 +519,7 @@ interface Apple {
 type AppleBox = Box<Apple>;
 ```
 
-This also means that we can avoid overloads entirely by instead using [generic functions](./More-on-Functions.md#Generic-Functions).
+This also means that we can avoid overloads entirely by instead using [generic functions](./More on Functions.md#generic-functions).
 
 ```ts twoslash
 interface Box<Type> {

--- a/packages/documentation/copy/en/handbook-v2/Object Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Object Types.md
@@ -519,7 +519,7 @@ interface Apple {
 type AppleBox = Box<Apple>;
 ```
 
-This also means that we can avoid overloads entirely by instead using [generic functions](<./More on Functions.md#generic-functions>).
+This also means that we can avoid overloads entirely by instead using [generic functions](/docs/handbook/2/functions.html#generic-functions).
 
 ```ts twoslash
 interface Box<Type> {


### PR DESCRIPTION
Updates link to **Generic Functions** reference from **Object Types** doc [here](https://github.com/microsoft/TypeScript-Website/blob/v2/packages/documentation/copy/en/handbook-v2/Object%20Types.md#generic-object-types) so that it links to the correct documentation file which has spaces in the name (`More on Functions.md#generic-functions`) and so needs wrapping in angle brackets