### PR TITLE
Change playground SEO config

### DIFF
--- a/packages/typescriptlang-org/src/copy/en/head-seo.ts
+++ b/packages/typescriptlang-org/src/copy/en/head-seo.ts
@@ -1,6 +1,6 @@
 export const headCopy = {
   head_playground_title:
-    "TS Playground - An online editor for exploring TypeScript and JavaScript",
+    "TypeScript Playground - An online editor for exploring TypeScript and JavaScript",
   head_playground_description:
     "The Playground lets you write TypeScript or JavaScript online in a safe and sharable way.",
   tsconfig_title: "TSConfig Reference - Docs on every TSConfig option",

--- a/packages/typescriptlang-org/src/copy/en/head-seo.ts
+++ b/packages/typescriptlang-org/src/copy/en/head-seo.ts
@@ -2,7 +2,7 @@ export const headCopy = {
   head_playground_title:
     "TypeScript Playground - An online editor for exploring TypeScript and JavaScript",
   head_playground_description:
-    "The Playground lets you write TypeScript or JavaScript online in a safe and sharable way.",
+    "The TypeScript Playground lets you write TypeScript or JavaScript online in a safe and sharable way.",
   tsconfig_title: "TSConfig Reference - Docs on every TSConfig option",
   tsconfig_description:
     "From allowJs to useDefineForClassFields the TSConfig reference includes information about all of the active compiler flags setting up a TypeScript project.",


### PR DESCRIPTION
Expanded the abbreviation "TS" and reiterated "TypeScript" in the desc.