### PR TITLE
Incorrect class reference used in method parameter

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -630,7 +630,7 @@ class Derived2 extends Base {
   f1(other: Derived2) {
     other.x = 10;
   }
-  f2(other: Base) {
+  f2(other: Derived1) {
     other.x = 10;
   }
 }

--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -619,7 +619,7 @@ The main thing to note here is that in the derived class, we need to be careful 
 Different OOP languages disagree about whether it's legal to access a `protected` member through a base class reference:
 
 ```ts twoslash
-// @errors: 2446
+// @errors: 2445
 class Base {
   protected x: number = 1;
 }


### PR DESCRIPTION
The class reference used in the method parameter in the example seems to be incorrect according to the explanation given.