### PR TITLE
re: 'as const' - change prefix to suffix

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -627,7 +627,7 @@ There are two ways to work around this.
    handleRequest(req.url, req.method);
    ```
 
-The `as const` prefix acts like `const` but for the type system, ensuring that all properties are assigned the literal type instead of a more general version like `string` or `number`.
+The `as const` suffix acts like `const` but for the type system, ensuring that all properties are assigned the literal type instead of a more general version like `string` or `number`.
 
 ## `null` and `undefined`
 


### PR DESCRIPTION
I recommend changing the word prefix to suffix.  'as const' is a suffix and the word prefix creates confusion because, in this example, the word 'const' is a prefix to the line of code.