### PR TITLE
Docs: Fix navigation for type manipulation section

### DIFF
--- a/packages/documentation/scripts/generateDocsNavigationPerLanguage.js
+++ b/packages/documentation/scripts/generateDocsNavigationPerLanguage.js
@@ -52,6 +52,7 @@ const handbookPages = [
       { file: "handbook-v2/Object Types.md" },
       {
         title: "Type Manipulation",
+        chronological: true,
         items: [
           { file: "handbook-v2/Type Manipulation/_Creating Types from Types.md" },
           { file: "handbook-v2/Type Manipulation/Generics.md" },
@@ -241,6 +242,7 @@ for (const lang of langs) {
             title: "${subItem.title}",
             id: "${toID(sectionIndex, subItem.title)}",
             oneline: "${subItem.oneliner}",
+            chronological: ${subItem.chronological || false},
           `);
           addItems(subItem);
           codeForTheHandbook.push(",");
@@ -312,6 +314,7 @@ writeFileSync(
  * @property {string= } href - a language prefixless
  * @property {string= } title - the display only used when href exists
  * @property {string= } oneliner
+ * @property {boolean=} chronological - should we recommend a next/prev
  */
 
 /**

--- a/packages/typescriptlang-org/src/lib/documentationNavigation.ts
+++ b/packages/typescriptlang-org/src/lib/documentationNavigation.ts
@@ -20,7 +20,7 @@ export interface SidebarNavItem {
 export function getDocumentationNavForLanguage(
   langRequest: string
 ): SidebarNavItem[] {
-  const langs = ["en", "id", "ja", "ko", "pl", "pt", "zh"];
+  const langs = ["en", "id", "ja", "ko", "pl", "pt", "vo", "zh"];
   const lang = langs.includes(langRequest) ? langRequest : "en";
   const navigations: Record<string, SidebarNavItem[]> = {};
 
@@ -115,6 +115,7 @@ export function getDocumentationNavForLanguage(
           title: "Type Manipulation",
           id: "1-type-manipulation",
           oneline: "undefined",
+          chronological: true,
 
           items: [
             {
@@ -557,6 +558,7 @@ export function getDocumentationNavForLanguage(
           title: ".d.ts Templates",
           id: "5-.d.ts-templates",
           oneline: "undefined",
+          chronological: false,
 
           items: [
             {
@@ -814,6 +816,7 @@ export function getDocumentationNavForLanguage(
           title: "Type Manipulation",
           id: "1-type-manipulation",
           oneline: "undefined",
+          chronological: true,
 
           items: [
             {
@@ -1256,6 +1259,7 @@ export function getDocumentationNavForLanguage(
           title: ".d.ts Templates",
           id: "5-.d.ts-templates",
           oneline: "undefined",
+          chronological: false,
 
           items: [
             {
@@ -1513,6 +1517,7 @@ export function getDocumentationNavForLanguage(
           title: "Type Manipulation",
           id: "1-type-manipulation",
           oneline: "undefined",
+          chronological: true,
 
           items: [
             {
@@ -1955,6 +1960,7 @@ export function getDocumentationNavForLanguage(
           title: ".d.ts Templates",
           id: "5-.d.ts-templates",
           oneline: "undefined",
+          chronological: false,
 
           items: [
             {
@@ -2133,33 +2139,33 @@ export function getDocumentationNavForLanguage(
         {
           title: "TS for the New Programmer",
           id: "0-typescript-for-the-new-programmer",
-          permalink: "/docs/handbook/typescript-from-scratch.html",
+          permalink: "/ko/docs/handbook/typescript-from-scratch.html",
           oneline: "Learn TypeScript from scratch",
         },
         {
           title: "TypeScript for JS Programmers",
           id: "0-typescript-for-javascript-programmers",
-          permalink: "/docs/handbook/typescript-in-5-minutes.html",
+          permalink: "/ko/docs/handbook/typescript-in-5-minutes.html",
           oneline: "Learn how TypeScript extends JavaScript",
         },
         {
           title: "TS for Java/C# Programmers",
           id: "0-typescript-for-java/c#-programmers",
-          permalink: "/docs/handbook/typescript-in-5-minutes-oop.html",
+          permalink: "/ko/docs/handbook/typescript-in-5-minutes-oop.html",
           oneline:
             "Learn TypeScript if you have a background in object-oriented languages",
         },
         {
           title: "TS for Functional Programmers",
           id: "0-typescript-for-functional-programmers",
-          permalink: "/docs/handbook/typescript-in-5-minutes-func.html",
+          permalink: "/ko/docs/handbook/typescript-in-5-minutes-func.html",
           oneline:
             "Learn TypeScript if you have a background in functional programming",
         },
         {
           title: "TypeScript Tooling in 5 minutes",
           id: "0-typescript-tooling-in-5-minutes",
-          permalink: "/docs/handbook/typescript-tooling-in-5-minutes.html",
+          permalink: "/ko/docs/handbook/typescript-tooling-in-5-minutes.html",
           oneline:
             "A tutorial to understand how to create a small website with TypeScript",
         },
@@ -2175,7 +2181,7 @@ export function getDocumentationNavForLanguage(
         {
           title: "The TypeScript Handbook",
           id: "1-the-typescript-handbook",
-          permalink: "/docs/handbook/intro.html",
+          permalink: "/ko/docs/handbook/intro.html",
           oneline: "Your first step to learn TypeScript",
         },
         {
@@ -2213,6 +2219,7 @@ export function getDocumentationNavForLanguage(
           title: "Type Manipulation",
           id: "1-type-manipulation",
           oneline: "undefined",
+          chronological: true,
 
           items: [
             {
@@ -2225,7 +2232,7 @@ export function getDocumentationNavForLanguage(
             {
               title: "Generics",
               id: "1-generics",
-              permalink: "/docs/handbook/2/generics.html",
+              permalink: "/ko/docs/handbook/2/generics.html",
               oneline: "Types which take parameters",
             },
             {
@@ -2299,7 +2306,7 @@ export function getDocumentationNavForLanguage(
         {
           title: "Decorators",
           id: "2-decorators",
-          permalink: "/docs/handbook/decorators.html",
+          permalink: "/ko/docs/handbook/decorators.html",
           oneline: "TypeScript Decorators overview",
         },
         {
@@ -2311,7 +2318,7 @@ export function getDocumentationNavForLanguage(
         {
           title: "Enums",
           id: "2-enums",
-          permalink: "/docs/handbook/enums.html",
+          permalink: "/ko/docs/handbook/enums.html",
           oneline: "How TypeScript enums work",
         },
         {
@@ -2335,25 +2342,25 @@ export function getDocumentationNavForLanguage(
         {
           title: "Modules",
           id: "2-modules",
-          permalink: "/docs/handbook/modules.html",
+          permalink: "/ko/docs/handbook/modules.html",
           oneline: "How modules work in TypeScript",
         },
         {
           title: "Module Resolution",
           id: "2-module-resolution",
-          permalink: "/docs/handbook/module-resolution.html",
+          permalink: "/ko/docs/handbook/module-resolution.html",
           oneline: "How TypeScript resolves modules in JavaScript",
         },
         {
           title: "Namespaces",
           id: "2-namespaces",
-          permalink: "/docs/handbook/namespaces.html",
+          permalink: "/ko/docs/handbook/namespaces.html",
           oneline: "How TypeScript namespaces work",
         },
         {
           title: "Namespaces and Modules",
           id: "2-namespaces-and-modules",
-          permalink: "/docs/handbook/namespaces-and-modules.html",
+          permalink: "/ko/docs/handbook/namespaces-and-modules.html",
           oneline:
             "How to organize code in TypeScript via modules or namespaces",
         },
@@ -2372,7 +2379,7 @@ export function getDocumentationNavForLanguage(
         {
           title: "Type Compatibility",
           id: "2-type-compatibility",
-          permalink: "/docs/handbook/type-compatibility.html",
+          permalink: "/ko/docs/handbook/type-compatibility.html",
           oneline: "How type-checking works in TypeScript",
         },
         {
@@ -2384,7 +2391,7 @@ export function getDocumentationNavForLanguage(
         {
           title: "Variable Declaration",
           id: "2-variable-declaration",
-          permalink: "/docs/handbook/variable-declarations.html",
+          permalink: "/ko/docs/handbook/variable-declarations.html",
           oneline: "How TypeScript handles variable declaration",
         },
       ],
@@ -2399,31 +2406,31 @@ export function getDocumentationNavForLanguage(
         {
           title: "ASP.NET Core",
           id: "3-asp.net-core",
-          permalink: "/docs/handbook/asp-net-core.html",
+          permalink: "/ko/docs/handbook/asp-net-core.html",
           oneline: "Using TypeScript in ASP.NET Core",
         },
         {
           title: "Gulp",
           id: "3-gulp",
-          permalink: "/docs/handbook/gulp.html",
+          permalink: "/ko/docs/handbook/gulp.html",
           oneline: "Using TypeScript with Gulp",
         },
         {
           title: "DOM Manipulation",
           id: "3-dom-manipulation",
-          permalink: "/docs/handbook/dom-manipulation.html",
+          permalink: "/ko/docs/handbook/dom-manipulation.html",
           oneline: "Using the DOM with TypeScript",
         },
         {
           title: "Migrating from JavaScript",
           id: "3-migrating-from-javascript",
-          permalink: "/docs/handbook/migrating-from-javascript.html",
+          permalink: "/ko/docs/handbook/migrating-from-javascript.html",
           oneline: "How to migrate from JavaScript to TypeScript",
         },
         {
           title: "Using Babel with TypeScript",
           id: "3-using-babel-with-typescript",
-          permalink: "/docs/handbook/babel-with-typescript.html",
+          permalink: "/ko/docs/handbook/babel-with-typescript.html",
           oneline: "How to create a hybrid Babel + TypeScript project",
         },
       ],
@@ -2457,19 +2464,19 @@ export function getDocumentationNavForLanguage(
         {
           title: "TypeScript 4.0",
           id: "4-typescript-4.0",
-          permalink: "/docs/handbook/release-notes/typescript-4-0.html",
+          permalink: "/ko/docs/handbook/release-notes/typescript-4-0.html",
           oneline: "TypeScript 4.0 Release Notes",
         },
         {
           title: "TypeScript 3.9",
           id: "4-typescript-3.9",
-          permalink: "/docs/handbook/release-notes/typescript-3-9.html",
+          permalink: "/ko/docs/handbook/release-notes/typescript-3-9.html",
           oneline: "TypeScript 3.9 Release Notes",
         },
         {
           title: "TypeScript 3.8",
           id: "4-typescript-3.8",
-          permalink: "/docs/handbook/release-notes/typescript-3-8.html",
+          permalink: "/ko/docs/handbook/release-notes/typescript-3-8.html",
           oneline: "TypeScript 3.8 Release Notes",
         },
         {
@@ -2635,26 +2642,28 @@ export function getDocumentationNavForLanguage(
         {
           title: "Introduction",
           id: "5-introduction",
-          permalink: "/docs/handbook/declaration-files/introduction.html",
+          permalink: "/ko/docs/handbook/declaration-files/introduction.html",
           oneline:
             "How to write a high-quality TypeScript Declaration (d.ts) file",
         },
         {
           title: "Declaration Reference",
           id: "5-declaration-reference",
-          permalink: "/docs/handbook/declaration-files/by-example.html",
+          permalink: "/ko/docs/handbook/declaration-files/by-example.html",
           oneline: "How to create a d.ts file for a module",
         },
         {
           title: "Library Structures",
           id: "5-library-structures",
-          permalink: "/docs/handbook/declaration-files/library-structures.html",
+          permalink:
+            "/ko/docs/handbook/declaration-files/library-structures.html",
           oneline: "How to structure your d.ts files",
         },
         {
           title: ".d.ts Templates",
           id: "5-.d.ts-templates",
           oneline: "undefined",
+          chronological: false,
 
           items: [
             {
@@ -2675,14 +2684,14 @@ export function getDocumentationNavForLanguage(
               title: "Module: Class",
               id: "5-module:-class",
               permalink:
-                "/docs/handbook/declaration-files/templates/module-class-d-ts.html",
+                "/ko/docs/handbook/declaration-files/templates/module-class-d-ts.html",
               oneline: "undefined",
             },
             {
               title: "Module: Function",
               id: "5-module:-function",
               permalink:
-                "/docs/handbook/declaration-files/templates/module-function-d-ts.html",
+                "/ko/docs/handbook/declaration-files/templates/module-function-d-ts.html",
               oneline: "undefined",
             },
             {
@@ -2704,25 +2713,25 @@ export function getDocumentationNavForLanguage(
         {
           title: "Do's and Don'ts",
           id: "5-do's-and-don'ts",
-          permalink: "/docs/handbook/declaration-files/do-s-and-don-ts.html",
+          permalink: "/ko/docs/handbook/declaration-files/do-s-and-don-ts.html",
           oneline: "Recommendations for writing d.ts files",
         },
         {
           title: "Deep Dive",
           id: "5-deep-dive",
-          permalink: "/docs/handbook/declaration-files/deep-dive.html",
+          permalink: "/ko/docs/handbook/declaration-files/deep-dive.html",
           oneline: "How do d.ts files work, a deep dive",
         },
         {
           title: "Publishing",
           id: "5-publishing",
-          permalink: "/docs/handbook/declaration-files/publishing.html",
+          permalink: "/ko/docs/handbook/declaration-files/publishing.html",
           oneline: "How to get your d.ts files to users",
         },
         {
           title: "Consumption",
           id: "5-consumption",
-          permalink: "/docs/handbook/declaration-files/consumption.html",
+          permalink: "/ko/docs/handbook/declaration-files/consumption.html",
           oneline: "How to download d.ts files for your project",
         },
       ],
@@ -2737,27 +2746,27 @@ export function getDocumentationNavForLanguage(
         {
           title: "JS Projects Utilizing TypeScript",
           id: "6-js-projects-utilizing-typescript",
-          permalink: "/docs/handbook/intro-to-js-ts.html",
+          permalink: "/ko/docs/handbook/intro-to-js-ts.html",
           oneline:
             "How to add type checking to JavaScript files using TypeScript",
         },
         {
           title: "Type Checking JavaScript Files",
           id: "6-type-checking-javascript-files",
-          permalink: "/docs/handbook/type-checking-javascript-files.html",
+          permalink: "/ko/docs/handbook/type-checking-javascript-files.html",
           oneline:
             "How to add type checking to JavaScript files using TypeScript",
         },
         {
           title: "JSDoc Reference",
           id: "6-jsdoc-reference",
-          permalink: "/docs/handbook/jsdoc-supported-types.html",
+          permalink: "/ko/docs/handbook/jsdoc-supported-types.html",
           oneline: "What JSDoc does TypeScript-powered JavaScript support?",
         },
         {
           title: "Creating .d.ts Files from .js files",
           id: "6-creating-.d.ts-files-from-.js-files",
-          permalink: "/docs/handbook/declaration-files/dts-from-js.html",
+          permalink: "/ko/docs/handbook/declaration-files/dts-from-js.html",
           oneline: "How to add d.ts generation to JavaScript projects",
         },
       ],
@@ -2772,13 +2781,13 @@ export function getDocumentationNavForLanguage(
         {
           title: "What is a tsconfig.json",
           id: "7-what-is-a-tsconfig.json",
-          permalink: "/docs/handbook/tsconfig-json.html",
+          permalink: "/ko/docs/handbook/tsconfig-json.html",
           oneline: "Learn about how a TSConfig works",
         },
         {
           title: "Compiler Options in MSBuild",
           id: "7-compiler-options-in-msbuild",
-          permalink: "/docs/handbook/compiler-options-in-msbuild.html",
+          permalink: "/ko/docs/handbook/compiler-options-in-msbuild.html",
           oneline: "Which compiler options are available in MSBuild projects.",
         },
         {
@@ -2790,32 +2799,32 @@ export function getDocumentationNavForLanguage(
         {
           title: "tsc CLI Options",
           id: "7-tsc-cli-options",
-          permalink: "/docs/handbook/compiler-options.html",
+          permalink: "/ko/docs/handbook/compiler-options.html",
           oneline:
             "A very high-level overview of the CLI compiler options for tsc",
         },
         {
           title: "Project References",
           id: "7-project-references",
-          permalink: "/docs/handbook/project-references.html",
+          permalink: "/ko/docs/handbook/project-references.html",
           oneline: "How to split up a large TypeScript project",
         },
         {
           title: "Integrating with Build Tools",
           id: "7-integrating-with-build-tools",
-          permalink: "/docs/handbook/integrating-with-build-tools.html",
+          permalink: "/ko/docs/handbook/integrating-with-build-tools.html",
           oneline: "How to use TypeScript with other build tools",
         },
         {
           title: "Configuring Watch",
           id: "7-configuring-watch",
-          permalink: "/docs/handbook/configuring-watch.html",
+          permalink: "/ko/docs/handbook/configuring-watch.html",
           oneline: "How to configure the watch mode of TypeScript",
         },
         {
           title: "Nightly Builds",
           id: "7-nightly-builds",
-          permalink: "/docs/handbook/nightly-builds.html",
+          permalink: "/ko/docs/handbook/nightly-builds.html",
           oneline: "How to use a nightly build of TypeScript",
         },
       ],
@@ -2872,10 +2881,10 @@ export function getDocumentationNavForLanguage(
 
       items: [
         {
-          title: "The TypeScript Handbook",
-          id: "1-the-typescript-handbook",
-          permalink: "/docs/handbook/intro.html",
-          oneline: "Your first step to learn TypeScript",
+          title: "Przewodnik po TypeScript",
+          id: "1-przewodnik-po-typescript",
+          permalink: "/pl/docs/handbook/intro.html",
+          oneline: "Twoje pierwsze kroki w nauce TypeScript",
         },
         {
           title: "The Basics",
@@ -2912,6 +2921,7 @@ export function getDocumentationNavForLanguage(
           title: "Type Manipulation",
           id: "1-type-manipulation",
           oneline: "undefined",
+          chronological: true,
 
           items: [
             {
@@ -3354,6 +3364,7 @@ export function getDocumentationNavForLanguage(
           title: ".d.ts Templates",
           id: "5-.d.ts-templates",
           oneline: "undefined",
+          chronological: false,
 
           items: [
             {
@@ -3512,15 +3523,716 @@ export function getDocumentationNavForLanguage(
           oneline: "How to configure the watch mode of TypeScript",
         },
         {
-          title: "Nightly Builds",
-          id: "7-nightly-builds",
-          permalink: "/docs/handbook/nightly-builds.html",
-          oneline: "How to use a nightly build of TypeScript",
+          title: "Nocna kompilacja",
+          id: "7-nocna-kompilacja",
+          permalink: "/pl//docs/handbook/nightly-builds.html",
+          oneline: "Jak korzystać z nocnej kompilacji języka TypeScript",
         },
       ],
     },
   ];
   navigations.pt = [
+    {
+      title: "Get Started",
+      oneline: "Quick introductions based on your background or preference.",
+      id: "get-started",
+      chronological: false,
+
+      items: [
+        {
+          title: "TS for the New Programmer",
+          id: "0-typescript-for-the-new-programmer",
+          permalink: "/docs/handbook/typescript-from-scratch.html",
+          oneline: "Learn TypeScript from scratch",
+        },
+        {
+          title: "TypeScript for JS Programmers",
+          id: "0-typescript-for-javascript-programmers",
+          permalink: "/docs/handbook/typescript-in-5-minutes.html",
+          oneline: "Learn how TypeScript extends JavaScript",
+        },
+        {
+          title: "TS for Java/C# Programmers",
+          id: "0-typescript-for-java/c#-programmers",
+          permalink: "/docs/handbook/typescript-in-5-minutes-oop.html",
+          oneline:
+            "Learn TypeScript if you have a background in object-oriented languages",
+        },
+        {
+          title: "TS for Functional Programmers",
+          id: "0-typescript-for-functional-programmers",
+          permalink: "/docs/handbook/typescript-in-5-minutes-func.html",
+          oneline:
+            "Learn TypeScript if you have a background in functional programming",
+        },
+        {
+          title: "Ferramentas TypeScript em 5 minutos",
+          id: "0-ferramentas-typescript-em-5-minutos",
+          permalink: "/pt/docs/handbook/typescript-tooling-in-5-minutes.html",
+          oneline:
+            "Um tutorial para entender como criar um pequeno site com TypeScript",
+        },
+      ],
+    },
+    {
+      title: "Handbook",
+      oneline: "A great first read for your daily TS work.",
+      id: "handbook",
+      chronological: true,
+
+      items: [
+        {
+          title: "The TypeScript Handbook",
+          id: "1-the-typescript-handbook",
+          permalink: "/docs/handbook/intro.html",
+          oneline: "Your first step to learn TypeScript",
+        },
+        {
+          title: "The Basics",
+          id: "1-the-basics",
+          permalink: "/docs/handbook/2/basic-types.html",
+          oneline: "Step one in learning TypeScript: The basic types.",
+        },
+        {
+          title: "Everyday Types",
+          id: "1-everyday-types",
+          permalink: "/docs/handbook/2/everyday-types.html",
+          oneline: "The language primitives.",
+        },
+        {
+          title: "Narrowing",
+          id: "1-narrowing",
+          permalink: "/docs/handbook/2/narrowing.html",
+          oneline:
+            "Understand how TypeScript uses JavaScript knowledge to reduce the amount of type syntax in your projects.",
+        },
+        {
+          title: "More on Functions",
+          id: "1-more-on-functions",
+          permalink: "/docs/handbook/2/functions.html",
+          oneline: "Learn about how Functions work in TypeScript.",
+        },
+        {
+          title: "Object Types",
+          id: "1-object-types",
+          permalink: "/docs/handbook/2/objects.html",
+          oneline: "How TypeScript describes the shapes of JavaScript objects.",
+        },
+        {
+          title: "Type Manipulation",
+          id: "1-type-manipulation",
+          oneline: "undefined",
+          chronological: true,
+
+          items: [
+            {
+              title: "Creating Types from Types",
+              id: "1-creating-types-from-types",
+              permalink: "/docs/handbook/2/types-from-types.html",
+              oneline:
+                "An overview of the ways in which you can create more types from existing types.",
+            },
+            {
+              title: "Generics",
+              id: "1-generics",
+              permalink: "/docs/handbook/2/generics.html",
+              oneline: "Types which take parameters",
+            },
+            {
+              title: "Keyof Type Operator",
+              id: "1-keyof-type-operator",
+              permalink: "/docs/handbook/2/keyof-types.html",
+              oneline: "Using the keyof operator in type contexts.",
+            },
+            {
+              title: "Typeof Type Operator",
+              id: "1-typeof-type-operator",
+              permalink: "/docs/handbook/2/typeof-types.html",
+              oneline: "Using the typeof operator in type contexts.",
+            },
+            {
+              title: "Indexed Access Types",
+              id: "1-indexed-access-types",
+              permalink: "/docs/handbook/2/indexed-access-types.html",
+              oneline: "Using Type['a'] syntax to access a subset of a type.",
+            },
+            {
+              title: "Conditional Types",
+              id: "1-conditional-types",
+              permalink: "/docs/handbook/2/conditional-types.html",
+              oneline:
+                "Create types which act like if statements in the type system.",
+            },
+            {
+              title: "Mapped Types",
+              id: "1-mapped-types",
+              permalink: "/docs/handbook/2/mapped-types.html",
+              oneline: "Generating types by re-using an existing type.",
+            },
+            {
+              title: "Template Literal Types",
+              id: "1-template-literal-types",
+              permalink: "/docs/handbook/2/template-literal-types.html",
+              oneline:
+                "Generating mapping types which change properties via template literal strings.",
+            },
+          ],
+        },
+        {
+          title: "Classes",
+          id: "1-classes",
+          permalink: "/docs/handbook/2/classes.html",
+          oneline: "How classes work in TypeScript",
+        },
+        {
+          title: "Modules",
+          id: "1-modules",
+          permalink: "/docs/handbook/2/modules.html",
+          oneline:
+            "How JavaScript handles communicating across file boundaries.",
+        },
+      ],
+    },
+    {
+      title: "Reference",
+      oneline: "Deep dive reference materials.",
+      id: "reference",
+      chronological: false,
+
+      items: [
+        {
+          title: "Tipos Utilitários",
+          id: "2-tipos-utilitários",
+          permalink: "/pt/docs/handbook/utility-types.html",
+          oneline: "Tipos que são inclusos globalmente em TypeScript",
+        },
+        {
+          title: "Decoradores",
+          id: "2-decoradores",
+          permalink: "/pt/docs/handbook/Decorators.html",
+          oneline: "Visão geral dos Decoradores no TypeScript",
+        },
+        {
+          title: "Fusão de Declarações",
+          id: "2-fusão-de-declarações",
+          permalink: "/pt/docs/handbook/declaration-merging.html",
+          oneline: "Como a fusão de namespaces e interfaces funciona",
+        },
+        {
+          title: "Enums",
+          id: "2-enums",
+          permalink: "/docs/handbook/enums.html",
+          oneline: "How TypeScript enums work",
+        },
+        {
+          title: "Iteradores e Geradores",
+          id: "2-iteradores-e-geradores",
+          permalink: "/pt/docs/handbook/iterators-and-generators.html",
+          oneline: "Como os Iteradores e Geradores funcionam no TypeScript",
+        },
+        {
+          title: "JSX",
+          id: "2-jsx",
+          permalink: "/pt/docs/handbook/jsx.html",
+          oneline: "Utilizando JSX com TypeScript",
+        },
+        {
+          title: "Mixins",
+          id: "2-mixins",
+          permalink: "/pt/docs/handbook/mixins.html",
+          oneline: "Usando o padrão Mixin com TypeScript",
+        },
+        {
+          title: "Modules",
+          id: "2-modules",
+          permalink: "/pt/docs/handbook/modules.html",
+          oneline: "Como módulos funcionam no TypeScript",
+        },
+        {
+          title: "Resolução de módulos",
+          id: "2-resolução-de-módulos",
+          permalink: "/pt/docs/handbook/module-resolution.html",
+          oneline: "Como o TypeScript resolve módulos em JavaScript",
+        },
+        {
+          title: "Namespaces",
+          id: "2-namespaces",
+          permalink: "/pt/docs/handbook/namespaces.html",
+          oneline: "Como funcionam os Namespaces no TypeScript",
+        },
+        {
+          title: "Namespaces e Módulos",
+          id: "2-namespaces-e-módulos",
+          permalink: "/pt/docs/handbook/namespaces-and-modules.html",
+          oneline:
+            "Como organizar o código em TypeScript através de módulos ou namespaces",
+        },
+        {
+          title: "Símbolos (Symbols)",
+          id: "2-símbolos-(symbols)",
+          permalink: "/pt/docs/handbook/symbols.html",
+          oneline: "Usando o símbolo primitivo do JavaScript no TypeScript",
+        },
+        {
+          title: "Diretivas de barra tripla",
+          id: "2-diretivas-de-barra-tripla",
+          permalink: "/pt/docs/handbook/triple-slash-directives.html",
+          oneline: "Como usar diretivas de barra tripla no TypeScript",
+        },
+        {
+          title: "Compatibilidade de Tipos",
+          id: "2-compatibilidade-de-tipos",
+          permalink: "/pt/docs/handbook/type-compatibility.html",
+          oneline: "Como checagem de tipos funciona em TypeScript",
+        },
+        {
+          title: "Inferência de Tipo",
+          id: "2-inferência-de-tipo",
+          permalink: "/pt/docs/handbook/type-inference.html",
+          oneline: "Como a analise do fluxo de código funciona em TypeScript",
+        },
+        {
+          title: "Declarações de variáveis",
+          id: "2-declarações-de-variáveis",
+          permalink: "/pt/docs/handbook/variable-declarations.html",
+          oneline: "Como TypeScript lida com declarações de variáveis",
+        },
+      ],
+    },
+    {
+      title: "Tutorials",
+      oneline: "Using TypeScript in several environments.",
+      id: "tutorials",
+      chronological: false,
+
+      items: [
+        {
+          title: "ASP.NET Core",
+          id: "3-asp.net-core",
+          permalink: "/docs/handbook/asp-net-core.html",
+          oneline: "Using TypeScript in ASP.NET Core",
+        },
+        {
+          title: "Gulp",
+          id: "3-gulp",
+          permalink: "/docs/handbook/gulp.html",
+          oneline: "Using TypeScript with Gulp",
+        },
+        {
+          title: "Manipulação do DOM",
+          id: "3-manipulação-do-dom",
+          permalink: "/pt/docs/handbook/manipulacao-dom.html",
+          oneline: "Usando o DOM com TypeScript",
+        },
+        {
+          title: "Migrating from JavaScript",
+          id: "3-migrating-from-javascript",
+          permalink: "/docs/handbook/migrating-from-javascript.html",
+          oneline: "How to migrate from JavaScript to TypeScript",
+        },
+        {
+          title: "Usando Babel com TypeScript",
+          id: "3-usando-babel-com-typescript",
+          permalink: "/pt/docs/handbook/babel-with-typescript.html",
+          oneline: "Como criar um projeto híbrido com Babel + TypeScript",
+        },
+      ],
+    },
+    {
+      title: "What's New",
+      oneline:
+        "Find out how TypeScript has evolved and what's new in the releases.",
+      id: "what's-new",
+      chronological: false,
+
+      items: [
+        {
+          title: "Overview",
+          id: "4-overview",
+          permalink: "/docs/handbook/release-notes/overview.html",
+          oneline: "All TypeScript release notes",
+        },
+        {
+          title: "TypeScript 4.2",
+          id: "4-typescript-4.2",
+          permalink: "/docs/handbook/release-notes/typescript-4-2.html",
+          oneline: "TypeScript 4.2 Release Notes",
+        },
+        {
+          title: "TypeScript 4.1",
+          id: "4-typescript-4.1",
+          permalink: "/docs/handbook/release-notes/typescript-4-1.html",
+          oneline: "TypeScript 4.1 Release Notes",
+        },
+        {
+          title: "TypeScript 4.0",
+          id: "4-typescript-4.0",
+          permalink: "/docs/handbook/release-notes/typescript-4-0.html",
+          oneline: "TypeScript 4.0 Release Notes",
+        },
+        {
+          title: "TypeScript 3.9",
+          id: "4-typescript-3.9",
+          permalink: "/docs/handbook/release-notes/typescript-3-9.html",
+          oneline: "TypeScript 3.9 Release Notes",
+        },
+        {
+          title: "TypeScript 3.8",
+          id: "4-typescript-3.8",
+          permalink: "/docs/handbook/release-notes/typescript-3-8.html",
+          oneline: "TypeScript 3.8 Release Notes",
+        },
+        {
+          title: "TypeScript 3.7",
+          id: "4-typescript-3.7",
+          permalink: "/docs/handbook/release-notes/typescript-3-7.html",
+          oneline: "TypeScript 3.7 Release Notes",
+        },
+        {
+          title: "TypeScript 3.6",
+          id: "4-typescript-3.6",
+          permalink: "/docs/handbook/release-notes/typescript-3-6.html",
+          oneline: "TypeScript 3.6 Release Notes",
+        },
+        {
+          title: "TypeScript 3.5",
+          id: "4-typescript-3.5",
+          permalink: "/docs/handbook/release-notes/typescript-3-5.html",
+          oneline: "TypeScript 3.5 Release Notes",
+        },
+        {
+          title: "TypeScript 3.4",
+          id: "4-typescript-3.4",
+          permalink: "/docs/handbook/release-notes/typescript-3-4.html",
+          oneline: "TypeScript 3.4 Release Notes",
+        },
+        {
+          title: "TypeScript 3.3",
+          id: "4-typescript-3.3",
+          permalink: "/docs/handbook/release-notes/typescript-3-3.html",
+          oneline: "TypeScript 3.3 Release Notes",
+        },
+        {
+          title: "TypeScript 3.2",
+          id: "4-typescript-3.2",
+          permalink: "/docs/handbook/release-notes/typescript-3-2.html",
+          oneline: "TypeScript 3.2 Release Notes",
+        },
+        {
+          title: "TypeScript 3.1",
+          id: "4-typescript-3.1",
+          permalink: "/docs/handbook/release-notes/typescript-3-1.html",
+          oneline: "TypeScript 3.1 Release Notes",
+        },
+        {
+          title: "TypeScript 3.0",
+          id: "4-typescript-3.0",
+          permalink: "/docs/handbook/release-notes/typescript-3-0.html",
+          oneline: "TypeScript 3.0 Release Notes",
+        },
+        {
+          title: "TypeScript 2.9",
+          id: "4-typescript-2.9",
+          permalink: "/docs/handbook/release-notes/typescript-2-9.html",
+          oneline: "TypeScript 2.9 Release Notes",
+        },
+        {
+          title: "TypeScript 2.8",
+          id: "4-typescript-2.8",
+          permalink: "/docs/handbook/release-notes/typescript-2-8.html",
+          oneline: "TypeScript 2.8 Release Notes",
+        },
+        {
+          title: "TypeScript 2.7",
+          id: "4-typescript-2.7",
+          permalink: "/docs/handbook/release-notes/typescript-2-7.html",
+          oneline: "TypeScript 2.7 Release Notes",
+        },
+        {
+          title: "TypeScript 2.6",
+          id: "4-typescript-2.6",
+          permalink: "/docs/handbook/release-notes/typescript-2-6.html",
+          oneline: "TypeScript 2.6 Release Notes",
+        },
+        {
+          title: "TypeScript 2.5",
+          id: "4-typescript-2.5",
+          permalink: "/docs/handbook/release-notes/typescript-2-5.html",
+          oneline: "TypeScript 2.5 Release Notes",
+        },
+        {
+          title: "TypeScript 2.4",
+          id: "4-typescript-2.4",
+          permalink: "/docs/handbook/release-notes/typescript-2-4.html",
+          oneline: "TypeScript 2.4 Release Notes",
+        },
+        {
+          title: "TypeScript 2.3",
+          id: "4-typescript-2.3",
+          permalink: "/docs/handbook/release-notes/typescript-2-3.html",
+          oneline: "TypeScript 2.3 Release Notes",
+        },
+        {
+          title: "TypeScript 2.2",
+          id: "4-typescript-2.2",
+          permalink: "/docs/handbook/release-notes/typescript-2-2.html",
+          oneline: "TypeScript 2.2 Release Notes",
+        },
+        {
+          title: "TypeScript 2.1",
+          id: "4-typescript-2.1",
+          permalink: "/docs/handbook/release-notes/typescript-2-1.html",
+          oneline: "TypeScript 2.1 Release Notes",
+        },
+        {
+          title: "TypeScript 2.0",
+          id: "4-typescript-2.0",
+          permalink: "/docs/handbook/release-notes/typescript-2-0.html",
+          oneline: "TypeScript 2.0 Release Notes",
+        },
+        {
+          title: "TypeScript 1.8",
+          id: "4-typescript-1.8",
+          permalink: "/docs/handbook/release-notes/typescript-1-8.html",
+          oneline: "TypeScript 1.8 Release Notes",
+        },
+        {
+          title: "TypeScript 1.7",
+          id: "4-typescript-1.7",
+          permalink: "/docs/handbook/release-notes/typescript-1-7.html",
+          oneline: "TypeScript 1.7 Release Notes",
+        },
+        {
+          title: "TypeScript 1.6",
+          id: "4-typescript-1.6",
+          permalink: "/docs/handbook/release-notes/typescript-1-6.html",
+          oneline: "TypeScript 1.6 Release Notes",
+        },
+        {
+          title: "TypeScript 1.5",
+          id: "4-typescript-1.5",
+          permalink: "/docs/handbook/release-notes/typescript-1-5.html",
+          oneline: "TypeScript 1.5 Release Notes",
+        },
+        {
+          title: "TypeScript 1.4",
+          id: "4-typescript-1.4",
+          permalink: "/docs/handbook/release-notes/typescript-1-4.html",
+          oneline: "TypeScript 1.3 Release Notes",
+        },
+        {
+          title: "TypeScript 1.3",
+          id: "4-typescript-1.3",
+          permalink: "/docs/handbook/release-notes/typescript-1-3.html",
+          oneline: "TypeScript 1.3 Release Notes",
+        },
+        {
+          title: "TypeScript 1.1",
+          id: "4-typescript-1.1",
+          permalink: "/docs/handbook/release-notes/typescript-1-1.html",
+          oneline: "TypeScript 1.1 Release Notes",
+        },
+      ],
+    },
+    {
+      title: "Declaration Files",
+      oneline:
+        "Learn how to write declaration files to describe existing JavaScript. Important for DefinitelyTyped contributions.",
+      id: "declaration-files",
+      chronological: true,
+
+      items: [
+        {
+          title: "Introduction",
+          id: "5-introduction",
+          permalink: "/docs/handbook/declaration-files/introduction.html",
+          oneline:
+            "How to write a high-quality TypeScript Declaration (d.ts) file",
+        },
+        {
+          title: "Declaration Reference",
+          id: "5-declaration-reference",
+          permalink: "/docs/handbook/declaration-files/by-example.html",
+          oneline: "How to create a d.ts file for a module",
+        },
+        {
+          title: "Library Structures",
+          id: "5-library-structures",
+          permalink: "/docs/handbook/declaration-files/library-structures.html",
+          oneline: "How to structure your d.ts files",
+        },
+        {
+          title: ".d.ts Templates",
+          id: "5-.d.ts-templates",
+          oneline: "undefined",
+          chronological: false,
+
+          items: [
+            {
+              title: "Modules .d.ts",
+              id: "5-modules-.d.ts",
+              permalink:
+                "/docs/handbook/declaration-files/templates/module-d-ts.html",
+              oneline: "undefined",
+            },
+            {
+              title: "Module: Plugin",
+              id: "5-module:-plugin",
+              permalink:
+                "/docs/handbook/declaration-files/templates/module-plugin-d-ts.html",
+              oneline: "undefined",
+            },
+            {
+              title: "Module: Class",
+              id: "5-module:-class",
+              permalink:
+                "/docs/handbook/declaration-files/templates/module-class-d-ts.html",
+              oneline: "undefined",
+            },
+            {
+              title: "Module: Function",
+              id: "5-module:-function",
+              permalink:
+                "/docs/handbook/declaration-files/templates/module-function-d-ts.html",
+              oneline: "undefined",
+            },
+            {
+              title: "Global .d.ts",
+              id: "5-global-.d.ts",
+              permalink:
+                "/docs/handbook/declaration-files/templates/global-d-ts.html",
+              oneline: "undefined",
+            },
+            {
+              title: "Global: Modifying Module",
+              id: "5-global:-modifying-module",
+              permalink:
+                "/docs/handbook/declaration-files/templates/global-modifying-module-d-ts.html",
+              oneline: "undefined",
+            },
+          ],
+        },
+        {
+          title: "Do's and Don'ts",
+          id: "5-do's-and-don'ts",
+          permalink: "/docs/handbook/declaration-files/do-s-and-don-ts.html",
+          oneline: "Recommendations for writing d.ts files",
+        },
+        {
+          title: "Deep Dive",
+          id: "5-deep-dive",
+          permalink: "/docs/handbook/declaration-files/deep-dive.html",
+          oneline: "How do d.ts files work, a deep dive",
+        },
+        {
+          title: "Publishing",
+          id: "5-publishing",
+          permalink: "/docs/handbook/declaration-files/publishing.html",
+          oneline: "How to get your d.ts files to users",
+        },
+        {
+          title: "Consumption",
+          id: "5-consumption",
+          permalink: "/docs/handbook/declaration-files/consumption.html",
+          oneline: "How to download d.ts files for your project",
+        },
+      ],
+    },
+    {
+      title: "JavaScript",
+      oneline: "How to use TypeScript-powered JavaScript tooling.",
+      id: "javascript",
+      chronological: true,
+
+      items: [
+        {
+          title: "Projetos JS utilizando TypeScript",
+          id: "6-projetos-js-utilizando-typescript",
+          permalink: "/pt/docs/handbook/intro-to-js-ts.html",
+          oneline:
+            "Como adicionar verificação de tipo a arquivos JavaScript usando TypeScript",
+        },
+        {
+          title: "Checando tipos de arquivos JavaScript",
+          id: "6-checando-tipos-de-arquivos-javascript",
+          permalink: "/pt/docs/handbook/type-checking-javascript-files.html",
+          oneline:
+            "Como adicionar checagem de tipos a arquivos JavaScript usando Typescript",
+        },
+        {
+          title: "Referência JSDoc",
+          id: "6-referência-jsdoc",
+          permalink: "/pt/docs/handbook/jsdoc-supported-types.html",
+          oneline: "Quais JSDoc Javascript baseado em Typescript suporta?",
+        },
+        {
+          title: "Criação de arquivos .d.ts a partir de arquivos .js",
+          id: "6-criação-de-arquivos-.d.ts-a-partir-de-arquivos-.js",
+          permalink: "/pt/docs/handbook/declaration-files/dts-from-js.html",
+          oneline: "Como adicionar geração d.ts a projetos JavaScript",
+        },
+      ],
+    },
+    {
+      title: "Project Configuration",
+      oneline: "Compiler configuration reference.",
+      id: "project-configuration",
+      chronological: false,
+
+      items: [
+        {
+          title: "tsconfig.json",
+          id: "7-tsconfig.json",
+          permalink: "/pt/docs/handbook/tsconfig-json.html",
+          oneline: "Aprenda sobre como o TSConfig funciona",
+        },
+        {
+          title: "Compiler Options in MSBuild",
+          id: "7-compiler-options-in-msbuild",
+          permalink: "/docs/handbook/compiler-options-in-msbuild.html",
+          oneline: "Which compiler options are available in MSBuild projects.",
+        },
+        {
+          title: "TSConfig Reference",
+          id: "7-tsconfig-reference",
+          permalink: "/tsconfig",
+          oneline: "The page covering every TSConfig option",
+        },
+        {
+          title: "tsc CLI Options",
+          id: "7-tsc-cli-options",
+          permalink: "/docs/handbook/compiler-options.html",
+          oneline:
+            "A very high-level overview of the CLI compiler options for tsc",
+        },
+        {
+          title: "Referência de Projeto",
+          id: "7-referência-de-projeto",
+          permalink: "/pt/docs/handbook/project-references.html",
+          oneline: "Como dividir um projeto Typescript grande",
+        },
+        {
+          title: "Integrating with Build Tools",
+          id: "7-integrating-with-build-tools",
+          permalink: "/docs/handbook/integrating-with-build-tools.html",
+          oneline: "How to use TypeScript with other build tools",
+        },
+        {
+          title: "Configurando Watch",
+          id: "7-configurando-watch",
+          permalink: "/pt/docs/handbook/configuring-watch.html",
+          oneline: "Como configurar o modo de observação do Typescript",
+        },
+        {
+          title: "Compilação Noturna",
+          id: "7-compilação-noturna",
+          permalink: "/pt/docs/handbook/nightly-builds.html",
+          oneline: "Como usar uma compilação noturna de TypeScript",
+        },
+      ],
+    },
+  ];
+  navigations.vo = [
     {
       title: "Get Started",
       oneline: "Quick introductions based on your background or preference.",
@@ -3611,6 +4323,7 @@ export function getDocumentationNavForLanguage(
           title: "Type Manipulation",
           id: "1-type-manipulation",
           oneline: "undefined",
+          chronological: true,
 
           items: [
             {
@@ -3689,10 +4402,10 @@ export function getDocumentationNavForLanguage(
 
       items: [
         {
-          title: "Tipos Utilitários",
-          id: "2-tipos-utilitários",
-          permalink: "/pt/docs/handbook/utility-types.html",
-          oneline: "Tipos que são inclusos globalmente em TypeScript",
+          title: "Utility Types",
+          id: "2-utility-types",
+          permalink: "/docs/handbook/utility-types.html",
+          oneline: "Types which are globally included in TypeScript",
         },
         {
           title: "Decorators",
@@ -3701,10 +4414,10 @@ export function getDocumentationNavForLanguage(
           oneline: "TypeScript Decorators overview",
         },
         {
-          title: "Fusão de Declarações",
-          id: "2-fusão-de-declarações",
-          permalink: "/pt/docs/handbook/declaration-merging.html",
-          oneline: "Como a fusão de namespaces e interfaces funciona",
+          title: "Declaration Merging",
+          id: "2-declaration-merging",
+          permalink: "/docs/handbook/declaration-merging.html",
+          oneline: "How merging namespaces and interfaces works",
         },
         {
           title: "Enums",
@@ -3713,28 +4426,28 @@ export function getDocumentationNavForLanguage(
           oneline: "How TypeScript enums work",
         },
         {
-          title: "Iteradores e Geradores",
-          id: "2-iteradores-e-geradores",
-          permalink: "/pt/docs/handbook/iterators-and-generators.html",
-          oneline: "Como os Iteradores e Geradores funcionam no TypeScript",
+          title: "Iterators and Generators",
+          id: "2-iterators-and-generators",
+          permalink: "/docs/handbook/iterators-and-generators.html",
+          oneline: "How Iterators and Generators work in TypeScript",
         },
         {
           title: "JSX",
           id: "2-jsx",
-          permalink: "/pt/docs/handbook/jsx.html",
-          oneline: "Utilizando JSX com TypeScript",
+          permalink: "/docs/handbook/jsx.html",
+          oneline: "Using JSX with TypeScript",
         },
         {
           title: "Mixins",
           id: "2-mixins",
-          permalink: "/pt/docs/handbook/mixins.html",
-          oneline: "Usando o padrão Mixin com TypeScript",
+          permalink: "/docs/handbook/mixins.html",
+          oneline: "Using the mixin pattern with TypeScript",
         },
         {
           title: "Modules",
           id: "2-modules",
-          permalink: "/pt/docs/handbook/modules.html",
-          oneline: "Como módulos funcionam no TypeScript",
+          permalink: "/docs/handbook/modules.html",
+          oneline: "How modules work in TypeScript",
         },
         {
           title: "Module Resolution",
@@ -3780,10 +4493,10 @@ export function getDocumentationNavForLanguage(
           oneline: "How code flow analysis works in TypeScript",
         },
         {
-          title: "Declarações de variáveis",
-          id: "2-declarações-de-variáveis",
-          permalink: "/pt/docs/handbook/variable-declarations.html",
-          oneline: "Como TypeScript lida com declarações de variáveis",
+          title: "Variable Declaration",
+          id: "2-variable-declaration",
+          permalink: "/docs/handbook/variable-declarations.html",
+          oneline: "How TypeScript handles variable declaration",
         },
       ],
     },
@@ -3807,10 +4520,10 @@ export function getDocumentationNavForLanguage(
           oneline: "Using TypeScript with Gulp",
         },
         {
-          title: "Manipulação do DOM",
-          id: "3-manipulação-do-dom",
-          permalink: "/pt/docs/handbook/manipulacao-dom.html",
-          oneline: "Usando o DOM com TypeScript",
+          title: "DOM Manipulation",
+          id: "3-dom-manipulation",
+          permalink: "/docs/handbook/dom-manipulation.html",
+          oneline: "Using the DOM with TypeScript",
         },
         {
           title: "Migrating from JavaScript",
@@ -4053,6 +4766,7 @@ export function getDocumentationNavForLanguage(
           title: ".d.ts Templates",
           id: "5-.d.ts-templates",
           oneline: "undefined",
+          chronological: false,
 
           items: [
             {
@@ -4140,23 +4854,23 @@ export function getDocumentationNavForLanguage(
             "How to add type checking to JavaScript files using TypeScript",
         },
         {
-          title: "Checando tipos de arquivos JavaScript",
-          id: "6-checando-tipos-de-arquivos-javascript",
-          permalink: "/pt/docs/handbook/type-checking-javascript-files.html",
+          title: "Type Checking JavaScript Files",
+          id: "6-type-checking-javascript-files",
+          permalink: "/docs/handbook/type-checking-javascript-files.html",
           oneline:
-            "Como adicionar checagem de tipos a arquivos JavaScript usando Typescript",
+            "How to add type checking to JavaScript files using TypeScript",
         },
         {
-          title: "Referência JSDoc",
-          id: "6-referência-jsdoc",
-          permalink: "/pt/docs/handbook/jsdoc-supported-types.html",
-          oneline: "Quais JSDoc Javascript baseado em Typescript suporta?",
+          title: "JSDoc Reference",
+          id: "6-jsdoc-reference",
+          permalink: "/docs/handbook/jsdoc-supported-types.html",
+          oneline: "What JSDoc does TypeScript-powered JavaScript support?",
         },
         {
-          title: "Criação de arquivos .d.ts a partir de arquivos .js",
-          id: "6-criação-de-arquivos-.d.ts-a-partir-de-arquivos-.js",
-          permalink: "/pt/docs/handbook/declaration-files/dts-from-js.html",
-          oneline: "Como adicionar geração d.ts a projetos JavaScript",
+          title: "Creating .d.ts Files from .js files",
+          id: "6-creating-.d.ts-files-from-.js-files",
+          permalink: "/docs/handbook/declaration-files/dts-from-js.html",
+          oneline: "How to add d.ts generation to JavaScript projects",
         },
       ],
     },
@@ -4193,10 +4907,10 @@ export function getDocumentationNavForLanguage(
             "A very high-level overview of the CLI compiler options for tsc",
         },
         {
-          title: "Referência de Projeto",
-          id: "7-referência-de-projeto",
-          permalink: "/pt/docs/handbook/project-references.html",
-          oneline: "Como dividir um projeto Typescript grande",
+          title: "Project References",
+          id: "7-project-references",
+          permalink: "/docs/handbook/project-references.html",
+          oneline: "How to split up a large TypeScript project",
         },
         {
           title: "Integrating with Build Tools",
@@ -4205,10 +4919,10 @@ export function getDocumentationNavForLanguage(
           oneline: "How to use TypeScript with other build tools",
         },
         {
-          title: "Configurando Watch",
-          id: "7-configurando-watch",
-          permalink: "/pt/docs/handbook/configuring-watch.html",
-          oneline: "Como configurar o modo de observação do Typescript",
+          title: "Configuring Watch",
+          id: "7-configuring-watch",
+          permalink: "/docs/handbook/configuring-watch.html",
+          oneline: "How to configure the watch mode of TypeScript",
         },
         {
           title: "Nightly Builds",
@@ -4310,6 +5024,7 @@ export function getDocumentationNavForLanguage(
           title: "Type Manipulation",
           id: "1-type-manipulation",
           oneline: "undefined",
+          chronological: true,
 
           items: [
             {
@@ -4752,6 +5467,7 @@ export function getDocumentationNavForLanguage(
           title: ".d.ts Templates",
           id: "5-.d.ts-templates",
           oneline: "undefined",
+          chronological: false,
 
           items: [
             {


### PR DESCRIPTION
Closes https://github.com/microsoft/TypeScript-Website/issues/1723

The previous/next links aren't currently being generated for Type Manipulation because the subitem doesn't have chronological set to true & it's returning early when trying to compute the links: https://github.com/microsoft/TypeScript-Website/blob/2750cd8bee1f8d8101d13b55da7a1a4e5f5c479b/packages/typescriptlang-org/src/lib/documentationNavigation.ts#L4951 This PR resolves it