### PR TITLE
Added @deprecated tag to jsdoc support

### DIFF
--- a/packages/documentation/copy/en/javascript/JSDoc Reference.md
+++ b/packages/documentation/copy/en/javascript/JSDoc Reference.md
@@ -21,7 +21,7 @@ Note any tags which are not explicitly listed below (such as `@async`) are not y
 - [`@this`](#this)
 - [`@extends`](#extends) (or [`@augments`](#extends))
 - [`@enum`](#enum)
-- [`@deprecated`](#deprecated)
+- [`@deprecated`](#deprecated-comments)
 
 #### `class` extensions
 
@@ -507,12 +507,19 @@ const MathFuncs = {
 MathFuncs.add1;
 ```
 
-## `@deprecated`
+## `@deprecated` Comments
 
 When a function, method, or property is deprecated you can let users know by marking it with a `/** @deprecated */` JSDoc comment. That information is surfaced in completion lists and as a suggestion diagnostic that editors can handle specially. In an editor like VS Code, deprecated values are typically displayed in a strike-through style ~~like this~~.
 
-![Some examples of deprecated declarations with strikethrough text in the editor](https://devblogs.microsoft.com/typescript/wp-content/uploads/sites/11/2020/06/deprecated_4-0.png)
+```js
+// @noErrors
+/** @deprecated */
+const apiV1 = {};
+const apiV2 = {};
 
+apiV;
+// ^|
+```
 
 ## More examples
 

--- a/packages/documentation/copy/en/javascript/JSDoc Reference.md
+++ b/packages/documentation/copy/en/javascript/JSDoc Reference.md
@@ -509,7 +509,7 @@ MathFuncs.add1;
 
 ## `@deprecated`
 
-When a function, method, or property is deprecated you can let users know by marking it with a `/** @deprecated */` JSDoc comment. That information is surfaced in completion lists and as a suggestion diagnostic that editors can handle specially. In an editor like VS Code, deprecated values are typically displayed a strike-through style ~~like this~~.
+When a function, method, or property is deprecated you can let users know by marking it with a `/** @deprecated */` JSDoc comment. That information is surfaced in completion lists and as a suggestion diagnostic that editors can handle specially. In an editor like VS Code, deprecated values are typically displayed in a strike-through style ~~like this~~.
 
 ![Some examples of deprecated declarations with strikethrough text in the editor](https://devblogs.microsoft.com/typescript/wp-content/uploads/sites/11/2020/06/deprecated_4-0.png)
 

--- a/packages/documentation/copy/en/javascript/JSDoc Reference.md
+++ b/packages/documentation/copy/en/javascript/JSDoc Reference.md
@@ -21,6 +21,7 @@ Note any tags which are not explicitly listed below (such as `@async`) are not y
 - [`@this`](#this)
 - [`@extends`](#extends) (or [`@augments`](#extends))
 - [`@enum`](#enum)
+- [`@deprecated`](#deprecated)
 
 #### `class` extensions
 
@@ -505,6 +506,13 @@ const MathFuncs = {
 
 MathFuncs.add1;
 ```
+
+## `@deprecated`
+
+When a function, method, or property is deprecated you can let users know by marking it with a `/** @deprecated */` JSDoc comment. That information is surfaced in completion lists and as a suggestion diagnostic that editors can handle specially. In an editor like VS Code, deprecated values are typically displayed a strike-through style ~~like this~~.
+
+![Some examples of deprecated declarations with strikethrough text in the editor](https://devblogs.microsoft.com/typescript/wp-content/uploads/sites/11/2020/06/deprecated_4-0.png)
+
 
 ## More examples
 


### PR DESCRIPTION
Since this is also a part of JSDoc, I thought this should be mentioned here also.

Ref: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-0.html#-deprecated--support
