### PR TITLE
Edit info about allowUnusedLabels flag.

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/allowUnusedLabels.md
+++ b/packages/tsconfig-reference/copy/en/options/allowUnusedLabels.md
@@ -3,7 +3,11 @@ display: "Allow Unused Labels"
 oneline: "Disable error reporting for unused labels."
 ---
 
-Set to false to disable warnings about unused labels.
+When:
+
+- `undefined` (default) provide suggestions as warnings to editors
+- `true` unused labels are ignored
+- `false` raises compiler errors about unused labels
 
 Labels are very rare in JavaScript and typically indicate an attempt to write an object literal:
 

--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -132,7 +132,7 @@ export const defaultsForOptions = {
   allowSyntheticDefaultImports: 'module === "system" or esModuleInterop',
   allowUmdGlobalAccess: "false",
   allowUnreachableCode: "undefined",
-  allowUnusedLabels: "false",
+  allowUnusedLabels: "undefined",
   alwaysStrict: "`false`, unless `strict` is set",
   charset: "utf8",
   checkJs: "false",


### PR DESCRIPTION
The behavior of [allowUnusedLabels](https://www.typescriptlang.org/tsconfig#allowUnusedLabels) is the same as [allowUnreachableCode](https://www.typescriptlang.org/tsconfig#allowUnreachableCode).

Here is the code example from tsconfig reference:

```typescript
function fn(n: number) {
    if (n > 5) {
      return true;
    } else {
      return false;
    }
    return true;
}

function verifyAge(age: number) {
    // Forgot 'return' statement
    if (age > 18) {
      verified: true;
    }
}
```

And the config:

```json
{
  "compilerOptions": {
    "outDir": "./dist"
  },
  "include": [
    "src"
  ]
}
```

Now compilation works without any warnings, but VSC show messages "Unreachable code detected. ts(7027)" for the line `7` and "Unused label. ts(7028)" for line `13`.

Now this config:

```json
{
  "compilerOptions": {
    "outDir": "./dist",
    "allowUnreachableCode": true,
    "allowUnusedLabels": true
  },
  "include": [
    "src"
  ]
}
```

Compilation still works and VSC messages disappeared.

And the last one:

```json
{
  "compilerOptions": {
    "outDir": "./dist",
    "allowUnreachableCode": false,
    "allowUnusedLabels": false
  },
  "include": [
    "src"
  ]
}
```

Now we have errors from both VSC and compiler:

```
src/index.ts:7:5 - error TS7027: Unreachable code detected.

7     return true;
      ~~~~~~~~~~~~

src/index.ts:13:7 - error TS7028: Unused label.

13       verified: true;
         ~~~~~~~~
```

I know nobody uses labels in our days, but it will be better to fix the reference.
