### PR TITLE
Update link to first page of the handbook

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/The Handbook.md
+++ b/packages/documentation/copy/en/handbook-v2/The Handbook.md
@@ -49,11 +49,11 @@ Finally, the Handbook won't cover how TypeScript interacts with other tools, exc
 
 ## Get Started
 
-Before getting started with [Basic Types](/docs/handbook/2/basic-types.html), we recommend reading one of the following introductory pages. These introductions are intended to highlight key similarities and differences between TypeScript and your favored programming language, and clear up common misconceptions specific to those languages.
+Before getting started with [The Basics](/docs/handbook/2/basic-types.html), we recommend reading one of the following introductory pages. These introductions are intended to highlight key similarities and differences between TypeScript and your favored programming language, and clear up common misconceptions specific to those languages.
 
 - [TypeScript for New Programmers](/docs/handbook/typescript-from-scratch.html)
 - [TypeScript for JavaScript Programmers](/docs/handbook/typescript-in-5-minutes.html)
 - [TypeScript for OOP Programmers](/docs/handbook/typescript-in-5-minutes-oop.html)
 - [TypeScript for Functional Programmers](/docs/handbook/typescript-in-5-minutes-func.html)
 
-Otherwise, jump to [Basic Types](/docs/handbook/2/basic-types.html) or grab a copy in [Epub](/assets/typescript-handbook.epub) or [PDF](/assets/typescript-handbook.pdf) form.
+Otherwise, jump to [The Basics](/docs/handbook/2/basic-types.html) or grab a copy in [Epub](/assets/typescript-handbook.epub) or [PDF](/assets/typescript-handbook.pdf) form.


### PR DESCRIPTION
The hyperlink text matched the name of the deprecated page, so it was updated to match the current page. 