### PR TITLE
fix: remove name of convicted terrorist from the main page; replace with generic name

### DIFF
--- a/packages/typescriptlang-org/src/components/index/twoslash/showErrors.ts-sample
+++ b/packages/typescriptlang-org/src/components/index/twoslash/showErrors.ts-sample
@@ -1,7 +1,7 @@
 // @errors: 2339
 const user = {
-  firstName: "Angela",
-  lastName: "Davis",
+  firstName: "Jane",
+  lastName: "Smith",
   role: "Professor"
 }
 


### PR DESCRIPTION
The main page shows the name of a convicted Communist terrorist, Angela Davis. 

https://upload.wikimedia.org/wikipedia/commons/2/2d/Angela_Yvonne_Davis_Wanted_Poster.jpg

What purpose does it serve on the main page other than stoke political argument or troll people?

Let's replace it with a generic name.