### PR TITLE
Add max-width to #handbook-content for wider displays

### DIFF
--- a/packages/typescriptlang-org/src/templates/documentation.scss
+++ b/packages/typescriptlang-org/src/templates/documentation.scss
@@ -24,6 +24,7 @@
 #handbook-content {
   margin-left: 2rem;
   margin-right: 2rem;
+  max-width: 1200px;
   min-width: 0;
 
   @media (max-width: $screen-xs) {

--- a/packages/typescriptlang-org/src/templates/documentation.scss
+++ b/packages/typescriptlang-org/src/templates/documentation.scss
@@ -22,14 +22,13 @@
 }
 
 #handbook-content {
-  margin-left: 2rem;
-  margin-right: 2rem;
+  margin: auto;
+  padding: 0 2rem;
   max-width: 1200px;
   min-width: 0;
-
+  
   @media (max-width: $screen-xs) {
-    margin-left: 0;
-    margin-right: 0;
+    padding: 0;
   }
 
   // Page title


### PR DESCRIPTION
This makes reading the documentation page much easier on wider displays as the content is in the center.

See before & after images.

Before
![image](https://user-images.githubusercontent.com/63161941/116092095-6b95fc80-a69d-11eb-8a6b-1cdc882aa59d.png)

After
![image](https://user-images.githubusercontent.com/63161941/116092037-5caf4a00-a69d-11eb-8416-5d3cae15c70d.png)
