### PR TITLE
Another stab at the a11y for JS in the sidebar of the playground 

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/main.scss
+++ b/packages/typescriptlang-org/src/components/layout/main.scss
@@ -8,6 +8,7 @@
   --background-minor-highlight-color: #343434;
   --inline-code-background-color: rgb(58, 58, 92, 0.7);
   --link-color: #{$ts-main-blue-lightest-color};
+  --pure-background: black;
   --raised-background-color: #{$ts-dark-bg-for-foreground-color};
   --alt-text-color: #fff;
   --raised-box-shadow: 0 1.6px 3.6px 0 rgba(255, 255, 255, 0.132),
@@ -40,6 +41,7 @@ html,
 html.light-theme {
   // light theme
   --background-color: #{$ts-light-bg-sandy-color};
+  --pure-background: white;
   --text-color: #333;
   --border-color: #eee;
   --background-minor-highlight-color: #fcfcfc;

--- a/packages/typescriptlang-org/src/templates/play.scss
+++ b/packages/typescriptlang-org/src/templates/play.scss
@@ -383,7 +383,7 @@ main #editor-toolbar {
       }
 
       pre {
-        background-color: var(--raised-background-color);
+        background-color: var(--pure-background);
         color: var(--text-color);
         border: none;
         overflow-x: auto;
@@ -391,8 +391,8 @@ main #editor-toolbar {
         padding: 0 10px;
         code {
           font-family: $font-code;
-          font-size: 0.7rem;
-          line-height: 0.7rem;
+          font-size: 14px;
+          line-height: 19px;
         }
       }
     }


### PR DESCRIPTION
Re: 1314737

Font size was throwing off the audit