### PR TITLE
Fix typo in Narrowing.md

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Narrowing.md
+++ b/packages/documentation/copy/en/handbook-v2/Narrowing.md
@@ -445,7 +445,7 @@ Most of the examples we've looked at so far have focused around narrowing single
 While this is common, most of the time in JavaScript we'll be dealing with slightly more complex structures.
 
 For some motivation, let's imagine we're trying to encode shapes like circles and squares.
-Circles keep track of their radii and squares keep track of their side lengths.
+Circles keep track of their radius and squares keep track of their side lengths.
 We'll use a field called `kind` to tell which shape we're dealing with.
 Here's a first attempt at defining `Shape`.
 


### PR DESCRIPTION
Changes `radii` for `radius`