### PR TITLE
Update More on Functions.md

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -298,7 +298,7 @@ That's always a red flag, because it means callers wanting to specify type argum
 
 #### Type Parameters Should Appear Twice
 
-Sometimes we forget that function doesn't need to be generic:
+Sometimes we forget that a function might not need to be generic:
 
 ```ts twoslash
 function greet<Str extends string>(s: Str) {


### PR DESCRIPTION
Section: https://www.typescriptlang.org/docs/handbook/2/functions.html#type-parameters-should-appear-twice

The phrase **"function doesn't need to be generic"** may imply to someone as a **thumb rule**.
As per the topic, changing the sentence to a more **general** scenario.
