### PR TITLE
Clarify namespace import behavior with esModuleInterop

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/esModuleInterop.md
+++ b/packages/tsconfig-reference/copy/en/options/esModuleInterop.md
@@ -54,6 +54,8 @@ fs.readFileSync("file.txt", "utf8");
 _.chunk(["a", "b", "c", "d"], 2);
 ```
 
+Notice that the namespace import `import * as fs from "fs"` only considers own properties of the imported object. If the module you're importing defines its API using inherited properties, you need to use the default import form (`import fs from "fs"`), or disable `esModuleInterop`.
+
 _Note_: You can make JS emit terser by enabling [`importHelpers`](#importHelpers):
 
 ```ts twoslash

--- a/packages/tsconfig-reference/copy/en/options/esModuleInterop.md
+++ b/packages/tsconfig-reference/copy/en/options/esModuleInterop.md
@@ -54,7 +54,7 @@ fs.readFileSync("file.txt", "utf8");
 _.chunk(["a", "b", "c", "d"], 2);
 ```
 
-Notice that the namespace import `import * as fs from "fs"` only considers own properties of the imported object. If the module you're importing defines its API using inherited properties, you need to use the default import form (`import fs from "fs"`), or disable `esModuleInterop`.
+_Note_: The namespace import `import * as fs from "fs"` only accounts for properties which [are owned](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty) (basically properties set on the object and not via the prototype chain) on the imported object. If the module you're importing defines its API using inherited properties, you need to use the default import form (`import fs from "fs"`), or disable `esModuleInterop`.
 
 _Note_: You can make JS emit terser by enabling [`importHelpers`](#importHelpers):
 


### PR DESCRIPTION
Add note about the treatment of own/inherited properties with namespace
import when `esModuleInterop` is `true`.