### PR TITLE
Invalid argument for `--target`

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Basics.md
+++ b/packages/documentation/copy/en/handbook-v2/Basics.md
@@ -393,8 +393,8 @@ This process of moving from a newer or "higher" version of ECMAScript down to an
 
 By default TypeScript targets ES3, an extremely old version of ECMAScript.
 We could have chosen something a little bit more recent by using the `--target` flag.
-Running with `--target ES6` changes TypeScript to target ECMAScript 2015, meaning code should be able to run wherever ECMAScript 2015 is supported.
-So running `tsc --target ES6 hello.ts` gives us the following output:
+Running with `--target es2015` changes TypeScript to target ECMAScript 2015, meaning code should be able to run wherever ECMAScript 2015 is supported.
+So running `tsc --target es2015 hello.ts` gives us the following output:
 
 ```js
 function greet(person, date) {

--- a/packages/documentation/copy/en/handbook-v2/Basics.md
+++ b/packages/documentation/copy/en/handbook-v2/Basics.md
@@ -393,8 +393,8 @@ This process of moving from a newer or "higher" version of ECMAScript down to an
 
 By default TypeScript targets ES3, an extremely old version of ECMAScript.
 We could have chosen something a little bit more recent by using the `--target` flag.
-Running with `--target es2015` changes TypeScript to target ECMAScript 2015, meaning code should be able to run wherever ECMAScript 2015 is supported.
-So running `tsc --target es2015 input.ts` gives us the following output:
+Running with `--target ES6` changes TypeScript to target ECMAScript 2015, meaning code should be able to run wherever ECMAScript 2015 is supported.
+So running `tsc --target ES6 hello.ts` gives us the following output:
 
 ```js
 function greet(person, date) {


### PR DESCRIPTION
In the *Downleveling* section, an invalid argument (`es2015`) is passed for the `--target` flag, which results in an error: **`error TS6047: Argument for '--target' option must be 'ES3', 'ES5', or 'ES6'.`**

Also, the file to transpile is wrongly referenced as `input.ts` instead of `hello.ts`

![image](https://user-images.githubusercontent.com/49292621/117388179-dcb08d80-aeaf-11eb-90f6-55985b7ece2f.png)
