### PR TITLE
Add glob examples for excludeDirectories

### DIFF
--- a/packages/documentation/copy/en/project-config/Configuring Watch.md
+++ b/packages/documentation/copy/en/project-config/Configuring Watch.md
@@ -42,7 +42,7 @@ The `--watch` implementation of the compiler relies on using `fs.watch` and `fs.
 
     // Finally, two additional settings for reducing the amount of possible
     // files to track  work from these directories
-    "excludeDirectories": ["node_modules", "_build"],
+    "excludeDirectories": ["**/node_modules", "_build"],
     "excludeFiles": ["build/fileWhichChangesOfent.ts"]
   }
 }

--- a/packages/tsconfig-reference/copy/en/options/excludeDirectories.md
+++ b/packages/tsconfig-reference/copy/en/options/excludeDirectories.md
@@ -8,7 +8,7 @@ You can use `excludeFiles` to drastically reduce the number of files which are w
 ```json tsconfig
 {
   "watchOptions": {
-    "excludeDirectories": ["node_modules", "_build", "temp/*"]
+    "excludeDirectories": ["**/node_modules", "_build", "temp/*"]
   }
 }
 ```


### PR DESCRIPTION
Turns out globs are allowed.

I don't know whether we want to document it, but the patterns are resolved relative to the current directory.  This is unlikely to affect anyone who isn't forking their own process.