### PR TITLE
Fix a mistake in Utility Types.md

### DIFF
--- a/packages/documentation/copy/en/reference/Utility Types.md
+++ b/packages/documentation/copy/en/reference/Utility Types.md
@@ -15,7 +15,7 @@ Constructs a type with all properties of `Type` set to optional. This utility wi
 ##### Example
 
 ```ts twoslash
-interface Todo {
+type Todo {
   title: string;
   description: string;
 }


### PR DESCRIPTION
Typescript version: 4.2.4

Partial only works on `type` and not on `interface`.

If I try to use `Partial` with `interface` instead, then I get this error/warning:

<img width="598" alt="Screenshot 2021-05-13 at 5 33 13 pm" src="https://user-images.githubusercontent.com/1476807/118157013-eedf7e00-b411-11eb-8edf-9d61b9377c2c.png">
