### PR TITLE
Retain custom query URL params when the URL is updated

### DIFF
--- a/packages/sandbox/src/compilerOptions.ts
+++ b/packages/sandbox/src/compilerOptions.ts
@@ -157,7 +157,6 @@ export const createURLQueryWithCompilerOptions = (sandbox: any, paramOverrides?:
 
     initialOptions.forEach((value, key) => {
       if (queryString.includes(key)) return
-      if (key === "install-plugin") return
       if (compilerOptions[key]) return
 
       queryString += `&${key}=${value}`

--- a/packages/sandbox/src/compilerOptions.ts
+++ b/packages/sandbox/src/compilerOptions.ts
@@ -84,6 +84,8 @@ export const getCompilerOptionsFromParams = (options: CompilerOptions, params: U
 
 /** Gets a query string representation (hash + queries) */
 export const createURLQueryWithCompilerOptions = (sandbox: any, paramOverrides?: any): string => {
+  const initialOptions = new URLSearchParams(document.location.search)
+
   const compilerOptions = sandbox.getCompilerOptions()
   const compilerDefaults = sandbox.compilerDefaults
   const diff = Object.entries(compilerOptions).reduce((acc, [key, value]) => {
@@ -136,14 +138,30 @@ export const createURLQueryWithCompilerOptions = (sandbox: any, paramOverrides?:
     urlParams = { ...urlParams, ...paramOverrides }
   }
 
-  if (Object.keys(urlParams).length > 0) {
-    const queryString = Object.entries(urlParams)
+  // @ts-ignore - this is in MDN but not libdom
+  const hasInitialOpts = initialOptions.keys().length > 0
+
+  if (Object.keys(urlParams).length > 0 || hasInitialOpts) {
+    let queryString = Object.entries(urlParams)
       .filter(([_k, v]) => v !== undefined)
       .filter(([_k, v]) => v !== null)
       .map(([key, value]) => {
         return `${key}=${encodeURIComponent(value as string)}`
       })
       .join("&")
+
+    // We want to keep around custom query variables, which
+    // are usually used by playground plugins, with the exception
+    // being the install-plugin param and any compiler options
+    // which have a default value
+
+    initialOptions.forEach((value, key) => {
+      if (queryString.includes(key)) return
+      if (key === "install-plugin") return
+      if (compilerOptions[key]) return
+
+      queryString += `&${key}=${value}`
+    })
 
     return `?${queryString}#${hash}`
   } else {


### PR DESCRIPTION
When updating the text in a playground, then custom URL params which aren't controlled by the playground/sandbox used to get dropped - this isn't great as installing a plugin may want to read those params after, or you might want to share a URL which would include that info to others.