### PR TITLE
feat(playground): Export markdown preview with syntax highlighting

### DIFF
--- a/packages/playground/src/exporter.ts
+++ b/packages/playground/src/exporter.ts
@@ -269,7 +269,9 @@ ${codify(stringifiedCompilerOptions, "json")}
     const ts = sandbox.getText()
     const preview = ts.length > 200 ? ts.substring(0, 200) + "..." : ts.substring(0, 200)
 
-    const code = "```\n" + preview + "\n```\n"
+    const jsx = getJsxEmitText(sandbox.getCompilerOptions().jsx)
+    const codeLanguage = jsx !== undefined ? "tsx" : "ts"
+    const code = "```" + codeLanguage + "\n" + preview + "\n```\n"
     const chat = `${code}\n[Playground Link](${fullURL})`
     ui.showModal(chat, document.getElementById("exports-dropdown")!, "Markdown code", undefined, e)
     return false


### PR DESCRIPTION
Enables syntax highlighting of markdown previews:

~~~diff
-```
+```tsx
~~~

<details>
<summary>before: no syntax highlighting</summary>

~~~
```
import * as React from 'react';

<div />;
```

[Playground Link](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcA5FDvmQNwBQdAPACbABucA9AHw1A)
~~~
</details>

<details>
<summary>after: ts(x) syntax highlighting</summary>

~~~
```tsx
import * as React from 'react';

function Component() {
    return <div data-testid="bar" />
}
```

[Playground Link](http://localhost:8000/play?&ssl=15&ssc=3&pln=1&pc=1#code/JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcA5FDvmQNwBQdBArgHb7AQtwDCJkLWFjAAUASjgBvOnBlxKMJlC4AeACbAAbnFXIYyALQwsqGMFUBeAEQAjZFEtwA9AD46AXyA)
~~~
</details>