### PR TITLE
documentation/handbook-v2: Typo at Anonymous Functions section of Everyday Types v2 documentation

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -156,7 +156,7 @@ names.forEach((s) => {
 
 Even though the parameter `s` didn't have a type annotation, TypeScript used the types of the `forEach` function, along with the inferred type of the array, to determine the type `s` will have.
 
-This process is called _contextual typing_ because the _context_ that the function occurred in informed what type it should have.
+This process is called _contextual typing_ because the _context_ that the function occurred is informed what type it should have.
 Similar to the inference rules, you don't need to explicitly learn how this happens, but understanding that it _does_ happen can help you notice when type annotations aren't needed.
 Later, we'll see more examples of how the context that a value occurs in can affect its type.
 


### PR DESCRIPTION
In the Everyday Types Documentation Handbook, at the anonymous functions section, the `contextual typing` definition has a grammatical mistake. 

**url**: https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#anonymous-functions

**It says** : 
This process is called _contextual typing_ because the _context_ that the function occurred `in` informed what type it should have.


**Fix**:
the `in` highlighted in the above sentence, should be `is`. which will make much sense in the implementation perspective.
