### PR TITLE
Adds support for refering to other code samples to be a bit more DRY

### DIFF
--- a/packages/remark-shiki-twoslash/README.md
+++ b/packages/remark-shiki-twoslash/README.md
@@ -1,7 +1,7 @@
 ### remark-shiki-twoslash
 
 Sets up markdown code blocks to run through [shiki](https://shiki.matsu.io) which means it gets the VS Code quality
-syntax highlighting. This code is _basically_ the same as [gatsby-remark-shiki-twoslash](https://www.gatsbyjs.org/packages/gatsby-remark-shiki-thoslash/) but not tied to gatsby.
+syntax highlighting, with optional inline TypeScript compiler-backed tooling.
 
 Why Shiki? Shiki uses the same syntax highlighter engine as VS Code, which means no matter how complex your code is - it will syntax highlight correctly.
 
@@ -11,7 +11,7 @@ This module powers the code samples on the TypeScript website.
 
 ![](https://user-images.githubusercontent.com/49038/78996047-ca7be880-7b11-11ea-9e6e-fa7ea8854993.png)
 
-With a bit of work, you can explain complicated code in a way that lets people introspect at their own pace.
+With Shiki Twoslash, you can explain complicated code in a way that lets people introspect at their own pace.
 
 ## Plugin Setup
 
@@ -149,7 +149,7 @@ With a bit of work, you can explain complicated code in a way that lets people i
 
    ```jsx
    import React, { useEffect } from "react"
-   import { setupTwoslashHovers } from "shiki-twoslash/dom";
+   import { setupTwoslashHovers } from "shiki-twoslash/dist/dom";
 
    export default () => {
      // Add a the hovers
@@ -207,3 +207,52 @@ Then it worked, and you should be able to hover over `createLabel` to see it's t
 
 This plugin passes the config options directly to Shiki and Twoslash. You probably will want to
 [set `theme`](https://github.com/octref/shiki/blob/master/packages/themes/README.md#shiki-themes), then also the [TwoslashOptions here](https://www.npmjs.com/package/@typescript/twoslash#api-1).
+
+### Power User Features
+
+Once you start writing long articles, you'll start to feel the desire to remove repetition in your code samples. This plugin adds the ability to import code into code samples. This is a string replacement before code is passed to twoslash. This is done by making a `twoslash include` code sample which is given a unique identifier.
+
+Inside that code-block, you can use `// - [id]` to make sub-queries to the import, these will be stripped out in the code show. Here's an example markdown file using `includes`:
+
+````markdown
+# Hello, world!
+
+```twoslash include main
+const a = 1
+// - 1
+const b = 2
+// - 2
+const c= 3
+```
+
+Let's talk a bit about `a`:
+
+```ts twoslash
+// @include: main-1
+```
+
+`a` can be added to another number
+
+```ts twoslash
+// @include: main-1
+// ---cut---
+const nextA = a + 13
+```
+
+You can see what happens when you add `a + b`
+
+```ts twoslash
+// @include: main-2
+// ---cut---
+const result = a + b
+//    ^?
+```
+
+Finally here is `c`:
+
+```ts twoslash
+// @include: main
+// ---cut---
+c.toString()
+```
+````

--- a/packages/remark-shiki-twoslash/package.json
+++ b/packages/remark-shiki-twoslash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remark-shiki-twoslash",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "license": "MIT",
   "homepage": "https://github.com/microsoft/TypeScript-Website",
   "repository": {

--- a/packages/remark-shiki-twoslash/src/includes.ts
+++ b/packages/remark-shiki-twoslash/src/includes.ts
@@ -1,0 +1,48 @@
+export const addIncludes = (map: Map<string, string>, code: string, metaInfo: string) => {
+  const name = metaInfo.split(" ")[1]
+  const lines: string[] = []
+
+  code.split("\n").forEach((l, _i) => {
+    const trimmed = l.trim()
+
+    if (trimmed.startsWith("// - ")) {
+      const key = trimmed.split("// - ")[1].split(" ")[0]
+      map.set(name + "-" + key, lines.join("\n"))
+    } else {
+      lines.push(l)
+    }
+  })
+  map.set(name, lines.join("\n"))
+}
+
+export const replaceIncludesInCode = (_map: Map<string, string>, code: string) => {
+  const includes = /\/\/ @include: (.*)$/gm
+  
+  // Basically run a regex over the code replacing any // @include: thing with
+  // 'thing' from the map
+  const toReplace: [index:number, length: number, str: string][] = []
+  
+  let match
+  while ((match = includes.exec(code)) !== null) {
+    // This is necessary to avoid infinite loops with zero-width matches
+    if (match.index === includes.lastIndex) {
+      includes.lastIndex++
+    }
+    const key = match[1]
+    const replaceWith = _map.get(key)
+
+    if (!replaceWith) {
+      const msg = `Could not find an includes with the key: '${key}'.\nThere is: ${[..._map.keys()]}.`
+      throw new Error(msg)
+    }
+
+    toReplace.push([match.index, match[0].length, replaceWith])
+  }
+
+  let newCode = code.toString()
+  // Go backwards through the found changes so that we can retain index position
+  toReplace.reverse().forEach(r => {
+    newCode = newCode.substring(0, r[0]) + r[2] + newCode.substring(r[0] + r[1])
+  })
+  return newCode
+}

--- a/packages/remark-shiki-twoslash/test/includes.test.ts
+++ b/packages/remark-shiki-twoslash/test/includes.test.ts
@@ -1,0 +1,35 @@
+import { addIncludes, replaceIncludesInCode } from "../src/includes"
+
+const multiExample = `
+const a = 1
+// - 1
+const b = 2
+// - 2
+const c = 3
+`
+
+it("creates a set of examples", () => {
+  const map = new Map()
+  addIncludes(map, multiExample, "include main")
+  expect(map.size == 3)
+
+  expect(map.get("main")).toContain("const c")
+  expect(map.get("main-1")).toContain("const a = 1")
+  expect(map.get("main-2")).toContain("const b = 2")
+})
+
+it("replaces the code", () => {
+  const map = new Map()
+  addIncludes(map, multiExample, "include main")
+  expect(map.size == 3)
+
+  const sample = `// @include: main`
+  const replaced = replaceIncludesInCode(map, sample)
+  expect(replaced).toMatchInlineSnapshot(`
+    "
+    const a = 1
+    const b = 2
+    const c = 3
+    "
+  `)
+})

--- a/packages/remark-shiki-twoslash/test/mdx.test.ts
+++ b/packages/remark-shiki-twoslash/test/mdx.test.ts
@@ -1,40 +1,60 @@
 const mdx = require("@mdx-js/mdx")
 import remarkShikiTwoslash from "../src"
 
+const transpile = async (str: string) => {
+  const jsx = await mdx(str, {
+    filepath: "file/path/file.mdx",
+    remarkPlugins: [[remarkShikiTwoslash, { theme: "dark-plus" }]],
+  })
+  return jsx
+}
+
 it("renders twoslash", async () => {
   const content = `
-  # Hello, world!
+# Hello, world!
 
-  \`\`\`ts twoslash
-  const a = '123'
-  \`\`\`
+\`\`\`ts twoslash
+const a = '123'
+\`\`\`
   `
-  const transpile = async () => {
-    const jsx = await mdx(content, {
-      filepath: "file/path/file.mdx",
-      remarkPlugins: [remarkShikiTwoslash],
-    })
-    return jsx
-  }
-  const res = await transpile()
+  const res = await transpile(content)
   expect(res).toContain("shiki twoslash lsp")
 })
 
 it("renders twoslash with settings", async () => {
   const content = `
-  # Hello, world!
+# Hello, world!
 
-  \`\`\`ts twoslash
-  const a = '123'
-  \`\`\`
+\`\`\`ts twoslash
+const a = '123'
+\`\`\`
   `
-  const transpile = async () => {
-    const jsx = await mdx(content, {
-      filepath: "file/path/file.mdx",
-      remarkPlugins: [[remarkShikiTwoslash, { theme: "dark-plus" }]],
-    })
-    return jsx
-  }
-  const res = await transpile()
+
+  const res = await transpile(content)
   expect(res).toContain("shiki twoslash lsp")
+})
+
+it("handles includes", async () => {
+  const content = `
+# Hello, world!
+
+\`\`\`twoslash include main
+const a = 1
+// - 1
+const b = 2
+// - 2
+const c= 3
+\`\`\`
+
+OK
+
+\`\`\`ts twoslash
+// @include: main
+c.toString()
+\`\`\`
+`
+  const res = await transpile(content)
+  expect(res).toContain("shiki twoslash lsp")
+
+  // This would bail if the include did not work (because c would not exist in the code sample)
 })


### PR DESCRIPTION
I was converting a blog to use twoslash and came to the conclusion that whilst for the TypeScript repo having each code sample as perfectly isolated is fine, it's much less useful in other sites. 

> Once you start writing long articles, you'll start to feel the desire to remove repetition in your code samples. This plugin adds the ability to import code into code samples. This is a string replacement before code is passed to twoslash. This is done by making a `twoslash include` code sample which is given a unique identifier.

> Inside that code-block, you can use `// - [id]` to make sub-queries to the import, these will be stripped out in the code show. Here's an example markdown file using `includes`:

````markdown
# Hello, world!

```twoslash include main
const a = 1
// - 1
const b = 2
// - 2
const c= 3
```

Let's talk a bit about `a`:

```ts twoslash
// @include: main-1
```

`a` can be added to another number

```ts twoslash
// @include: main-1
// ---cut---
const nextA = a + 13
```

You can see what happens when you add `a + b`

```ts twoslash
// @include: main-2
// ---cut---
const result = a + b
//    ^?
```

Finally here is `c`:

```ts twoslash
// @include: main
// ---cut---
c.toString()
```
````
