### PR TITLE
Add new plugins for static site builders

### DIFF
--- a/packages/docusaurus-preset-shiki-twoslash/LICENSE
+++ b/packages/docusaurus-preset-shiki-twoslash/LICENSE
@@ -1,0 +1,17 @@
+The MIT License (MIT)
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the "Software"), to deal in the Software without restriction, 
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, 
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial 
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT 
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/docusaurus-preset-shiki-twoslash/README.md
+++ b/packages/docusaurus-preset-shiki-twoslash/README.md
@@ -1,0 +1,25 @@
+### Docusaurus Preset Shiki Twoslash
+
+Sets up markdown code blocks to run through [shiki](https://shiki.matsu.io) which means it gets the VS Code quality
+syntax highlighting mixed with the twoslash JavaScript tooling from the TypeScript website.
+
+#### Setup
+
+1. **Install the dependency**: `yarn add docusaurus-preset-shiki-twoslash`
+1. **Include `"docusaurus-preset-shiki-twoslash"` in the presets section** of `docusaurus.config.js`
+
+   ```diff
+     presets: [
+    [
+      '@docusaurus/preset-classic',
+      {
+        // ...
+      },
+    ],
+    + ["docusaurus-preset-shiki-twoslash", { theme: "nord" }]
+   ],
+
+   ```
+
+1. This will automatically add your CSS, and JS to handle hovers
+1. **Go read [npmjs.com/package/remark-shiki-twoslash](https://www.npmjs.com/package/remark-shiki-twoslash)** to see what is available, this package leaves all the heavy work to that module.

--- a/packages/docusaurus-preset-shiki-twoslash/index.d.ts
+++ b/packages/docusaurus-preset-shiki-twoslash/index.d.ts
@@ -1,0 +1,2 @@
+import type { UserConfigSettings } from "shiki-twoslash"
+export default function (settings: UserConfigSettings): any

--- a/packages/docusaurus-preset-shiki-twoslash/index.js
+++ b/packages/docusaurus-preset-shiki-twoslash/index.js
@@ -1,0 +1,34 @@
+function theme(context, pluginOptions) {
+  // So, how do we hijack the code renderer? We mostly override the user's configuration for
+  // preset classic.
+
+  const preset = context.siteConfig.presets.find(p => p[0] === "@docusaurus/preset-classic")
+  if (!preset) throw new Error("Couldn't find a preset of @docusaurus/preset-classic")
+
+  // Step 1 - Add the remark pre-processor to the three sections it should be in
+  const keys = ["docs", "blog", "pages"]
+  for (const key of keys) {
+    if (!preset[1][key]) preset[1][key] = {}
+    if (!preset[1][key].beforeDefaultRemarkPlugins) preset[1][key].beforeDefaultRemarkPlugins = []
+
+    // Add to before - because otherwise it would have been set by the existing code syntax renderer
+    // now all they have is divs which will NOOP
+    preset[1][key].beforeDefaultRemarkPlugins.push([require("remark-shiki-twoslash").default, pluginOptions])
+  }
+
+  // Step 2 - Add the CSS
+  if (!preset[1].theme) preset[1].theme = {}
+  const existingCSS = preset[1].theme.customCss
+  let newCSS = [require.resolve("docusaurus-plugin-shiki-twoslash/twoslash.css")]
+  if (existingCSS && typeof existingCSS === "string") newCSS.push(existingCSS)
+  if (existingCSS && typeof existingCSS === "object") newCSS = newCSS.concat(existingCSS)
+  preset[1].theme.customCss = newCSS
+
+  // Step 3 - Inject the hover via the internal 'theme' - this is a real nasty hack
+  return {
+    name: "docusaurus-preset-shiki-twoslash",
+    plugins: [require.resolve("./shiki-twoslash-theme")],
+  }
+}
+
+module.exports = theme

--- a/packages/docusaurus-preset-shiki-twoslash/package.json
+++ b/packages/docusaurus-preset-shiki-twoslash/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "docusaurus-preset-shiki-twoslash",
+  "version": "1.0.0",
+  "license": "MIT",
+  "homepage": "https://github.com/microsoft/TypeScript-Website",
+  "repository": {
+    "url": "https://github.com/microsoft/TypeScript-Website.git",
+    "directory": "packages/docusaurus-preset-shiki-twoslash",
+    "type": "git"
+  },
+  "bugs": {
+    "url": "https://github.com/microsoft/TypeScript-Website/issues"
+  },
+  "description": "An Docusaurus plugin which adds shiki with optional twoslash-powered code samples",
+  "author": "Orta Therox",
+  "main": "./index.js",
+  "typings": "./index.d.ts",
+  "scripts": {
+    "bootstrap": "echo 'NOOP'",
+    "build": "echo 'NOOP'",
+    "test": "echo 'NOOP'",
+    "lint": "echo 'NOOP'"
+  },
+  "dependencies": {
+    "remark-shiki-twoslash": "1.3.0",
+    "typescript": "*"
+  }
+}

--- a/packages/docusaurus-preset-shiki-twoslash/twoslash.css
+++ b/packages/docusaurus-preset-shiki-twoslash/twoslash.css
@@ -1,0 +1,224 @@
+/* Code blocks look like: 
+   <pre class='shiki [theme-name] twoslash'>
+    <div class='language-id>[lang-id]</div>
+    <div class='code-container'>
+       <code>
+        <div class='line'>[the code as a series of spans]</div>
+       </code>
+    </div>
+   </pre> 
+   */
+pre {
+  /* Give the text some space to breathe */
+  padding: 12px;
+  /* All code samples get a grey border, twoslash ones get a different color */
+  border-left: 1px solid #999;
+  border-bottom: 1px solid #999;
+  margin-bottom: 3rem;
+  /* Important to allow the code to move horizontally;
+   */
+  overflow: auto;
+  /* So that folks know you can highlight */
+  position: relative;
+}
+pre.shiki {
+  overflow: initial;
+}
+pre.shiki:hover .dim {
+  opacity: 1;
+}
+pre.shiki div.dim {
+  opacity: 0.5;
+}
+pre.shiki div.dim,
+pre.shiki div.highlight {
+  margin: 0;
+  padding: 0;
+}
+pre.shiki div.highlight {
+  opacity: 1;
+  background-color: #f1f8ff;
+}
+pre.shiki div.line {
+  min-height: 1rem;
+}
+pre.twoslash {
+  border-color: #719af4;
+}
+pre .code-container {
+  overflow: auto;
+}
+pre .code-container > a {
+  position: absolute;
+  right: 8px;
+  bottom: 8px;
+  border-radius: 4px;
+  border: 1px solid #719af4;
+  padding: 0 8px;
+  color: #719af4;
+  text-decoration: none;
+  opacity: 0;
+  transition-timing-function: ease;
+  transition: opacity 0.3s;
+}
+@media (prefers-reduced-motion: reduce) {
+  pre .code-container > a {
+    transition: none;
+  }
+}
+pre .code-container > a:hover {
+  color: white;
+  background-color: #719af4;
+}
+pre .code-container:hover a {
+  opacity: 1;
+}
+pre code {
+  /** Style setup */
+  font-size: 15px;
+  font-family: var(--code-font);
+  white-space: pre;
+  -webkit-overflow-scrolling: touch;
+}
+pre code a {
+  text-decoration: none;
+}
+pre data-err {
+  background: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23c94824'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E")
+    repeat-x bottom left;
+  padding-bottom: 3px;
+}
+pre .query {
+  margin-bottom: 10px;
+  color: #137998;
+  display: inline-block;
+}
+pre .error,
+pre .error-behind {
+  margin-left: -14px;
+  margin-top: 8px;
+  margin-bottom: 4px;
+  padding: 6px;
+  padding-left: 14px;
+  width: calc(100% - 19px);
+  white-space: pre-wrap;
+  display: block;
+}
+pre .error {
+  position: absolute;
+  background-color: #fee;
+  border-left: 2px solid #bf1818;
+  /* Give the space to the error code */
+  display: flex;
+  align-items: center;
+  color: black;
+}
+pre .error .code {
+  display: none;
+}
+pre .error-behind {
+  user-select: none;
+  color: #fee;
+}
+pre .arrow {
+  /* Transparent background */
+  background-color: #eee;
+  position: relative;
+  top: -7px;
+  margin-left: 0.1rem;
+  /* Edges */
+  border-left: 1px solid #eee;
+  border-top: 1px solid #eee;
+  transform: translateY(25%) rotate(45deg);
+  /* Size */
+  height: 8px;
+  width: 8px;
+}
+pre .popover {
+  margin-bottom: 10px;
+  background-color: #eee;
+  display: inline-block;
+  padding: 0 0.5rem 0.3rem;
+  margin-top: 10px;
+  border-radius: 3px;
+}
+pre .inline-completions ul.dropdown {
+  display: inline-block;
+  position: absolute;
+  width: 240px;
+  background-color: gainsboro;
+  color: grey;
+  padding-top: 4px;
+  font-family: "JetBrains Mono", Menlo, Monaco, Consolas, Courier New, monospace;
+  font-size: 0.8rem;
+  margin: 0;
+  padding: 0;
+  border-left: 4px solid #4b9edd;
+}
+pre .inline-completions ul.dropdown::before {
+  background-color: #4b9edd;
+  width: 2px;
+  position: absolute;
+  top: -1.2rem;
+  left: -3px;
+  content: " ";
+}
+pre .inline-completions ul.dropdown li {
+  overflow-x: hidden;
+  padding-left: 4px;
+  margin-bottom: 4px;
+}
+pre .inline-completions ul.dropdown li.deprecated {
+  text-decoration: line-through;
+}
+pre .inline-completions ul.dropdown li span.result-found {
+  color: #4b9edd;
+}
+pre .inline-completions ul.dropdown li span.result {
+  width: 100px;
+  color: black;
+  display: inline-block;
+}
+.dark-theme .markdown pre {
+  background-color: #d8d8d8;
+  border-color: #ddd;
+  filter: invert(98%) hue-rotate(180deg);
+}
+data-lsp {
+  /* Ensures there's no 1px jump when the hover happens above */
+  border-bottom: 1px dotted transparent;
+  /* Fades in unobtrusively */
+  transition-timing-function: ease;
+  transition: border-color 0.3s;
+  /* Respect people's wishes to not have animations */
+}
+@media (prefers-reduced-motion: reduce) {
+  data-lsp {
+    transition: none;
+  }
+}
+/** When you mouse over the pre, show the underlines */
+pre:hover data-lsp {
+  border-color: #747474;
+}
+/** The tooltip-like which provides the LSP response */
+#twoslash-mouse-hover-info {
+  background-color: #3f3f3f;
+  color: #fff;
+  text-align: left;
+  padding: 5px 8px;
+  border-radius: 2px;
+  font-family: "Cascadia Mono-SemiLight", "JetBrains Mono", Menlo, Monaco, Consolas, Courier New, monospace;
+  font-size: 14px;
+  white-space: pre-wrap;
+  border-radius: 2px;
+  z-index: 100;
+  pointer-events: none;
+}
+/* These are probably annoying to most others */
+.shiki.playground-link {
+  display: none;
+}
+.shiki.language-id {
+  display: none;
+}

--- a/packages/eleventy-plugin-shiki-twoslash/LICENSE
+++ b/packages/eleventy-plugin-shiki-twoslash/LICENSE
@@ -1,0 +1,17 @@
+The MIT License (MIT)
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the "Software"), to deal in the Software without restriction, 
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, 
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial 
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT 
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/eleventy-plugin-shiki-twoslash/README.md
+++ b/packages/eleventy-plugin-shiki-twoslash/README.md
@@ -1,0 +1,19 @@
+### Eleventy Shiki Twoslash
+
+Sets up markdown code blocks to run through [shiki](https://shiki.matsu.io) which means it gets the VS Code quality
+syntax highlighting mixed with the twoslash JavaScript tooling from the TypeScript website.
+
+#### Setup
+
+1. **Install the dependency**: `yarn add eleventy-plugin-shiki-twoslash`
+1. **Include `"eleventy-plugin-shiki-twoslash"` in the plugins section** of `.eleventy.js`
+
+   ```ts
+   const shikiTwoslash = require("eleventy-plugin-shiki-twoslash")
+
+   module.exports = function (eleventyConfig) {
+     eleventyConfig.addPlugin(shikiTwoslash, { theme: "nord" })
+   }
+   ```
+
+1. **Go read [npmjs.com/package/remark-shiki-twoslash](https://www.npmjs.com/package/remark-shiki-twoslash)** to see the next steps, and what is available, this module leaves all the heavy work to that module.

--- a/packages/eleventy-plugin-shiki-twoslash/index.d.ts
+++ b/packages/eleventy-plugin-shiki-twoslash/index.d.ts
@@ -1,0 +1,2 @@
+import type { UserConfigSettings } from "shiki-twoslash"
+export default function (settings: UserConfigSettings): any

--- a/packages/eleventy-plugin-shiki-twoslash/index.js
+++ b/packages/eleventy-plugin-shiki-twoslash/index.js
@@ -1,0 +1,29 @@
+// @ts-check
+const { setupForFile, transformAttributesToHTML } = require("remark-shiki-twoslash")
+const { sleep } = require("deasync")
+
+/**
+ * @param {*} eleventyConfig
+ * @param {import("shiki-twoslash").UserConfigSettings} options
+ */
+module.exports = function (eleventyConfig, options = {}) {
+  /** @type {import("shiki").Highlighter[]} */
+  let highlighters = undefined
+  setupForFile(options).then(h => (highlighters = h.highlighters))
+
+  if (!highlighters) {
+    let count = 10000 / 200
+    while (!highlighters) {
+      sleep(200)
+      count -= 1
+      if (count <= 0)
+        throw new Error(
+          "Could not get Shiki loaded async via 'deasync'. 11ty doesn't have an API for async plugins, and Shiki needs this for the WASM syntax highlighter. You can try using a different version of node, or requesting APIs at https://github.com/11ty/eleventy"
+        )
+    }
+  }
+
+  eleventyConfig.addMarkdownHighlighter((code, lang, fence) =>
+    transformAttributesToHTML(code, lang, fence, highlighters, options)
+  )
+}

--- a/packages/eleventy-plugin-shiki-twoslash/package.json
+++ b/packages/eleventy-plugin-shiki-twoslash/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "eleventy-plugin-shiki-twoslash",
+  "version": "1.0.0",
+  "license": "MIT",
+  "homepage": "https://github.com/microsoft/TypeScript-Website",
+  "repository": {
+    "url": "https://github.com/microsoft/TypeScript-Website.git",
+    "directory": "packages/eleventy-plugin-shiki-twoslash",
+    "type": "git"
+  },
+  "bugs": {
+    "url": "https://github.com/microsoft/TypeScript-Website/issues"
+  },
+  "description": "An 11ty plugin which adds shiki with optional twoslash-powered code samples",
+  "author": "Orta Therox",
+  "main": "./index.js",
+  "typings": "./index.d.ts",
+  "scripts": {
+    "bootstrap": "echo 'NOOP'",
+    "build": "echo 'NOOP'",
+    "test": "echo 'NOOP'",
+    "lint": "echo 'NOOP'"
+  },
+  "dependencies": {
+    "remark-shiki-twoslash": "1.3.0",
+    "typescript": "*"
+  }
+}

--- a/packages/remark-shiki-twoslash/package.json
+++ b/packages/remark-shiki-twoslash/package.json
@@ -31,7 +31,7 @@
     "@typescript/twoslash": "1.1.7",
     "@typescript/vfs": "1.3.4",
     "shiki": "^0.9.3",
-    "shiki-twoslash": "1.3.0",
+    "shiki-twoslash": "1.3.1",
     "tslib": "2.1.0",
     "typescript": "*",
     "unist-util-visit": "^2.0.0"

--- a/packages/shiki-twoslash/package.json
+++ b/packages/shiki-twoslash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shiki-twoslash",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "homepage": "https://github.com/microsoft/TypeScript-Website",
   "repository": {

--- a/packages/vuepress-plugin-shiki-twoslash/LICENSE
+++ b/packages/vuepress-plugin-shiki-twoslash/LICENSE
@@ -1,0 +1,17 @@
+The MIT License (MIT)
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the "Software"), to deal in the Software without restriction, 
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, 
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial 
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT 
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/vuepress-plugin-shiki-twoslash/README.md
+++ b/packages/vuepress-plugin-shiki-twoslash/README.md
@@ -1,0 +1,28 @@
+### VuePress Shiki Twoslash
+
+Sets up markdown code blocks to run through [shiki](https://shiki.matsu.io) which means it gets the VS Code quality
+syntax highlighting mixed with the twoslash JavaScript tooling from the TypeScript website.
+
+#### Setup
+
+1. **Install the dependency**: `yarn add vuepress-shiki-twoslash`
+1. **Include `"vuepress-shiki-twoslash"` in the plugins section** of `./vuepress/config.ts`
+
+   ```diff
+   + import vuepressShikiTwoslash from "vuepress-shiki-twoslash"
+
+   export default defineUserConfig<DefaultThemeOptions>({
+     lang: 'en-US',
+     title: 'Hello VuePress',
+     description: 'Just playing around',
+
+     themeConfig: {
+       logo: 'https://vuejs.org/images/logo.png',
+     },
+   + plugins: [
+   +   [vuepressShikiTwoslash, { theme: "nord" }]
+   + ]
+   })
+   ```
+
+1. **Go read [npmjs.com/package/remark-shiki-twoslash](https://www.npmjs.com/package/remark-shiki-twoslash)** to see what is available, this module leaves all the heavy work to that module.

--- a/packages/vuepress-plugin-shiki-twoslash/index.d.ts
+++ b/packages/vuepress-plugin-shiki-twoslash/index.d.ts
@@ -1,0 +1,2 @@
+import type { UserConfigSettings } from "shiki-twoslash"
+export default function (settings: UserConfigSettings): any

--- a/packages/vuepress-plugin-shiki-twoslash/index.js
+++ b/packages/vuepress-plugin-shiki-twoslash/index.js
@@ -1,0 +1,12 @@
+console.log({ a: require("markdown-it-shiki-twoslash") })
+const { markdownItShikiTwoslashSetup } = require("markdown-it-shiki-twoslash")
+
+module.exports = settings => ({
+  name: "vuepress-plugin-shiki-twoslash",
+  extendsMarkdown: async md => {
+    console.log({ a: require("markdown-it-shiki-twoslash") })
+
+    const shiki = await markdownItShikiTwoslashSetup(settings)
+    md.use(shiki)
+  },
+})

--- a/packages/vuepress-plugin-shiki-twoslash/package.json
+++ b/packages/vuepress-plugin-shiki-twoslash/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "vuepress-plugin-shiki-twoslash",
+  "version": "1.0.0",
+  "license": "MIT",
+  "homepage": "https://github.com/microsoft/TypeScript-Website",
+  "repository": {
+    "url": "https://github.com/microsoft/TypeScript-Website.git",
+    "directory": "packages/vuepress-plugin-shiki-twoslash",
+    "type": "git"
+  },
+  "bugs": {
+    "url": "https://github.com/microsoft/TypeScript-Website/issues"
+  },
+  "description": "A VuePress plugin which adds shiki with optional twoslash-powered code samples",
+  "author": "Orta Therox",
+  "main": "./index.js",
+  "typings": "./index.d.ts",
+  "scripts": {
+    "bootstrap": "echo 'NOOP'",
+    "build": "echo 'NOOP'",
+    "test": "echo 'NOOP'",
+    "lint": "echo 'NOOP'"
+  },
+  "dependencies": {
+    "remark-shiki-twoslash": "1.3.0",
+    "typescript": "*"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9470,6 +9470,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"docusaurus-preset-shiki-twoslash@workspace:packages/docusaurus-preset-shiki-twoslash":
+  version: 0.0.0-use.local
+  resolution: "docusaurus-preset-shiki-twoslash@workspace:packages/docusaurus-preset-shiki-twoslash"
+  dependencies:
+    remark-shiki-twoslash: 1.3.0
+    typescript: "*"
+  languageName: unknown
+  linkType: soft
+
 "dom-converter@npm:^0.2":
   version: 0.2.0
   resolution: "dom-converter@npm:0.2.0"
@@ -9746,6 +9755,15 @@ __metadata:
   checksum: ad363a68f39cecd94483bcd2b0b52e027fe5fdbc8d9623135a2e354a644d80bbe60c4a4e88aa1e505e63ccd18146124ada6dd54c10e62a7fecccdfdf34fb0046
   languageName: node
   linkType: hard
+
+"eleventy-plugin-shiki-twoslash@workspace:packages/eleventy-plugin-shiki-twoslash":
+  version: 0.0.0-use.local
+  resolution: "eleventy-plugin-shiki-twoslash@workspace:packages/eleventy-plugin-shiki-twoslash"
+  dependencies:
+    remark-shiki-twoslash: 1.3.0
+    typescript: "*"
+  languageName: unknown
+  linkType: soft
 
 "elliptic@npm:^6.5.3":
   version: 6.5.4
@@ -12288,7 +12306,7 @@ fsevents@^1.2.7:
   dependencies:
     "@types/jest": ^25.1.3
     rehype-stringify: ^6.0.1
-    remark-shiki-twoslash: 1.2.1
+    remark-shiki-twoslash: 1.3.0
     tsdx: ^0.14.1
     tslib: ^1.10.0
     typescript: "*"
@@ -17682,7 +17700,7 @@ fsevents@^1.2.7:
     markdown-it: ^12.0.6
     markdown-it-shiki: ^0.2.3
     rehype-stringify: ^6.0.1
-    remark-shiki-twoslash: 1.2.1
+    remark-shiki-twoslash: 1.3.0
     tsdx: ^0.14.1
     tslib: ^1.10.0
     typescript: "*"
@@ -22396,7 +22414,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"remark-shiki-twoslash@1.2.1, remark-shiki-twoslash@workspace:packages/remark-shiki-twoslash":
+"remark-shiki-twoslash@1.3.0, remark-shiki-twoslash@workspace:packages/remark-shiki-twoslash":
   version: 0.0.0-use.local
   resolution: "remark-shiki-twoslash@workspace:packages/remark-shiki-twoslash"
   dependencies:
@@ -23687,7 +23705,19 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"shiki-twoslash@1.3.0, shiki-twoslash@workspace:packages/shiki-twoslash":
+"shiki-twoslash@npm:1.3.0":
+  version: 1.3.0
+  resolution: "shiki-twoslash@npm:1.3.0"
+  dependencies:
+    "@typescript/twoslash": 1.1.7
+    "@typescript/vfs": 1.3.4
+    shiki: ^0.9.3
+    typescript: "*"
+  checksum: 7f58c05ef2454f36bf513990cab90fbeb822e61d433dd6bde20f4faabde286e903cdaa678ecbb9fcf5c69bc3e0b096358895bc722af7c0ab649ff89cfbdd68ab
+  languageName: node
+  linkType: hard
+
+"shiki-twoslash@workspace:packages/shiki-twoslash":
   version: 0.0.0-use.local
   resolution: "shiki-twoslash@workspace:packages/shiki-twoslash"
   dependencies:
@@ -26738,6 +26768,15 @@ resolve@^2.0.0-next.3:
   checksum: 5b05dda398cc1df7ba244316ddfb8f6463dbaafb4d23a4ac7e1cb8914e813a464f4ac055e41ac6e60feeadd4cccdeec1111fac592f2bb4eeb320889846a18912
   languageName: node
   linkType: hard
+
+"vuepress-plugin-shiki-twoslash@workspace:packages/vuepress-plugin-shiki-twoslash":
+  version: 0.0.0-use.local
+  resolution: "vuepress-plugin-shiki-twoslash@workspace:packages/vuepress-plugin-shiki-twoslash"
+  dependencies:
+    remark-shiki-twoslash: 1.3.0
+    typescript: "*"
+  languageName: unknown
+  linkType: soft
 
 "w3c-hr-time@npm:^1.0.1, w3c-hr-time@npm:^1.0.2":
   version: 1.0.2


### PR DESCRIPTION
Adds shiki-twoslash support for:

 - 11ty (tested against on the v1 beta) 
 - VuePress (tested on the v2 beta
 - Docusaurus (tested on the v2 beta)