### PR TITLE
revise greet() examples in Object Types.md

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Object Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Object Types.md
@@ -13,7 +13,7 @@ As we've seen, they can be anonymous:
 ```ts twoslash
 function greet(person: { name: string; age: number }) {
   //                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  return "Hello " + person.age;
+  return "Hello " + person.name;
 }
 ```
 
@@ -27,7 +27,7 @@ interface Person {
 }
 
 function greet(person: Person) {
-  return "Hello " + person.age;
+  return "Hello " + person.name;
 }
 ```
 
@@ -41,7 +41,7 @@ type Person = {
 };
 
 function greet(person: Person) {
-  return "Hello " + person.age;
+  return "Hello " + person.name;
 }
 ```
 


### PR DESCRIPTION
I revised the (first three) function greet() examples to return person.name instead of person.age. It seems more intuitive to "greet" a person by name than age. ("Hello Mary" rather than "Hello 27")

Without knowing for certain, it seems plausible that this was the intent of the author and perhaps person.age was used instead by mistake.

URL
https://www.typescriptlang.org/docs/handbook/2/objects.html