### PR TITLE
docs: Everyday Types

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -543,7 +543,7 @@ function printText(s: string, alignment: "left" | "right" | "center") {
   // ...
 }
 printText("Hello, world", "left");
-printText("G'day, mate", "centre");
+printText("G'day, mate", "top");
 ```
 
 Numeric literal types work the same way:


### PR DESCRIPTION
The point of this example was to demonstrate functions that only accept a certain set of known values, not showing some sort of typo mistake, therefore I think it is better to show 'top' rather than 'centre' which resembles general world use cases in a better manner.