### PR TITLE
Fix small typo on page "Conditional Types"

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Conditional Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Conditional Types.md
@@ -79,7 +79,7 @@ type NameOrId<T extends number | string> = T extends number
   : NameLabel;
 ```
 
-We can then use that conditional type to simplify out overloads down to a single function with no overloads.
+We can then use that conditional type to simplify our overloads down to a single function with no overloads.
 
 ```ts twoslash
 interface IdLabel {


### PR DESCRIPTION
Fixes a small typo on the [conditional types page of the handbook](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html).