### PR TITLE
Fix typo in Typescript 3.1.md

### DIFF
--- a/packages/documentation/copy/en/release-notes/TypeScript 3.1.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 3.1.md
@@ -43,7 +43,7 @@ readImage.sync = (path: string) => {
 Here, we have a function `readImage` which reads an image in a non-blocking asynchronous way.
 In addition to `readImage`, we've provided a convenience function on `readImage` itself called `readImage.sync`.
 
-While ECMAScript exports are often a better way of providing this functionality, this new support allows code written in this style to "just work" TypeScript.
+While ECMAScript exports are often a better way of providing this functionality, this new support allows code written in this style to "just work" in TypeScript.
 Additionally, this approach for property declarations allows us to express common patterns like `defaultProps` and `propTypes` on React function components (formerly known as SFCs).
 
 ```ts


### PR DESCRIPTION
Adds a missing word ("in") to this line (emphasis added):

> allows code written in this style to "just work" **in** TypeScript.