### PR TITLE
Reduce prominence of keyof

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Mapped Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Mapped Types.md
@@ -22,7 +22,7 @@ const conforms: OnlyBoolsAndHorses = {
 };
 ```
 
-A mapped type is a generic type which uses a union created [via a `keyof`](/docs/handbook/2/indexed-access-types.html) to iterate through the keys of one type to create another:
+A mapped type is a generic type which uses a union of `PropertyKey`s (frequently created [via a `keyof`](/docs/handbook/2/indexed-access-types.html)) to iterate through keys to create a type:
 
 ```ts twoslash
 type OptionsFlags<Type> = {


### PR DESCRIPTION
Mapped types don't have to use keyof, and implying they do is confusing.