### PR TITLE
Remove typeof in Spritable example

### DIFF
--- a/packages/documentation/copy/en/reference/Mixins.md
+++ b/packages/documentation/copy/en/reference/Mixins.md
@@ -125,7 +125,7 @@ class Sprite {
 }
 // ---cut---
 type Positionable = GConstructor<{ setPos: (x: number, y: number) => void }>;
-type Spritable = GConstructor<typeof Sprite>;
+type Spritable = GConstructor<Sprite>;
 type Loggable = GConstructor<{ print: () => void }>;
 ```
 
@@ -143,7 +143,7 @@ class Sprite {
   }
 }
 type Positionable = GConstructor<{ setPos: (x: number, y: number) => void }>;
-type Spritable = GConstructor<typeof Sprite>;
+type Spritable = GConstructor<Sprite>;
 type Loggable = GConstructor<{ print: () => void }>;
 // ---cut---
 


### PR DESCRIPTION
The parameter `T` is the return type of the constructor, so it should be an object instead of a class.