### PR TITLE
Don't HTML encode error messages in twoslash

### DIFF
--- a/packages/ts-twoslasher/CHANGELOG.md
+++ b/packages/ts-twoslasher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0
+
+- Removes HTML encoding from the Twoslash error rendered results. It's really not the responsibility of Twoslash to do that. I'm classing this as a major semver as folks could be relying on this behavior (all the shiki-twoslash stuff does for example.)
+
 ## 1.1.1
 
 - Better handling of JSON files

--- a/packages/ts-twoslasher/package.json
+++ b/packages/ts-twoslasher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript/twoslash",
-  "version": "1.1.7",
+  "version": "2.0.0",
   "license": "MIT",
   "author": "TypeScript team",
   "homepage": "https://github.com/microsoft/TypeScript-Website",

--- a/packages/ts-twoslasher/src/index.ts
+++ b/packages/ts-twoslasher/src/index.ts
@@ -12,7 +12,6 @@ type CustomTransformers = import("typescript").CustomTransformers
 
 import {
   parsePrimitive,
-  escapeHtml,
   cleanMarkdownEscaped,
   typesToExtension,
   stringAroundIndex,
@@ -629,7 +628,7 @@ export function twoslasher(code: string, extension: string, options: TwoSlashOpt
   for (const err of relevantErrors) {
     const codeWhereErrorLives = env.sys.readFile(err.file!.fileName)!
     const fileContentStartIndexInModifiedFile = code.indexOf(codeWhereErrorLives)
-    const renderedMessage = escapeHtml(ts.flattenDiagnosticMessageText(err.messageText, "\n"))
+    const renderedMessage = ts.flattenDiagnosticMessageText(err.messageText, "\n")
     const id = `err-${err.code}-${err.start}-${err.length}`
     const { line, character } = ts.getLineAndCharacterOfPosition(err.file!, err.start!)
 

--- a/packages/ts-twoslasher/test/fixtures/errorsWithGenerics.ts
+++ b/packages/ts-twoslasher/test/fixtures/errorsWithGenerics.ts
@@ -1,0 +1,4 @@
+// @errors: 2322
+const a: Record<string, string> = {}
+let b: Record<string, number> = {}
+b = a

--- a/packages/ts-twoslasher/test/results/errorsWithGenerics.json
+++ b/packages/ts-twoslasher/test/results/errorsWithGenerics.json
@@ -1,0 +1,75 @@
+{
+  "code": "const a: Record<string, string> = {}\nlet b: Record<string, number> = {}\nb = a\n",
+  "extension": "ts",
+  "highlights": [],
+  "queries": [],
+  "staticQuickInfos": [
+    {
+      "text": "const a: Record<string, string>",
+      "docs": "",
+      "start": 6,
+      "length": 1,
+      "line": 0,
+      "character": 6,
+      "targetString": "a"
+    },
+    {
+      "text": "type Record<K extends string | number | symbol, T> = { [P in K]: T; }",
+      "docs": "Construct a type with a set of properties K of type T",
+      "start": 9,
+      "length": 6,
+      "line": 0,
+      "character": 9,
+      "targetString": "Record"
+    },
+    {
+      "text": "let b: Record<string, number>",
+      "docs": "",
+      "start": 41,
+      "length": 1,
+      "line": 1,
+      "character": 4,
+      "targetString": "b"
+    },
+    {
+      "text": "type Record<K extends string | number | symbol, T> = { [P in K]: T; }",
+      "docs": "Construct a type with a set of properties K of type T",
+      "start": 44,
+      "length": 6,
+      "line": 1,
+      "character": 7,
+      "targetString": "Record"
+    },
+    {
+      "text": "let b: Record<string, number>",
+      "docs": "",
+      "start": 72,
+      "length": 1,
+      "line": 2,
+      "character": 0,
+      "targetString": "b"
+    },
+    {
+      "text": "const a: Record<string, string>",
+      "docs": "",
+      "start": 76,
+      "length": 1,
+      "line": 2,
+      "character": 4,
+      "targetString": "a"
+    }
+  ],
+  "errors": [
+    {
+      "category": 1,
+      "code": 2322,
+      "length": 1,
+      "start": 72,
+      "line": 2,
+      "character": 0,
+      "renderedMessage": "Type 'Record<string, string>' is not assignable to type 'Record<string, number>'.\n  Index signatures are incompatible.\n    Type 'string' is not assignable to type 'number'.",
+      "id": "err-2322-72-1"
+    }
+  ],
+  "playgroundURL": "https://www.typescriptlang.org/play/#code/PTAEAEFMCdoe2gZwFygEwGY1oFAGM4A7RAF1AENUAlSA6AEwB5ToBLQgcwBpQX2OAfKAC8oAN4BfHABtIZAEbVaCJn049CAVwC28mENGSc8kRRxA"
+}

--- a/packages/typescriptlang-org/package.json
+++ b/packages/typescriptlang-org/package.json
@@ -24,7 +24,7 @@
     "@types/react-helmet": "^5.0.15",
     "@typescript/playground": "0.1.0",
     "@typescript/sandbox": "0.1.0",
-    "@typescript/twoslash": "1.1.7",
+    "@typescript/twoslash": "2.0.0",
     "canvas": "^2.6.1",
     "gatsby": "^3.2.1",
     "gatsby-link": "3.2.0",


### PR DESCRIPTION
The Shiki Twoslash world will need an update for this, but I think the tests for this bug were in those libs anyway