### PR TITLE
Adjust "The in operator narrowing" heading level

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Narrowing.md
+++ b/packages/documentation/copy/en/handbook-v2/Narrowing.md
@@ -271,7 +271,7 @@ function multiplyValue(container: Container, factor: number) {
 }
 ```
 
-### The `in` operator narrowing
+## The `in` operator narrowing
 
 Javascript has an operator for determining if an object has a property with a name: the `in` operator.
 TypeScript takes this into account as a way to narrow down potential types.


### PR DESCRIPTION
"The in operator narrowing" header must be one step larger to match the other headers on this page. Otherwise the user thinks it is a subheader.