### PR TITLE
Adjust "Enums" + "Less Common Primitives" heading

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -670,11 +670,11 @@ function liveDangerously(x?: number | null) {
 
 Just like other type assertions, this doesn't change the runtime behavior of your code, so it's important to only use `!` when you know that the value _can't_ be `null` or `undefined`.
 
-### Enums
+## Enums
 
 Enums are a feature added to JavaScript by TypeScript which allows for describing a value which could be one of a set of possible named constants. Unlike most TypeScript features, this is _not_ a type-level addition to JavaScript but something added to the language and runtime. Because of this, it's a feature which you should know exists, but maybe hold off on using unless you are sure. You can read more about enums in the [Enum reference page](/docs/handbook/enums.html).
 
-### Less Common Primitives
+## Less Common Primitives
 
 It's worth mentioning the rest of the primitives in JavaScript which are represented in the type system.
 Though we will not go into depth here.


### PR DESCRIPTION
On the Everyday Types page the section of "null and undefined" also includes "Enums" + "Less Common Primitives" as sub-sections. Is this intentional? The "null and undefined" section title doesn't really make sense for these sub-sections.

I propose moving the  "Enums" + "Less Common Primitives" to separate sections.