### PR TITLE
Case adjust

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -413,7 +413,7 @@ type Animal = {
   name: string
 }<br/>
 type Bear = Animal & { 
-  honey: Boolean 
+  honey: boolean 
 }<br/>
 const bear = getBear();
 bear.name;


### PR DESCRIPTION
According to its own documentation, the `boolean` type should be in lowercase, right?

> The type names `String`, `Number`, and `Boolean` (starting with capital letters) are legal, but refer to some special built-in types that will very rarely appear in your code. _Always_ use `string`, `number`, or `boolean` for types.