### PR TITLE
Updated ASP.NET Core.md

### DIFF
--- a/packages/documentation/copy/en/tutorials/ASP.NET Core.md
+++ b/packages/documentation/copy/en/tutorials/ASP.NET Core.md
@@ -158,8 +158,9 @@ gulp.task("clean", function () {
   return del(["wwwroot/scripts/**/*"]);
 });
 
-gulp.task("default", function () {
-  gulp.src(paths.scripts).pipe(gulp.dest("wwwroot/scripts"));
+gulp.task("default", function (done) {
+    gulp.src(paths.scripts).pipe(gulp.dest("wwwroot/scripts"));
+    done();
 });
 ```
 


### PR DESCRIPTION
Without returning an async completion signal, the Task Runner throws an error like below - 

```
[16:34:30] Starting 'default'...
[16:34:30] The following tasks did not complete: default
[16:34:30] Did you forget to signal async completion?
Process terminated with code 1.
```

We can fix this issue by invoking the default callback function.