### PR TITLE
Remove unnecessay interface Dog declaration

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Conditional Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Conditional Types.md
@@ -128,10 +128,6 @@ interface Email {
   message: string;
 }
 
-interface Dog {
-  bark(): void;
-}
-
 type EmailMessageContents = MessageOf<Email>;
 //   ^?
 ```


### PR DESCRIPTION
I think the `interface Dog` is unnecessary in this snippet. It is actually confusing. It is only needed in the next snippet.