### PR TITLE
Improve documentation for useUnknownInCatchVariables

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/useUnknownInCatchVariables.md
+++ b/packages/tsconfig-reference/copy/en/options/useUnknownInCatchVariables.md
@@ -18,4 +18,4 @@ try {
 }
 ```
 
-This pattern ensures that error handling code becomes more comprehensive because you cannot guarantee that the object being thrown _is_ a Error subclass ahead of time. With the flag `useUnknownInCatchVariables` enabled, then you do not need the additional syntax (`: unknown`) nor a linter rule to try enforce this behavior.
+This pattern ensures that error handling code becomes more comprehensive because you cannot guarantee that the object being thrown _is_ an Error subclass ahead of time. With the flag `useUnknownInCatchVariables` enabled, you do not need the additional syntax (`: unknown`) nor a linter rule to try enforce this behavior.


### PR DESCRIPTION
This PR fixes the grammar in the description of `useUnknownInCatchVariables` option.

I wanted to fix the rendering issue too **(the backticks in the first line)** but wasn't able to find the cause:

![TSConfig Reference - Docs on every TSConfig option](https://user-images.githubusercontent.com/51517103/124629217-db471580-de9e-11eb-8464-0b3e7ef02d4c.png)



ℹ️ A slightly smaller issue: shouldn't it show `(error: unknown)` without any need to hover over it?