### PR TITLE
Fix typo in sandbox console.log

### DIFF
--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -192,7 +192,7 @@ export const createTypeScriptSandbox = (
 
     if (config.supportTwoslashCompilerOptions) {
       const configOpts = getTwoSlashComplierOptions(code)
-      console.log("twoslahs", configOpts)
+      console.log("twoslash", configOpts)
       updateCompilerSettings(configOpts)
     }
 


### PR DESCRIPTION
(Would it be better to remove this log entirely, or is it desired?)