### PR TITLE
Update references to `master`

### DIFF
--- a/packages/documentation/copy/en/Nightly Builds.md
+++ b/packages/documentation/copy/en/Nightly Builds.md
@@ -6,7 +6,7 @@ oneline: How to use a nightly build of TypeScript
 translatable: true
 ---
 
-A nightly build from the [TypeScript's `master`](https://github.com/Microsoft/TypeScript/tree/master) branch is published by midnight PST to npm.
+A nightly build from the [TypeScript's `main`](https://github.com/Microsoft/TypeScript/tree/main) branch is published by midnight PST to npm.
 Here is how you can get it and use it with your tools.
 
 ## Using npm
@@ -49,7 +49,7 @@ More information is available at the [TypeScript Plugin for Sublime Text install
 
 The nightly build currently does not include the full plugin setup, but we are working on publishing an installer on a nightly basis as well.
 
-1. Download the [VSDevMode.ps1](https://github.com/Microsoft/TypeScript/blob/master/scripts/VSDevMode.ps1) script.
+1. Download the [VSDevMode.ps1](https://github.com/Microsoft/TypeScript/blob/main/scripts/VSDevMode.ps1) script.
 
    > Also see our wiki page on [using a custom language service file](https://github.com/Microsoft/TypeScript/wiki/Dev-Mode-in-Visual-Studio#using-a-custom-language-service-file).
 

--- a/packages/documentation/copy/en/reference/Module Resolution.md
+++ b/packages/documentation/copy/en/reference/Module Resolution.md
@@ -213,13 +213,13 @@ Value of _baseUrl_ is determined as either:
 
 Note that relative module imports are not impacted by setting the baseUrl, as they are always resolved relative to their importing files.
 
-You can find more documentation on baseUrl in [RequireJS](http://requirejs.org/docs/api.html#config-baseUrl) and [SystemJS](https://github.com/systemjs/systemjs/blob/master/docs/api.md) documentation.
+You can find more documentation on baseUrl in [RequireJS](http://requirejs.org/docs/api.html#config-baseUrl) and [SystemJS](https://github.com/systemjs/systemjs/blob/main/docs/api.md) documentation.
 
 ### Path mapping
 
 Sometimes modules are not directly located under _baseUrl_.
 For instance, an import to a module `"jquery"` would be translated at runtime to `"node_modules/jquery/dist/jquery.slim.min.js"`.
-Loaders use a mapping configuration to map module names to files at run-time, see [RequireJs documentation](http://requirejs.org/docs/api.html#config-paths) and [SystemJS documentation](https://github.com/systemjs/systemjs/blob/master/docs/import-maps.md).
+Loaders use a mapping configuration to map module names to files at run-time, see [RequireJs documentation](http://requirejs.org/docs/api.html#config-paths) and [SystemJS documentation](https://github.com/systemjs/systemjs/blob/main/docs/import-maps.md).
 
 The TypeScript compiler supports the declaration of such mappings using `"paths"` property in `tsconfig.json` files.
 Here is an example for how to specify the `"paths"` property for `jquery`.

--- a/packages/documentation/copy/en/release-notes/TypeScript 2.0.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 2.0.md
@@ -544,7 +544,7 @@ import A from "moduleA";
 ## Path mapping
 
 Sometimes modules are not directly located under _baseUrl_.
-Loaders use a mapping configuration to map module names to files at run-time, see [RequireJs documentation](http://requirejs.org/docs/api.html#config-paths) and [SystemJS documentation](https://github.com/systemjs/systemjs/blob/master/docs/import-maps.md).
+Loaders use a mapping configuration to map module names to files at run-time, see [RequireJs documentation](http://requirejs.org/docs/api.html#config-paths) and [SystemJS documentation](https://github.com/systemjs/systemjs/blob/main/docs/import-maps.md).
 
 The TypeScript compiler supports the declaration of such mappings using `"paths"` property in `tsconfig.json` files.
 
@@ -627,7 +627,7 @@ x(y);
 
 ## Wildcard character in module names
 
-Importing none-code resources using module loaders extension (e.g. [AMD](https://github.com/amdjs/amdjs-api/blob/master/LoaderPlugins.md) or [SystemJS](https://github.com/systemjs/systemjs/blob/master/docs/module-types.md)) has not been easy before;
+Importing none-code resources using module loaders extension (e.g. [AMD](https://github.com/amdjs/amdjs-api/blob/master/LoaderPlugins.md) or [SystemJS](https://github.com/systemjs/systemjs/blob/main/docs/module-types.md)) has not been easy before;
 previously an ambient module declaration had to be defined for each resource.
 
 TypeScript 2.0 supports the use of the wildcard character (`*`) to declare a "family" of module names;

--- a/packages/documentation/copy/en/tutorials/DOM Manipulation.md
+++ b/packages/documentation/copy/en/tutorials/DOM Manipulation.md
@@ -16,7 +16,7 @@ Websites are made up of HTML and/or XML documents. These documents are static, t
 
 TypeScript is a typed superset of JavaScript, and it ships type definitions for the DOM API. These definitions are readily available in any default TypeScript project. Of the 20,000+ lines of definitions in _lib.dom.d.ts_, one stands out among the rest: `HTMLElement` . This type is the backbone for DOM manipulation with TypeScript.
 
-> You can explore the source code for the [DOM type definitions](https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts)
+> You can explore the source code for the [DOM type definitions](https://github.com/microsoft/TypeScript/blob/main/lib/lib.dom.d.ts)
 
 ## Basic Example
 

--- a/packages/playground/README.md
+++ b/packages/playground/README.md
@@ -38,7 +38,7 @@ Then queries tend to be about changing the state of the Playground setup from th
   There are two special cases for the `ts` option:
 
   - `ts=Nightly` where it will switch to most recently the nightly version.
-  - `ts=dev` where it uses your [local developer's build of TypeScript](https://github.com/microsoft/TypeScript/blob/master/scripts/createPlaygroundBuild.js)
+  - `ts=dev` where it uses your [local developer's build of TypeScript](https://github.com/microsoft/TypeScript/blob/main/scripts/createPlaygroundBuild.js)
 
 - `?flag=value` - Any compiler flag referenced in can be set from a query
 - `?filetype=js|ts|dts` - Tells the Playground to set the editor's type

--- a/packages/tsconfig-reference/copy/en/options/lib.md
+++ b/packages/tsconfig-reference/copy/en/options/lib.md
@@ -64,4 +64,4 @@ You may want to change these for a few reasons:
 | `ESNext.Intl`             |
 | `ESNext.Symbol`           |
 
-This list may be out of date, you can see the full list in the [TypeScript source code](https://github.com/microsoft/TypeScript/tree/master/lib).
+This list may be out of date, you can see the full list in the [TypeScript source code](https://github.com/microsoft/TypeScript/tree/main/lib).


### PR DESCRIPTION
All these references have been checked and all remaining references are still valid (haven't been replaced by e.g. `main`)