### PR TITLE
Fix broken link in modules .d.ts

### DIFF
--- a/packages/documentation/copy/en/declaration-files/templates/module.d.ts.md
+++ b/packages/documentation/copy/en/declaration-files/templates/module.d.ts.md
@@ -105,7 +105,7 @@ declare namespace getArrayLength {
 export = getArrayLength;
 ```
 
-See [Module: Functions](module-function.d.ts.md) for details of how that works, and the [Modules reference](/docs/handbook/modules.html) page.
+See [Module: Functions](/docs/handbook/declaration-files/templates/module-function-d-ts.html) for details of how that works, and the [Modules reference](/docs/handbook/modules.html) page.
 
 ## Handling Many Consuming Import
 


### PR DESCRIPTION
The module: functions link on the [Modules .d.ts docs](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html) is broken.

https://user-images.githubusercontent.com/49620737/126084938-9d8d5075-2e89-432d-8906-672010a66358.mp4



This PR fixes this link.

https://user-images.githubusercontent.com/49620737/126085011-46a39c3e-b88d-4b85-9f41-545ec3fde5f0.mp4

