### PR TITLE
Use a simpler technique for declaring we're doing a staging build

### DIFF
--- a/.github/workflows/v2-merged-staging.yml
+++ b/.github/workflows/v2-merged-staging.yml
@@ -26,6 +26,7 @@ jobs:
           yarn install
           yarn docs-sync pull microsoft/TypeScript-Website-localizations#main 1
           yarn bootstrap
+          yarn workspace typescriptlang-org setup-staging
           yarn build
         env:
           YARN_CHECKSUM_BEHAVIOR: ignore
@@ -34,8 +35,6 @@ jobs:
         run: |
           yarn build-site
           cp -r packages/typescriptlang-org/public site
-        env:
-          GATSBY_TYPESCRIPT_SITE_STAGING: true
 
       - name: Deploy + Publish to CDN
         # You can find these keys here:

--- a/packages/typescriptlang-org/package.json
+++ b/packages/typescriptlang-org/package.json
@@ -10,6 +10,7 @@
     "bootstrap": "yarn update-versions",
     "update-static-assets": "node scripts/downloadSearchAssets.js",
     "update-versions": "node scripts/getTypeScriptNPMVersions.js",
+    "setup-staging": "node scripts/setupStaging.mjs",
     "create-lighthouse-json": "node scripts/createLighthouseJSON.js",
     "compile-index-examples": "node scripts/runTwoslashIndexExamples.js light; node scripts/runTwoslashIndexExamples.js dark",
     "start": "TWOSLASH_DISABLE=true gatsby develop",

--- a/packages/typescriptlang-org/scripts/setupStaging.mjs
+++ b/packages/typescriptlang-org/scripts/setupStaging.mjs
@@ -1,0 +1,8 @@
+import fs from "fs"
+
+const toChange = "src/components/HeadSEO.tsx"
+const content = fs
+  .readFileSync(toChange, "utf8")
+  .replace("const staging = false", "const staging = true")
+
+fs.writeFileSync(toChange, content)

--- a/packages/typescriptlang-org/src/components/HeadSEO.tsx
+++ b/packages/typescriptlang-org/src/components/HeadSEO.tsx
@@ -16,8 +16,10 @@ export const HeadSEO = (props: SeoProps) => {
     "twitter:site": "typescriptlang",
   }
 
-  // Skip indexing on the staging site
-  const staging = "process" in globalThis && process && process.env && process.env.GATSBY_TYPESCRIPT_SITE_STAGING
+  // Skip search engine indexing on the staging site, this is changed by running:
+  // yarn workspace typescriptlang-org setup-staging
+  const staging = false;
+
   if (staging) {
     ogTags["robots"] = "noindex"
   }


### PR DESCRIPTION
Staging TS site is pretty high on bing search, the old env var setup seems to work in dev but not during the build process.