### PR TITLE
Adds a cache bust for the playground

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: microsoft/playwright-github-action@v1
 
-      # Install, should be absically instant if cached
+      # Install, should be basically instant if cached
       - run: yarn install
         env:
           YARN_CHECKSUM_BEHAVIOR: ignore

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -24,6 +24,7 @@ jobs:
           yarn install
           yarn docs-sync pull microsoft/TypeScript-Website-localizations#main 1
           yarn bootstrap
+          yarn workspace typescriptlang-org setup-playground-cache-bust
           yarn build
         env:
           YARN_CHECKSUM_BEHAVIOR: ignore

--- a/.github/workflows/v2-merged-staging.yml
+++ b/.github/workflows/v2-merged-staging.yml
@@ -26,6 +26,7 @@ jobs:
           yarn install
           yarn docs-sync pull microsoft/TypeScript-Website-localizations#main 1
           yarn bootstrap
+          yarn workspace typescriptlang-org setup-playground-cache-bust
           yarn workspace typescriptlang-org setup-staging
           yarn build
         env:

--- a/packages/typescriptlang-org/package.json
+++ b/packages/typescriptlang-org/package.json
@@ -10,6 +10,7 @@
     "bootstrap": "yarn update-versions",
     "update-static-assets": "node scripts/downloadSearchAssets.js",
     "update-versions": "node scripts/getTypeScriptNPMVersions.js",
+    "setup-playground-cache-bust": "node scripts/cacheBustPlayground.mjs",
     "setup-staging": "node scripts/setupStaging.mjs",
     "create-lighthouse-json": "node scripts/createLighthouseJSON.js",
     "compile-index-examples": "node scripts/runTwoslashIndexExamples.js light; node scripts/runTwoslashIndexExamples.js dark",

--- a/packages/typescriptlang-org/scripts/cacheBustPlayground.mjs
+++ b/packages/typescriptlang-org/scripts/cacheBustPlayground.mjs
@@ -1,0 +1,35 @@
+// @ts-check
+// yarn workspace typescriptlang-org setup-playground-cache-bust
+
+import fs from "fs"
+import path from "path"
+import { execSync } from "child_process"
+const gitSha = execSync("git rev-parse HEAD").toString().trim().slice(0, 7)
+
+// Change the file
+const toChange = "src/lib/playgroundURLs.ts"
+const content = fs
+  .readFileSync(toChange, "utf8")
+  .replace(`const commitPrefix = "/"`, `const commitPrefix = "/${gitSha}/"`)
+
+if (!content.includes(gitSha)) throw new Error("Could not run cache busting")
+
+fs.writeFileSync(toChange, content)
+
+// https://stackoverflow.com/posts/52338335/revisions
+function copyFolderSync(from, to) {
+  fs.mkdirSync(to, { recursive: true })
+  fs.readdirSync(from).forEach(element => {
+    if (fs.lstatSync(path.join(from, element)).isFile()) {
+      fs.copyFileSync(path.join(from, element), path.join(to, element))
+    } else {
+      copyFolderSync(path.join(from, element), path.join(to, element))
+    }
+  })
+}
+
+// Create a sha copy of the playground and sandbox folders. We want to have
+// a copy (and not just move) because folks rely on the un-prefixed URLs.
+
+copyFolderSync("static/js/playground", `static/js/${gitSha}/playground`)
+copyFolderSync("static/js/sandbox", `static/js/${gitSha}/sandbox`)

--- a/packages/typescriptlang-org/src/lib/playgroundURLs.ts
+++ b/packages/typescriptlang-org/src/lib/playgroundURLs.ts
@@ -5,7 +5,7 @@ export const getPlaygroundUrls = () => {
   // scripts/cacheBustPlayground.mjs
 
   // This should always be a single slash string in the codebase: "/"
-  const commitPrefix = "/06a0e64/"
+  const commitPrefix = "/"
 
   return {
     sandboxRoot: withPrefix(`/js${commitPrefix}sandbox`),

--- a/packages/typescriptlang-org/src/lib/playgroundURLs.ts
+++ b/packages/typescriptlang-org/src/lib/playgroundURLs.ts
@@ -1,0 +1,14 @@
+import { withPrefix } from "gatsby"
+
+export const getPlaygroundUrls = () => {
+  // This will get switched out in CI by:
+  // scripts/cacheBustPlayground.mjs
+
+  // This should always be a single slash string in the codebase: "/"
+  const commitPrefix = "/06a0e64/"
+
+  return {
+    sandboxRoot: withPrefix(`/js${commitPrefix}sandbox`),
+    playgroundRoot: withPrefix(`/js${commitPrefix}playground`),
+  }
+}

--- a/packages/typescriptlang-org/src/pages/dev/bug-workbench.tsx
+++ b/packages/typescriptlang-org/src/pages/dev/bug-workbench.tsx
@@ -20,6 +20,7 @@ import { workbenchMarkdownPlugin } from "../../components/workbench/plugins/mark
 import { workbenchReferencePlugin } from "../../components/workbench/plugins/docs"
 import { createDefaultMapFromCDN } from "@typescript/vfs"
 import { twoslasher, TwoSlashReturn } from "@typescript/twoslash"
+import { getPlaygroundUrls } from "../../lib/playgroundURLs";
 
 type TwoSlashReturns = import("@typescript/twoslash").TwoSlashReturn
 
@@ -54,14 +55,16 @@ const Play: React.FC<Props> = (props) => {
         const nightlyJSON = await nightlyLookup.json()
         tsVersionParam = nightlyJSON.version
       }
-
+      // Allow prod/staging builds to set a custom commit prefix to bust caches
+      const {sandboxRoot, playgroundRoot} = getPlaygroundUrls()
+            
       // @ts-ignore
       const re: any = global.require
       re.config({
         paths: {
           vs: `https://typescript.azureedge.net/cdn/${tsVersionParam}/monaco/min/vs`,
-          "typescript-sandbox": withPrefix('/js/sandbox'),
-          "typescript-playground": withPrefix('/js/playground'),
+          "typescript-sandbox": sandboxRoot,
+          "typescript-playground": playgroundRoot,
           "unpkg": "https://unpkg.com/",
           "local": "http://localhost:5000"
         },

--- a/packages/typescriptlang-org/src/pages/dev/twoslash.tsx
+++ b/packages/typescriptlang-org/src/pages/dev/twoslash.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react"
 import { Layout } from "../../components/layout"
-import { withPrefix, graphql } from "gatsby"
+import { withPrefix } from "gatsby"
 import { twoslasher } from "@typescript/twoslash"
 import { createDefaultMapFromCDN } from "@typescript/vfs"
 import { renderers } from "shiki-twoslash"
@@ -11,6 +11,7 @@ import { Intl } from "../../components/Intl"
 import { DevNav } from "../../components/devNav"
 import { isTouchDevice } from "../../lib/isTouchDevice"
 import { SuppressWhenTouch } from "../../components/SuppressWhenTouch"
+import { getPlaygroundUrls } from "../../lib/playgroundURLs"
 
 /** Note: to run all the web infra in debug, run:
   localStorage.debug = '*'
@@ -31,13 +32,16 @@ const Index: React.FC<Props> = props => {
     getLoaderScript.src = withPrefix("/js/vs.loader.js")
     getLoaderScript.async = true
     getLoaderScript.onload = () => {
+      // Allow prod/staging builds to set a custom commit prefix to bust caches
+      const {sandboxRoot} = getPlaygroundUrls()
+      
       // @ts-ignore
       const re: any = global.require
 
       re.config({
         paths: {
           vs: "https://typescript.azureedge.net/cdn/4.0.5/monaco/min/vs",
-          sandbox: withPrefix("/js/sandbox"),
+          sandbox: sandboxRoot,
         },
         ignoreDuplicateModules: ["vs/editor/editor.main"],
       })

--- a/packages/typescriptlang-org/src/templates/play.tsx
+++ b/packages/typescriptlang-org/src/templates/play.tsx
@@ -16,6 +16,7 @@ import { Intl } from "../components/Intl"
 import "reflect-metadata"
 
 import playgroundReleases from "../../../sandbox/src/releases.json"
+import { getPlaygroundUrls } from "../lib/playgroundURLs"
 
 // This gets set by the playground
 declare const playground: ReturnType<typeof import("@typescript/playground").setupPlayground>
@@ -107,13 +108,16 @@ const Play: React.FC<Props> = (props) => {
         return
       }
 
+      // Allow prod/staging builds to set a custom commit prefix to bust caches
+      const {sandboxRoot, playgroundRoot} = getPlaygroundUrls()
+      
       // @ts-ignore
       const re: any = global.require
       re.config({
         paths: {
           vs: urlForMonaco,
-          "typescript-sandbox": withPrefix('/js/sandbox'),
-          "typescript-playground": withPrefix('/js/playground'),
+          "typescript-sandbox": sandboxRoot,
+          "typescript-playground": playgroundRoot,
           "unpkg": "https://unpkg.com",
           "local": "http://localhost:5000",
         },


### PR DESCRIPTION
It's not worth waiting on the static web apps deploy for this.

 It creates a copy of the playground / sandbox js in a unique sha folder which is referenced in the HTML files. So today instead of just:

```
packages/typescriptlang-org/static/js/
├── examples
│   ├── en
├── playground
│   ├── ds
│   ├── monaco
│   ├── nav
│   └── sidebar
│       └── fixtures
└── sandbox
    └── vendor
```

We get:

```
❯ yarn workspace typescriptlang-org setup-playground-cache-bust
❯ tree packages/typescriptlang-org/static/js/
packages/typescriptlang-org/static/js/
├── 6f56795
│   ├── playground
│   │   ├── ds
│   │   ├── monaco
│   │   ├── nav
│   │   └── sidebar
│   │       └── fixtures
│   └── sandbox
│       └── vendor
├── examples
│   ├── en
├── playground
│   ├── ds
│   ├── monaco
│   ├── nav
│   └── sidebar
│       └── fixtures
└── sandbox
    └── vendor
```

The SHA is known only to the site, and isn't static between deploys - the unprefixed still around because they're needed in a bunch of places.