### PR TITLE
Drop redundant `detectNewImportsToAcquireTypeFor` call

### DIFF
--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -215,13 +215,6 @@ export const createTypeScriptSandbox = (
   config.logger.log("[Compiler] Set compiler options: ", compilerOptions)
   defaults.setCompilerOptions(compilerOptions)
 
-  // Grab types last so that it logs in a logical way
-  if (config.acquireTypes) {
-    // Take the code from the editor right away
-    const code = editor.getModel()!.getValue()
-    detectNewImportsToAcquireTypeFor(code, addLibraryToRuntime, window.fetch.bind(window), config)
-  }
-
   // To let clients plug into compiler settings changes
   let didUpdateCompilerSettings = (opts: CompilerOptions) => {}
 


### PR DESCRIPTION
This is supposed to acquire types for the initial value but the same thing already happens within this call:
https://github.com/microsoft/TypeScript-Website/blob/23cd21aec8ef8284d3cb89fad6607e839c2f97e8/packages/sandbox/src/index.ts#L345
