### PR TITLE
update basic type link

### DIFF
--- a/packages/documentation/copy/en/reference/Type Compatibility.md
+++ b/packages/documentation/copy/en/reference/Type Compatibility.md
@@ -391,7 +391,7 @@ A "<span class='black-tick'>✓</span>" indicates a combination that is compatib
 </tbody>
 </table>
 
-Reiterating [Basic Types](/handbook/basic-types.html):
+Reiterating [Basic Types](/handbook/2/everyday-types.html):
 
 - Everything is assignable to itself.
 - `any` and `unknown` are the same in terms of what is assignable to them, different in that `unknown` is not assignable to anything except `any`.


### PR DESCRIPTION
Basic type link was broken and further the intended "basic-type" doc page was deprecated. So replaced broken link with the redirected link of mentioned depreciated.