### PR TITLE
Disable JSX:React to prevent syntax conflict with angle-bracket style type assertion in Playground

### DIFF
--- a/packages/sandbox/src/compilerOptions.ts
+++ b/packages/sandbox/src/compilerOptions.ts
@@ -51,7 +51,7 @@ export function getDefaultSandboxCompilerOptions(config: SandboxConfig, monaco: 
     moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,
 
     target: monaco.languages.typescript.ScriptTarget.ES2017,
-    jsx: monaco.languages.typescript.JsxEmit.React,
+    jsx: monaco.languages.typescript.JsxEmit.None,
     module: monaco.languages.typescript.ModuleKind.ESNext,
   }
 


### PR DESCRIPTION
To fix the [`angle-bracket style type assertion`](https://www.typescriptlang.org/docs/handbook/basic-types.html#type-assertions) conflict issue microsoft/TypeScript#45308

By a quick review, I found out that there are
1.  default config ~~`jsx: monaco.languages.typescript.JsxEmit.None`~~ in [`packages/playground-examples/copy/en/Playground/Config/New Compiler Defaults.ts`](https://github.com/microsoft/TypeScript-Website/blob/376a225dc2e7c9544f20d7dea0fa27bd140e25eb/packages/playground-examples/copy/en/Playground/Config/New%20Compiler%20Defaults.ts#L54)
2. and soon be overwritten (?) by `JsxEmit.React` in [`packages/sandbox/src/compilerOptions.ts`](https://github.com/microsoft/TypeScript-Website/blob/1f63d5aecaab5858b953b60518a5aa70975d9a21/packages/sandbox/src/compilerOptions.ts#L54)

Please help to check if the **2.** is the correct piece of code to be changed _(:3

---
I make this change mainly to prevent the conflict between the `angle-bracket style` type assertion and JSX syntax
Here's the quote of my comment in the original issue. If there's any concern on disabling React syntax by default, feel free to have a further discussion : )
> Yes, I know the other `as style` syntax is also available (and I always use it personally); however, some of the sample code (e.g., like the original post) is provided with the `angle-bracket style`.
> 
> Actually, there's a `typescript-eslint` rule called [`consistent-type-assertions`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-assertions.md#options) to limit the syntax of type assertion (also uses `assertionStyle: 'as'` by default)
> 
> However, if I were the designer of the Playground and need to make a trade-off between official TypeScript syntax (`<Type>foo`) and JSX syntax, I would rather pick the former one as it's part of the standard of TypeScript.

---
ps, the document also mention this:
1. [Basic Types (old docs)](https://www.typescriptlang.org/docs/handbook/basic-types.html#type-assertions):
    <img src="https://user-images.githubusercontent.com/37973545/128018890-55eb01e6-9cf9-4e3c-9b66-f6c2a79b0042.png" width="500"/>
2. [Everyday Types (new docs )](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-assertions):
    <img src="https://user-images.githubusercontent.com/37973545/128019054-56f34394-f583-41b7-b29c-8a3f1f7a1b6a.png" width="500"/>
