### PR TITLE
Deploy to prod SWA

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -51,6 +51,16 @@ jobs:
           PUBLISH_BRANCH: "SITE-PRODUCTION"
           PUBLISH_DIR: ./site
 
+      - name: Build And Deploy
+        id: builddeploy
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PROD }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: "upload"
+          app_location: "site"
+          skip_app_build: true
+
       # Update the site stats
       - run: node packages/typescriptlang-org/scripts/updateAppInsightsGitHubIssue.js
         env:

--- a/packages/typescriptlang-org/package.json
+++ b/packages/typescriptlang-org/package.json
@@ -25,7 +25,7 @@
     "@types/react-helmet": "^5.0.15",
     "@typescript/playground": "0.1.0",
     "@typescript/sandbox": "0.1.0",
-    "@typescript/twoslash": "2.2.0",
+    "@typescript/twoslash": "3.0.0",
     "canvas": "^2.6.1",
     "gatsby": "^3.8.1",
     "gatsby-link": "3.10.0",

--- a/packages/typescriptlang-org/src/pages/dev/twoslash.tsx
+++ b/packages/typescriptlang-org/src/pages/dev/twoslash.tsx
@@ -118,7 +118,8 @@ const Index: React.FC<Props> = props => {
                 const html = renderers.twoslashRenderer(
                   codeAsFakeShikiTokens,
                   {},
-                  newResults,
+                  // This is a hack because @typescript/twoslash gets released separately from remark-shiki-twoslash
+                  newResults as any,
                   {}
                 )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5379,18 +5379,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@typescript/twoslash@npm:2.2.0":
-  version: 2.2.0
-  resolution: "@typescript/twoslash@npm:2.2.0"
-  dependencies:
-    "@typescript/vfs": 1.3.4
-    debug: ^4.1.1
-    lz-string: ^1.4.4
-  checksum: fac5b861c8f0249c6828f0493f0065fa110bf60ad58a87e351f457524ab1c9caddb03f4e44a980ca5381019daf1629a589e0291d0505082779b77393b4ad3a82
-  languageName: node
-  linkType: hard
-
-"@typescript/twoslash@workspace:packages/ts-twoslasher":
+"@typescript/twoslash@3.0.0, @typescript/twoslash@workspace:packages/ts-twoslasher":
   version: 0.0.0-use.local
   resolution: "@typescript/twoslash@workspace:packages/ts-twoslasher"
   dependencies:
@@ -5409,6 +5398,17 @@ __metadata:
     typescript: "*"
   languageName: unknown
   linkType: soft
+
+"@typescript/twoslash@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@typescript/twoslash@npm:2.2.0"
+  dependencies:
+    "@typescript/vfs": 1.3.4
+    debug: ^4.1.1
+    lz-string: ^1.4.4
+  checksum: fac5b861c8f0249c6828f0493f0065fa110bf60ad58a87e351f457524ab1c9caddb03f4e44a980ca5381019daf1629a589e0291d0505082779b77393b4ad3a82
+  languageName: node
+  linkType: hard
 
 "@typescript/vfs@1.3.4, @typescript/vfs@workspace:packages/typescript-vfs":
   version: 0.0.0-use.local
@@ -27151,7 +27151,7 @@ resolve@^2.0.0-next.3:
     "@types/react-helmet": ^5.0.15
     "@typescript/playground": 0.1.0
     "@typescript/sandbox": 0.1.0
-    "@typescript/twoslash": 2.2.0
+    "@typescript/twoslash": 3.0.0
     canvas: ^2.6.1
     concurrently: ^5.1.0
     gatsby: ^3.8.1


### PR DESCRIPTION
Re: #1966 

We have staging running on https://static.staging-typescript.org/ but prod builds have never been deploying to SWA. Now it deploys to both.