### PR TITLE
Union primary definition may refer values rather than types

### DIFF
--- a/packages/documentation/copy/en/get-started/TS for JS Programmers.md
+++ b/packages/documentation/copy/en/get-started/TS for JS Programmers.md
@@ -128,7 +128,7 @@ With TypeScript, you can create complex types by combining simple ones. There ar
 
 ### Unions
 
-With a union, you can declare that a type could be one of many types. For example, you can describe a `boolean` type as being either `true` or `false`:
+With a union, you can declare that a type could be one of many values. For example, you can describe a `boolean` type as being either `true` or `false`:
 
 ```ts twoslash
 type MyBool = true | false;


### PR DESCRIPTION
With this change the primary definition seemed to me more natural. Because if you see line 147, it specifically refers how you 
 combine different "types". But, since I am a learner and missing important portion of concepts, the change may not be relevant.