### PR TITLE
firstElement examples should take into consideration undefined

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -103,21 +103,23 @@ In TypeScript, _generics_ are used when we want to describe a correspondence bet
 We do this by declaring a _type parameter_ in the function signature:
 
 ```ts twoslash
-function firstElement<Type>(arr: Type[]): Type {
+function firstElement<Type>(arr: Type[]) {
   return arr[0];
 }
 ```
 
-By adding a type parameter `Type` to this function and using it in two places, we've created a link between the input of the function (the array) and the output (the return value).
+By adding a type parameter `Type` to this function and using it in two places, we've created a link between the input of the function (the array) and the output (the return value). 
 Now when we call it, a more specific type comes out:
 
 ```ts twoslash
-declare function firstElement<Type>(arr: Type[]): Type;
+declare function firstElement<Type>(arr: Type[]);
 // ---cut---
 // s is of type 'string'
 const s = firstElement(["a", "b", "c"]);
 // n is of type 'number'
 const n = firstElement([1, 2, 3]);
+// u is of type undefined
+const u = firstElement([]);
 ```
 
 ### Inference

--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -103,7 +103,7 @@ In TypeScript, _generics_ are used when we want to describe a correspondence bet
 We do this by declaring a _type parameter_ in the function signature:
 
 ```ts twoslash
-function firstElement<Type>(arr: Type[]) {
+function firstElement<Type>(arr: Type[]): T | undefined {
   return arr[0];
 }
 ```
@@ -112,7 +112,7 @@ By adding a type parameter `Type` to this function and using it in two places, w
 Now when we call it, a more specific type comes out:
 
 ```ts twoslash
-declare function firstElement<Type>(arr: Type[]);
+declare function firstElement<Type>(arr: Type[]): T | undefined;
 // ---cut---
 // s is of type 'string'
 const s = firstElement(["a", "b", "c"]);


### PR DESCRIPTION
`function firstElement<T>(arr: T[]): T `

Started experimenting (n00b alert) with TS (4.3.5) and the above example does not compile. It gives me:

```
Type 'T | undefined' is not assignable to type 'T'.
  'T' could be instantiated with an arbitrary type which could be unrelated to 'T | undefined'. ts(2322)
```

There are two alternatives I think:

1. leave the function result T and let TS inference deal with it
2. specified T | undefined as function result