### PR TITLE
Link to Tuple Types section of Object Types page

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -32,7 +32,7 @@ To specify the type of an array like `[1, 2, 3]`, you can use the syntax `number
 You may also see this written as `Array<number>`, which means the same thing.
 We'll learn more about the syntax `T<U>` when we cover _generics_.
 
-> Note that `[number]` is a different thing; refer to the section on _tuple types_.
+> Note that `[number]` is a different thing; refer to the section on [Tuple Types](/docs/handbook/2/objects.html#tuple-types).
 
 ## `any`
 

--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -32,7 +32,8 @@ To specify the type of an array like `[1, 2, 3]`, you can use the syntax `number
 You may also see this written as `Array<number>`, which means the same thing.
 We'll learn more about the syntax `T<U>` when we cover _generics_.
 
-> Note that `[number]` is a different thing; refer to the section on [Tuple Types](/docs/handbook/2/objects.html#tuple-types).
+> Note that `[number]` is a different thing; refer to the section on [Tuples](/docs/handbook/2/objects.html#tuple-types).
+
 
 ## `any`
 


### PR DESCRIPTION
A search for 'tuple' on the website has the deprecated handbook basic types page as the only documentation result. That deprecated page links back to this one so there was is no way to find the current Tuple Types documentation in Object Types from the website.

Unfortunately a search for 'tuple types' shows no documentation results. Perhaps documentation sections (rather than just pages) could be indexed in Algolia.