### PR TITLE
Make the slogan less confusing to beginners

### DIFF
--- a/packages/typescriptlang-org/src/copy/en/index2.ts
+++ b/packages/typescriptlang-org/src/copy/en/index2.ts
@@ -1,6 +1,6 @@
 export const indexCopy = {
   index_2_headline:
-    "TypeScript is <bold>JavaScript with syntax for types.</bold>",
+    "TypeScript extends <bold>JavaScript with syntax for types.</bold>",
   index_2_byline: "TypeScript extends JavaScript by adding types.",
   index_2_summary:
     "TypeScript is a strongly typed programming language which builds on JavaScript giving you better tooling at any scale.",


### PR DESCRIPTION
A common misconception inside the community is that "TypeScript is JavaScript" while typescript doesn't have an exact "is" relationship with JavaScript. The rest of the documentation explains that it's a "superset" but the slogan still doesn't reflect it.

It hurts TypeScript when people expect it to be just JavaScript but then they learn that:

- many things can't be written exactly the same way because some extra checks are needed or some notation should be used for ts to infer the type correctly
- that in a non-trivial application, the types theory knowledge is a significant portion of the total language knowledge, probably much bigger than js itself
- that knowing javascript doesn't let you use typescript efficiently and you will spend a lot of time writing types
- that ts has even language features besides of types which compile to some equivalent in javascript (e.g. enums)

... and as a result they hate the language that promised them to be just JavaScript but it isn't in practice.


<img width="921" alt="Screenshot 2021-08-26 at 15 52 22" src="https://user-images.githubusercontent.com/52824/130976441-85e6a4b8-410c-406e-9381-8c557ddfc4eb.png">
