### PR TITLE
better alignment for the popover

### DIFF
--- a/packages/typescriptlang-org/src/templates/markdown-twoslash.scss
+++ b/packages/typescriptlang-org/src/templates/markdown-twoslash.scss
@@ -1,7 +1,7 @@
 @import "../style/globals.scss";
 /*  Start of Shiki Twoslash CSS:
 
-Code blocks structurally look like: 
+Code blocks structurally look like:
 
 <pre class='shiki lsp twoslash [theme-name]'>
   <div class='language-id'>[lang-id]</div>
@@ -9,7 +9,7 @@ Code blocks structurally look like:
       <code>[the code as a series of spans]</code>
       <a href='playground...'>Try</a> (optional)
     </div>
-  </pre> 
+  </pre>
 */
 
 pre {
@@ -185,7 +185,7 @@ pre .popover {
   margin-bottom: 10px;
   background-color: #eee;
   display: inline-block;
-  padding: 0 0.5rem 0.3rem;
+  padding: 0 0.5rem 0.6rem;
   margin-top: 10px;
   border-radius: 3px;
 }


### PR DESCRIPTION
@orta, hi! hope you're doing great. I was looking at the docs and I just wanted to center the popover's alignment. So I changed it a little bit, so this:

<img width="514"  src="https://user-images.githubusercontent.com/2157285/131191315-ccc403c7-767d-4335-bcf6-43ecf7d85cff.png">

becomes this:

<img width="497" src="https://user-images.githubusercontent.com/2157285/131191317-6458507d-1065-476b-9a76-1fd523eef6db.png">

Hope you like it :)
