### PR TITLE
Should not render </tr> as code block

### DIFF
--- a/packages/documentation/copy/en/project-config/Compiler Options.md
+++ b/packages/documentation/copy/en/project-config/Compiler Options.md
@@ -35,17 +35,17 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 **If you're looking for more information about the compiler options in a tsconfig, check out the [TSConfig Reference](/tsconfig)**
 
-<!-- Start of replacement  --><h3>CLI Commands</h3>
+<!-- Start of replacement  -->
+<h3>CLI Commands</h3>
 
-  <table class='cli-option' width="100%">
-    <thead>
-    <tr>
-      <th>Flag</th>
-      <th>Type</th>
-      
-    </tr>
-  </thead>
-  <tbody>
+<table class='cli-option' width="100%">
+  <thead>
+  <tr>
+    <th>Flag</th>
+    <th>Type</th>
+  </tr>
+</thead>
+<tbody>
 
 <tr class='odd' name='all'>
 <td><code>--all</code></td>
@@ -122,15 +122,15 @@ tsc app.ts util.ts --target esnext --outfile index.js
 </tbody></table>
 <h3>Build Options</h3>
 
-  <table class='cli-option' width="100%">
-    <thead>
-    <tr>
-      <th>Flag</th>
-      <th>Type</th>
-      
-    </tr>
-  </thead>
-  <tbody>
+<table class='cli-option' width="100%">
+  <thead>
+  <tr>
+    <th>Flag</th>
+    <th>Type</th>
+
+  </tr>
+</thead>
+<tbody>
 
 <tr class='odd' name='build'>
 <td><code>--build</code></td>
@@ -175,15 +175,15 @@ tsc app.ts util.ts --target esnext --outfile index.js
 </tbody></table>
 <h3>Watch Options</h3>
 
-  <table class='cli-option' width="100%">
-    <thead>
-    <tr>
-      <th>Flag</th>
-      <th>Type</th>
-      
-    </tr>
-  </thead>
-  <tbody>
+<table class='cli-option' width="100%">
+  <thead>
+  <tr>
+    <th>Flag</th>
+    <th>Type</th>
+
+  </tr>
+</thead>
+<tbody>
 
 <tr class='odd' name='excludeDirectories'>
 <td><code><a href='/tsconfig/#excludeDirectories'>--excludeDirectories</a></code></td>
@@ -244,16 +244,16 @@ tsc app.ts util.ts --target esnext --outfile index.js
 </tbody></table>
 <h3>Compiler Flags</h3>
 
-  <table class='cli-option' width="100%">
-    <thead>
-    <tr>
-      <th>Flag</th>
-      <th>Type</th>
-     <th>Default</th>
-      
-    </tr>
-  </thead>
-  <tbody>
+<table class='cli-option' width="100%">
+  <thead>
+  <tr>
+    <th>Flag</th>
+    <th>Type</th>
+   <th>Default</th>
+
+  </tr>
+</thead>
+<tbody>
 
 <tr class='odd' name='allowJs'>
 <td><code><a href='/tsconfig/#allowJs'>--allowJs</a></code></td>

--- a/packages/documentation/copy/en/project-config/Compiler Options.md
+++ b/packages/documentation/copy/en/project-config/Compiler Options.md
@@ -36,17 +36,14 @@ tsc app.ts util.ts --target esnext --outfile index.js
 **If you're looking for more information about the compiler options in a tsconfig, check out the [TSConfig Reference](/tsconfig)**
 
 <!-- Start of replacement  --><h3>CLI Commands</h3>
-
-  <table class='cli-option' width="100%">
-    <thead>
-    <tr>
-      <th>Flag</th>
-      <th>Type</th>
-      
-    </tr>
-  </thead>
-  <tbody>
-
+<table class="cli-option" width="100%">
+      <thead>
+      <tr>
+        <th>Flag</th>
+        <th>Type</th>
+      </tr>
+    </thead>
+    <tbody>
 <tr class='odd' name='all'>
 <td><code>--all</code></td>
   <td><code>boolean</code></td>
@@ -121,17 +118,14 @@ tsc app.ts util.ts --target esnext --outfile index.js
 </tr></td>
 </tbody></table>
 <h3>Build Options</h3>
-
-  <table class='cli-option' width="100%">
-    <thead>
-    <tr>
-      <th>Flag</th>
-      <th>Type</th>
-      
-    </tr>
-  </thead>
-  <tbody>
-
+<table class="cli-option" width="100%">
+      <thead>
+      <tr>
+        <th>Flag</th>
+        <th>Type</th>
+      </tr>
+    </thead>
+    <tbody>
 <tr class='odd' name='build'>
 <td><code>--build</code></td>
   <td><code>boolean</code></td>
@@ -174,17 +168,14 @@ tsc app.ts util.ts --target esnext --outfile index.js
 </tr></td>
 </tbody></table>
 <h3>Watch Options</h3>
-
-  <table class='cli-option' width="100%">
-    <thead>
-    <tr>
-      <th>Flag</th>
-      <th>Type</th>
-      
-    </tr>
-  </thead>
-  <tbody>
-
+<table class="cli-option" width="100%">
+      <thead>
+      <tr>
+        <th>Flag</th>
+        <th>Type</th>
+      </tr>
+    </thead>
+    <tbody>
 <tr class='odd' name='excludeDirectories'>
 <td><code><a href='/tsconfig/#excludeDirectories'>--excludeDirectories</a></code></td>
   <td><code>list</code></td>
@@ -243,18 +234,15 @@ tsc app.ts util.ts --target esnext --outfile index.js
 </tr></td>
 </tbody></table>
 <h3>Compiler Flags</h3>
-
-  <table class='cli-option' width="100%">
-    <thead>
-    <tr>
-      <th>Flag</th>
-      <th>Type</th>
+<table class="cli-option" width="100%">
+      <thead>
+      <tr>
+        <th>Flag</th>
+        <th>Type</th>
      <th>Default</th>
-      
-    </tr>
-  </thead>
-  <tbody>
-
+      </tr>
+    </thead>
+    <tbody>
 <tr class='odd' name='allowJs'>
 <td><code><a href='/tsconfig/#allowJs'>--allowJs</a></code></td>
   <td><code>boolean</code></td>
@@ -378,7 +366,7 @@ tsc app.ts util.ts --target esnext --outfile index.js
 <tr class='odd' name='declarationDir'>
 <td><code><a href='/tsconfig/#declarationDir'>--declarationDir</a></code></td>
   <td><code>string</code></td>
-  <td><p>n/a</p>
+  <td><p> n/a</p>
 </td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
@@ -548,7 +536,7 @@ tsc app.ts util.ts --target esnext --outfile index.js
 <tr class='even' name='generateCpuProfile'>
 <td><code><a href='/tsconfig/#generateCpuProfile'>--generateCpuProfile</a></code></td>
   <td><code>string</code></td>
-  <td><p>profile.cpuprofile</p>
+  <td><p> profile.cpuprofile</p>
 </td>
 </tr>
 <tr class="option-description even"><td colspan="3">

--- a/packages/tsconfig-reference/scripts/cli/generateMarkdown.ts
+++ b/packages/tsconfig-reference/scripts/cli/generateMarkdown.ts
@@ -51,17 +51,19 @@ languages.forEach((lang) => {
   function renderTable(title: string, options: CompilerOptionJSON[], opts?: { noDefaults: true }) {
     markdownChunks.push(`<h3>${title}</h3>`);
 
-    markdownChunks.push(`
-  <table class='cli-option' width="100%">
-    <thead>
-    <tr>
-      <th>Flag</th>
-      <th>Type</th>${opts?.noDefaults ? "" : "\n     <th>Default</th>"}
-      
-    </tr>
-  </thead>
-  <tbody>
-`);
+    // Trim leading whitespaces so that it is not rendered as a markdown code block
+    const tableHeader = `
+    <table class="cli-option" width="100%">
+      <thead>
+      <tr>
+        <th>Flag</th>
+        <th>Type</th>${opts?.noDefaults ? "" : "\n     <th>Default</th>"}
+      </tr>
+    </thead>
+    <tbody>
+    `.trim()
+
+    markdownChunks.push(tableHeader);
 
     options.forEach((option, index) => {
       // Heh, the section uses an article and the categories use a section
@@ -77,7 +79,7 @@ languages.forEach((lang) => {
           const sectionsPath = getPathInLocale(join("cli", option.name + ".md"));
           const optionFile = readMarkdownFile(sectionsPath);
           description = optionFile.data.oneline;
-        } catch (error) {}
+        } catch (error) { }
       }
 
       const oddEvenClass = index % 2 === 0 ? "odd" : "even";
@@ -131,7 +133,7 @@ languages.forEach((lang) => {
 languages.forEach((lang) => {
   const mdCLI = join(__dirname, "..", "..", "output", lang + "-cli.md");
   // prettier-ignore
-  const compOptsPath = join( __dirname, "..", "..", "..", `documentation/copy/${lang}/project-config/Compiler Options.md`);
+  const compOptsPath = join(__dirname, "..", "..", "..", `documentation/copy/${lang}/project-config/Compiler Options.md`);
 
   if (existsSync(compOptsPath)) {
     const md = readFileSync(compOptsPath, "utf8");


### PR DESCRIPTION
Before: `</tr>` is rendered as a code block

![Screen Shot 2564-08-31 at 20 51 29](https://user-images.githubusercontent.com/3814520/131514828-be424cb5-00cc-4f28-b80a-2ec3f381cee8.png)

After: `</tr>` is now part of the table's HTML

![Screen Shot 2564-08-31 at 20 51 05](https://user-images.githubusercontent.com/3814520/131514853-5ef5d70c-f3d3-4dae-86fa-72ab28250d37.png)
