### PR TITLE
improve an in-code comment

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -163,7 +163,7 @@ function longest<Type extends { length: number }>(a: Type, b: Type) {
 
 // longerArray is of type 'number[]'
 const longerArray = longest([1, 2], [1, 2, 3]);
-// longerString is of type 'string'
+// longerString is of type 'alice' | 'bob'
 const longerString = longest("alice", "bob");
 // Error! Numbers don't have a 'length' property
 const notOK = longest(10, 100);


### PR DESCRIPTION
" // longerString is of type 'string' " statement is at least imprecise, since the type of longerString is actually OR of two string literals 'alice' and 'bob'. At the end, the comment explains a type of 'string' and the type is actually 'alice' | 'bob' hovering over it.