### PR TITLE
Updated false information in Decorators.md

### DIFF
--- a/packages/documentation/copy/en/reference/Decorators.md
+++ b/packages/documentation/copy/en/reference/Decorators.md
@@ -187,7 +187,7 @@ function sealed(constructor: Function) {
 }
 ```
 
-When `@sealed` is executed, it will seal both the constructor and its prototype, and will therefore will prevent any further functionality from being added to or removed from this class during runtime by accessing `BugReport.prototype` or by defining properties on `BugReport` itself (note that ES2015 classes are really just syntactic sugar to prototype-based constructor functions). This decorator does **not** prevent classes from sub-classing `BugReport`.
+When `@sealed` is executed, it will seal both the constructor and its prototype, and will therefore prevent any further functionality from being added to or removed from this class during runtime by accessing `BugReport.prototype` or by defining properties on `BugReport` itself (note that ES2015 classes are really just syntactic sugar to prototype-based constructor functions). This decorator does **not** prevent classes from sub-classing `BugReport`.
 
 Next we have an example of how to override the constructor to set new defaults.
 

--- a/packages/documentation/copy/en/reference/Decorators.md
+++ b/packages/documentation/copy/en/reference/Decorators.md
@@ -187,7 +187,7 @@ function sealed(constructor: Function) {
 }
 ```
 
-When `@sealed` is executed, it will seal both the constructor and its prototype which would not allow the class to be sub-classed at runtime.
+When `@sealed` is executed, it will seal both the constructor and its prototype, and will therefore will prevent any further functionality from being added to or removed from this class during runtime by accessing `BugReport.prototype` or by defining properties on `BugReport` itself (note that ES2015 classes are really just syntactic sugar to prototype-based constructor functions). This decorator does **not** prevent classes from sub-classing `BugReport`.
 
 Next we have an example of how to override the constructor to set new defaults.
 


### PR DESCRIPTION
Below this example decorator function, the documentation states: "When `@sealed` is executed, it will seal both the constructor and its prototype which would not allow the class to be sub-classed at runtime."

```js
function sealed(constructor: Function) {
  Object.seal(constructor);
  Object.seal(constructor.prototype);
}
```
However, this information is incorrect as far as I'm concerned. This code doesn't prevent classes from subclassing ones decorated with `@sealed`. It only prevents any further modification from being made to `BugReport.prototype` and to the `BugReport` constructor function itself. I've explained this in more detail in my updates to the file.

Please correct me if I'm wrong.