### PR TITLE
Fixes running the JS when writing JavaScript

### DIFF
--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -46,9 +46,9 @@ export type SandboxConfig = {
     groupEnd: (...args: any[]) => void
   }
 } & (
-  | { /** theID of a dom node to add monaco to */ domID: string }
-  | { /** theID of a dom node to add monaco to */ elementToAppend: HTMLElement }
-)
+    | { /** theID of a dom node to add monaco to */ domID: string }
+    | { /** theID of a dom node to add monaco to */ elementToAppend: HTMLElement }
+  )
 
 const languageType = (config: SandboxConfig) => (config.filetype === "js" ? "javascript" : "typescript")
 
@@ -216,7 +216,7 @@ export const createTypeScriptSandbox = (
   defaults.setCompilerOptions(compilerOptions)
 
   // To let clients plug into compiler settings changes
-  let didUpdateCompilerSettings = (opts: CompilerOptions) => {}
+  let didUpdateCompilerSettings = (opts: CompilerOptions) => { }
 
   const updateCompilerSettings = (opts: CompilerOptions) => {
     const newKeys = Object.keys(opts)
@@ -262,13 +262,19 @@ export const createTypeScriptSandbox = (
   /** Gets the results of compiling your editor's code */
   const getEmitResult = async () => {
     const model = editor.getModel()!
-
     const client = await getWorkerProcess()
     return await client.getEmitOutput(model.uri.toString())
   }
 
   /** Gets the JS  of compiling your editor's code */
   const getRunnableJS = async () => {
+    // This isn't quite _right_ in theory, we can downlevel JS -> JS
+    // but a browser is basically always esnext-y and setting allowJs and
+    // checkJs does not actually give the downlevel'd .js file in the output
+    // later down the line.
+    if (isJSLang) {
+      return getText()
+    }
     const result = await getEmitResult()
     const firstJS = result.outputFiles.find((o: any) => o.name.endsWith(".js") || o.name.endsWith(".jsx"))
     return (firstJS && firstJS.text) || ""

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -192,7 +192,6 @@ export const createTypeScriptSandbox = (
 
     if (config.supportTwoslashCompilerOptions) {
       const configOpts = getTwoSlashCompilerOptions(code)
-      console.log("twoslash", configOpts)
       updateCompilerSettings(configOpts)
     }
 


### PR DESCRIPTION
Grabbing the downlevel'd JS doesn't give the downlevel'd JS currently - now we expose the original JS to the runner instead.