### PR TITLE
DOCS: Add a comment to the first example of Keyof Type Operator for beginners

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Keyof Type Operator.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Keyof Type Operator.md
@@ -7,7 +7,8 @@ oneline: "Using the keyof operator in type contexts."
 
 ## The `keyof` type operator
 
-The `keyof` operator takes an object type and produces a string or numeric literal union of its keys:
+The `keyof` operator takes an object type and produces a string or numeric literal union of its keys.
+The following type P is the same type as "x" | "y":
 
 ```ts twoslash
 type Point = { x: number; y: number };


### PR DESCRIPTION
It is related to issue #2025.
I add a short comment to Keyof type Operator. 
My mother tongue is not English, so this comment would be unnatural.
Would you point out an expression?