### PR TITLE
typo in `classes.html`: toLowercse -> toLowercase

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -339,7 +339,7 @@ interface Checkable {
 class NameChecker implements Checkable {
   check(s) {
     // Notice no error here
-    return s.toLowercse() === "ok";
+    return s.toLowercase() === "ok";
     //         ^?
   }
 }


### PR DESCRIPTION
found a typo in `classes.html`

`toLowercse` -> `toLowercase`