### PR TITLE
Massage tsconfig default and allowed values

### DIFF
--- a/packages/documentation/copy/en/project-config/Compiler Options.md
+++ b/packages/documentation/copy/en/project-config/Compiler Options.md
@@ -46,7 +46,8 @@ tsc app.ts util.ts --target esnext --outfile index.js
   <tbody>
 <tr class='odd' name='all'>
   <td><code>--all</code></td>
-  <td><code>boolean</code></td>
+  <td><p><code>boolean</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Show all compiler options.</p>
@@ -54,7 +55,8 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='generateTrace'>
   <td><code>--generateTrace</code></td>
-  <td><code>string</code></td>
+  <td><p><code>string</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Generates an event trace and a list of types.</p>
@@ -62,7 +64,8 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='help'>
   <td><code>--help</code></td>
-  <td><code>boolean</code></td>
+  <td><p><code>boolean</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Gives local information for help on the CLI.</p>
@@ -70,7 +73,8 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='init'>
   <td><code>--init</code></td>
-  <td><code>boolean</code></td>
+  <td><p><code>boolean</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Initializes a TypeScript project and creates a tsconfig.json file.</p>
@@ -78,7 +82,8 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='listFilesOnly'>
   <td><code>--listFilesOnly</code></td>
-  <td><code>boolean</code></td>
+  <td><p><code>boolean</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Print names of files that are part of the compilation and then stop processing.</p>
@@ -86,7 +91,8 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='locale'>
   <td><code>--locale</code></td>
-  <td><code>string</code></td>
+  <td><p><code>string</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Set the language of the messaging from TypeScript. This does not affect emit.</p>
@@ -94,7 +100,8 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='project'>
   <td><code>--project</code></td>
-  <td><code>string</code></td>
+  <td><p><code>string</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Compile the project given the path to its configuration file, or to a folder with a 'tsconfig.json'.</p>
@@ -102,7 +109,8 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='showConfig'>
   <td><code>--showConfig</code></td>
-  <td><code>boolean</code></td>
+  <td><p><code>boolean</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Print the final configuration instead of building.</p>
@@ -110,7 +118,8 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='version'>
   <td><code>--version</code></td>
-  <td><code>boolean</code></td>
+  <td><p><code>boolean</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Print the compiler's version.</p>
@@ -129,7 +138,8 @@ tsc app.ts util.ts --target esnext --outfile index.js
   <tbody>
 <tr class='odd' name='build'>
   <td><code>--build</code></td>
-  <td><code>boolean</code></td>
+  <td><p><code>boolean</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Build one or more projects and their dependencies, if out of date</p>
@@ -137,7 +147,8 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='clean'>
   <td><code>--clean</code></td>
-  <td><code>boolean</code></td>
+  <td><p><code>boolean</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Delete the outputs of all projects.</p>
@@ -145,7 +156,8 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='dry'>
   <td><code>--dry</code></td>
-  <td><code>boolean</code></td>
+  <td><p><code>boolean</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Show what would be built (or deleted, if specified with '--clean')</p>
@@ -153,7 +165,8 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='force'>
   <td><code><a href='/tsconfig/#force'>--force</a></code></td>
-  <td><code>boolean</code></td>
+  <td><p><code>boolean</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Build all projects, including those that appear to be up to date</p>
@@ -161,7 +174,8 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='verbose'>
   <td><code><a href='/tsconfig/#verbose'>--verbose</a></code></td>
-  <td><code>boolean</code></td>
+  <td><p><code>boolean</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Enable verbose logging</p>
@@ -180,7 +194,8 @@ tsc app.ts util.ts --target esnext --outfile index.js
   <tbody>
 <tr class='odd' name='excludeDirectories'>
   <td><code><a href='/tsconfig/#excludeDirectories'>--excludeDirectories</a></code></td>
-  <td><code>list</code></td>
+  <td><p><code>list</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Remove a list of directories from the watch process.</p>
@@ -188,7 +203,8 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='excludeFiles'>
   <td><code><a href='/tsconfig/#excludeFiles'>--excludeFiles</a></code></td>
-  <td><code>list</code></td>
+  <td><p><code>list</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Remove a list of files from the watch mode's processing.</p>
@@ -196,7 +212,8 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='fallbackPolling'>
   <td><code><a href='/tsconfig/#fallbackPolling'>--fallbackPolling</a></code></td>
-  <td><code><code>fixedPollingInterval</code>, <code>priorityPollingInterval</code>, or <code>dynamicPriorityPolling</code></code></td>
+  <td><p><code>fixedPollingInterval</code>, <code>priorityPollingInterval</code>, or <code>dynamicPriorityPolling</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Specify what approach the watcher should use if the system runs out of native file watchers.</p>
@@ -204,7 +221,8 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='synchronousWatchDirectory'>
   <td><code><a href='/tsconfig/#synchronousWatchDirectory'>--synchronousWatchDirectory</a></code></td>
-  <td><code>boolean</code></td>
+  <td><p><code>boolean</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Synchronously call callbacks and update the state of directory watchers on platforms that don`t support recursive watching natively.</p>
@@ -212,7 +230,8 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='watch'>
   <td><code>--watch</code></td>
-  <td><code>boolean</code></td>
+  <td><p><code>boolean</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Watch input files.</p>
@@ -220,7 +239,8 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='watchDirectory'>
   <td><code><a href='/tsconfig/#watchDirectory'>--watchDirectory</a></code></td>
-  <td><code><code>fixedPollingInterval</code>, <code>dynamicPriorityPolling</code>, or <code>useFsEvents</code></code></td>
+  <td><p><code>fixedPollingInterval</code>, <code>dynamicPriorityPolling</code>, or <code>useFsEvents</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Specify how directories are watched on systems that lack recursive file-watching functionality.</p>
@@ -228,7 +248,8 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='watchFile'>
   <td><code><a href='/tsconfig/#watchFile'>--watchFile</a></code></td>
-  <td><code><code>fixedPollingInterval</code>, <code>priorityPollingInterval</code>, <code>dynamicPriorityPolling</code>, <code>useFsEvents</code>, or <code>useFsEventsOnParentDirectory</code></code></td>
+  <td><p><code>fixedPollingInterval</code>, <code>priorityPollingInterval</code>, <code>dynamicPriorityPolling</code>, <code>useFsEvents</code>, or <code>useFsEventsOnParentDirectory</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Specify how the TypeScript watch mode works.</p>
@@ -248,8 +269,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
   <tbody>
 <tr class='odd' name='allowJs'>
   <td><code><a href='/tsconfig/#allowJs'>--allowJs</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Allow JavaScript files to be a part of your program. Use the <code>checkJS</code> option to get errors from these files.</p>
@@ -257,8 +280,13 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='allowSyntheticDefaultImports'>
   <td><code><a href='/tsconfig/#allowSyntheticDefaultImports'>--allowSyntheticDefaultImports</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>module === "system" or esModuleInterop</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><ul>
+<li><code>true</code> if <a href="#module"><code>module</code></a> is <code>system</code> or <a href="#esModuleInterop"><code>esModuleInterop</code></a> is <code>true</code> and <a href="#module"><code>module</code></a> is not <code>es6</code>/<code>es2015</code> or <code>esnext</code></li>
+<li><code>false</code> otherwise.</li>
+</ul>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Allow 'import x from y' when a module doesn't have a default export.</p>
@@ -266,8 +294,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='allowUmdGlobalAccess'>
   <td><code><a href='/tsconfig/#allowUmdGlobalAccess'>--allowUmdGlobalAccess</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Allow accessing UMD globals from modules.</p>
@@ -275,8 +305,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='allowUnreachableCode'>
   <td><code><a href='/tsconfig/#allowUnreachableCode'>--allowUnreachableCode</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>undefined</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>undefined</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Disable error reporting for unreachable code.</p>
@@ -284,8 +316,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='allowUnusedLabels'>
   <td><code><a href='/tsconfig/#allowUnusedLabels'>--allowUnusedLabels</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>undefined</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>undefined</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Disable error reporting for unused labels.</p>
@@ -293,8 +327,13 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='alwaysStrict'>
   <td><code><a href='/tsconfig/#alwaysStrict'>--alwaysStrict</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p><code>false</code>, unless <code>strict</code> is set</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><ul>
+<li><code>true</code> if <a href="#strict"><code>strict</code></a> is <code>true</code></li>
+<li><code>false</code> otherwise.</li>
+</ul>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Ensure 'use strict' is always emitted.</p>
@@ -302,17 +341,21 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='assumeChangesOnlyAffectDirectDependencies'>
   <td><code><a href='/tsconfig/#assumeChangesOnlyAffectDirectDependencies'>--assumeChangesOnlyAffectDirectDependencies</a></code></td>
-  <td><code>boolean</code></td>
-  <td></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
-<p>Have recompiles in projects that use <code>incremental</code> and <code>watch</code> mode assume that changes within a file will only affect files directly depending on it.</p>
+<p>Have recompiles in projects that use <a href="#incremental"><code>incremental</code></a> and <code>watch</code> mode assume that changes within a file will only affect files directly depending on it.</p>
 </td></tr>
 
 <tr class='even' name='baseUrl'>
   <td><code><a href='/tsconfig/#baseUrl'>--baseUrl</a></code></td>
-  <td><code>string</code></td>
-  <td></td>
+  <td><p><code>string</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Specify the base directory to resolve non-relative module names.</p>
@@ -320,8 +363,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='charset'>
   <td><code><a href='/tsconfig/#charset'>--charset</a></code></td>
-  <td><code>string</code></td>
-  <td><p>utf8</p></td>
+  <td><p><code>string</code></p>
+</td>
+  <td><p><code>utf8</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>No longer supported. In early versions, manually set the text encoding for reading files.</p>
@@ -329,8 +374,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='checkJs'>
   <td><code><a href='/tsconfig/#checkJs'>--checkJs</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Enable error reporting in type-checked JavaScript files.</p>
@@ -338,8 +385,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='composite'>
   <td><code><a href='/tsconfig/#composite'>--composite</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Enable constraints that allow a TypeScript project to be used with project references.</p>
@@ -347,8 +396,13 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='declaration'>
   <td><code><a href='/tsconfig/#declaration'>--declaration</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p><code>false</code>, unless <code>composite</code> is set</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><ul>
+<li><code>true</code> if <a href="#composite"><code>composite</code></a> is <code>true</code></li>
+<li><code>false</code> otherwise.</li>
+</ul>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Generate .d.ts files from TypeScript and JavaScript files in your project.</p>
@@ -356,8 +410,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='declarationDir'>
   <td><code><a href='/tsconfig/#declarationDir'>--declarationDir</a></code></td>
-  <td><code>string</code></td>
-  <td><p> n/a</p></td>
+  <td><p><code>string</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Specify the output directory for generated declaration files.</p>
@@ -365,8 +421,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='declarationMap'>
   <td><code><a href='/tsconfig/#declarationMap'>--declarationMap</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Create sourcemaps for d.ts files.</p>
@@ -374,8 +432,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='diagnostics'>
   <td><code><a href='/tsconfig/#diagnostics'>--diagnostics</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Output compiler performance information after building.</p>
@@ -383,8 +443,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='disableReferencedProjectLoad'>
   <td><code><a href='/tsconfig/#disableReferencedProjectLoad'>--disableReferencedProjectLoad</a></code></td>
-  <td><code>boolean</code></td>
-  <td></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Reduce the number of projects loaded automatically by TypeScript.</p>
@@ -392,8 +454,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='disableSizeLimit'>
   <td><code><a href='/tsconfig/#disableSizeLimit'>--disableSizeLimit</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Remove the 20mb cap on total source code size for JavaScript files in the TypeScript language server.</p>
@@ -401,8 +465,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='disableSolutionSearching'>
   <td><code><a href='/tsconfig/#disableSolutionSearching'>--disableSolutionSearching</a></code></td>
-  <td><code>boolean</code></td>
-  <td></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Opt a project out of multi-project reference checking when editing.</p>
@@ -410,8 +476,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='disableSourceOfProjectReferenceRedirect'>
   <td><code><a href='/tsconfig/#disableSourceOfProjectReferenceRedirect'>--disableSourceOfProjectReferenceRedirect</a></code></td>
-  <td><code>boolean</code></td>
-  <td></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Disable preferring source files instead of declaration files when referencing composite projects</p>
@@ -419,8 +487,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='downlevelIteration'>
   <td><code><a href='/tsconfig/#downlevelIteration'>--downlevelIteration</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Emit more compliant, but verbose and less performant JavaScript for iteration.</p>
@@ -428,8 +498,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='emitBOM'>
   <td><code><a href='/tsconfig/#emitBOM'>--emitBOM</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.</p>
@@ -437,8 +509,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='emitDeclarationOnly'>
   <td><code><a href='/tsconfig/#emitDeclarationOnly'>--emitDeclarationOnly</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Only output d.ts files and not JavaScript files.</p>
@@ -446,8 +520,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='emitDecoratorMetadata'>
   <td><code><a href='/tsconfig/#emitDecoratorMetadata'>--emitDecoratorMetadata</a></code></td>
-  <td><code>boolean</code></td>
-  <td></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Emit design-type metadata for decorated declarations in source files.</p>
@@ -455,17 +531,21 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='esModuleInterop'>
   <td><code><a href='/tsconfig/#esModuleInterop'>--esModuleInterop</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
-<p>Emit additional JavaScript to ease support for importing CommonJS modules. This enables <code>allowSyntheticDefaultImports</code> for type compatibility.</p>
+<p>Emit additional JavaScript to ease support for importing CommonJS modules. This enables <a href="#allowSyntheticDefaultImports"><code>allowSyntheticDefaultImports</code></a> for type compatibility.</p>
 </td></tr>
 
 <tr class='odd' name='exactOptionalPropertyTypes'>
   <td><code><a href='/tsconfig/#exactOptionalPropertyTypes'>--exactOptionalPropertyTypes</a></code></td>
-  <td><code>boolean</code></td>
-  <td></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Differentiate between undefined and not present when type checking</p>
@@ -473,8 +553,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='experimentalDecorators'>
   <td><code><a href='/tsconfig/#experimentalDecorators'>--experimentalDecorators</a></code></td>
-  <td><code>boolean</code></td>
-  <td></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Enable experimental support for TC39 stage 2 draft decorators.</p>
@@ -482,8 +564,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='explainFiles'>
   <td><code><a href='/tsconfig/#explainFiles'>--explainFiles</a></code></td>
-  <td><code>boolean</code></td>
-  <td></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Print files read during the compilation including why it was included.</p>
@@ -491,8 +575,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='extendedDiagnostics'>
   <td><code><a href='/tsconfig/#extendedDiagnostics'>--extendedDiagnostics</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Output more detailed compiler performance information after building.</p>
@@ -500,8 +586,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='forceConsistentCasingInFileNames'>
   <td><code><a href='/tsconfig/#forceConsistentCasingInFileNames'>--forceConsistentCasingInFileNames</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Ensure that casing is correct in imports.</p>
@@ -509,8 +597,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='generateCpuProfile'>
   <td><code><a href='/tsconfig/#generateCpuProfile'>--generateCpuProfile</a></code></td>
-  <td><code>string</code></td>
-  <td><p> profile.cpuprofile</p></td>
+  <td><p><code>string</code></p>
+</td>
+  <td><p><code>profile.cpuprofile</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Emit a v8 CPU profile of the compiler run for debugging.</p>
@@ -518,8 +608,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='importHelpers'>
   <td><code><a href='/tsconfig/#importHelpers'>--importHelpers</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Allow importing helper functions from tslib once per project, instead of including them per-file.</p>
@@ -527,8 +619,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='importsNotUsedAsValues'>
   <td><code><a href='/tsconfig/#importsNotUsedAsValues'>--importsNotUsedAsValues</a></code></td>
-  <td><code><code>remove</code>, <code>preserve</code>, or <code>error</code></code></td>
-  <td></td>
+  <td><p><code>remove</code>, <code>preserve</code>, or <code>error</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Specify emit/checking behavior for imports that are only used for types.</p>
@@ -536,8 +630,13 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='incremental'>
   <td><code><a href='/tsconfig/#incremental'>--incremental</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p><code>true</code> if <code>composite</code>, <code>false</code> otherwise</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><ul>
+<li><code>true</code> if <a href="#composite"><code>composite</code></a> is <code>true</code></li>
+<li><code>false</code> otherwise.</li>
+</ul>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Save .tsbuildinfo files to allow for incremental compilation of projects.</p>
@@ -545,8 +644,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='inlineSourceMap'>
   <td><code><a href='/tsconfig/#inlineSourceMap'>--inlineSourceMap</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Include sourcemap files inside the emitted JavaScript.</p>
@@ -554,8 +655,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='inlineSources'>
   <td><code><a href='/tsconfig/#inlineSources'>--inlineSources</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Include source code in the sourcemaps inside the emitted JavaScript.</p>
@@ -563,8 +666,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='isolatedModules'>
   <td><code><a href='/tsconfig/#isolatedModules'>--isolatedModules</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Ensure that each file can be safely transpiled without relying on other imports.</p>
@@ -572,8 +677,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='jsx'>
   <td><code><a href='/tsconfig/#jsx'>--jsx</a></code></td>
-  <td><code><code>`react`</code>, <code>`react-jsx`</code>, <code>`react-jsxdev`</code>, <code>`react-native`</code>, or <code>`preserve`</code></code></td>
-  <td><p>undefined</p></td>
+  <td><p><code>react</code>, react-jsx, react-jsxdev, react-native, or <code>preserve</code></p>
+</td>
+  <td><p><code>undefined</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Specify what JSX code is generated.</p>
@@ -581,8 +688,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='jsxFactory'>
   <td><code><a href='/tsconfig/#jsxFactory'>--jsxFactory</a></code></td>
-  <td><code>string</code></td>
-  <td><p><code>React.createElement</code></p></td>
+  <td><p><code>string</code></p>
+</td>
+  <td><p><code>React.createElement</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'</p>
@@ -590,8 +699,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='jsxFragmentFactory'>
   <td><code><a href='/tsconfig/#jsxFragmentFactory'>--jsxFragmentFactory</a></code></td>
-  <td><code>string</code></td>
-  <td></td>
+  <td><p><code>string</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'.</p>
@@ -599,8 +710,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='jsxImportSource'>
   <td><code><a href='/tsconfig/#jsxImportSource'>--jsxImportSource</a></code></td>
-  <td><code>string</code></td>
-  <td><p>react</p></td>
+  <td><p><code>string</code></p>
+</td>
+  <td><p><code>react</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Specify module specifier used to import the JSX factory functions when using <code>jsx: react-jsx*</code>.</p>
@@ -608,8 +721,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='keyofStringsOnly'>
   <td><code><a href='/tsconfig/#keyofStringsOnly'>--keyofStringsOnly</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Make keyof only return strings instead of string, numbers or symbols. Legacy option.</p>
@@ -617,8 +732,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='lib'>
   <td><code><a href='/tsconfig/#lib'>--lib</a></code></td>
-  <td><code>list</code></td>
-  <td></td>
+  <td><p><code>list</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Specify a set of bundled library declaration files that describe the target runtime environment.</p>
@@ -626,8 +743,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='listEmittedFiles'>
   <td><code><a href='/tsconfig/#listEmittedFiles'>--listEmittedFiles</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Print the names of emitted files after a compilation.</p>
@@ -635,8 +754,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='listFiles'>
   <td><code><a href='/tsconfig/#listFiles'>--listFiles</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Print all of the files read during the compilation.</p>
@@ -644,8 +765,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='mapRoot'>
   <td><code><a href='/tsconfig/#mapRoot'>--mapRoot</a></code></td>
-  <td><code>string</code></td>
-  <td></td>
+  <td><p><code>string</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Specify the location where debugger should locate map files instead of generated locations.</p>
@@ -653,17 +776,24 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='maxNodeModuleJsDepth'>
   <td><code><a href='/tsconfig/#maxNodeModuleJsDepth'>--maxNodeModuleJsDepth</a></code></td>
-  <td><code>number</code></td>
-  <td><p>0</p></td>
+  <td><p><code>number</code></p>
+</td>
+  <td><p><code>0</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
-<p>Specify the maximum folder depth used for checking JavaScript files from <code>node_modules</code>. Only applicable with <code>allowJs</code>.</p>
+<p>Specify the maximum folder depth used for checking JavaScript files from <code>node_modules</code>. Only applicable with <a href="#allowJs"><code>allowJs</code></a>.</p>
 </td></tr>
 
 <tr class='odd' name='module'>
   <td><code><a href='/tsconfig/#module'>--module</a></code></td>
-  <td><code><code>`CommonJS` (default if [`target`](/tsconfig#target) is `ES3` or `ES5`)</code>, <code></code>, <code>`ES6`</code>, <code>`ES2015`</code>, <code>`ES2020`</code>, <code></code>, <code>`None`</code>, <code>`UMD`</code>, <code>`AMD`</code>, <code>`System`</code>, or <code>`ESNext`</code></code></td>
-  <td></td>
+  <td><p><code>CommonJS</code>, <code>ES6</code>/<code>ES2015</code>, <code>ES2020</code>, <code>None</code>, <code>UMD</code>, <code>AMD</code>, <code>System</code>, or <code>ESNext</code></p>
+</td>
+  <td><ul>
+<li><code>CommonJS</code> if <a href="#target"><code>target</code></a> is <code>ES3</code> or <code>ES5</code></li>
+<li><code>ES6</code>/<code>ES2015</code> otherwise.</li>
+</ul>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Specify what module code is generated.</p>
@@ -671,8 +801,13 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='moduleResolution'>
   <td><code><a href='/tsconfig/#moduleResolution'>--moduleResolution</a></code></td>
-  <td><code></code></td>
-  <td><p>module === <code>AMD</code> or <code>UMD</code> or <code>System</code> or <code>ES6</code>, then <code>Classic</code><br/><br/>Otherwise <code>Node</code></p></td>
+  <td>
+</td>
+  <td><ul>
+<li><code>Classic</code> if <a href="#module"><code>module</code></a> is <code>AMD</code>, <code>UMD</code>, <code>System</code> or <code>ES6</code>/<code>ES2015</code></li>
+<li><code>Node</code> otherwise.</li>
+</ul>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Specify how TypeScript looks up a file from a given module specifier.</p>
@@ -680,8 +815,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='newLine'>
   <td><code><a href='/tsconfig/#newLine'>--newLine</a></code></td>
-  <td><code></code></td>
-  <td><p>Platform specific</p></td>
+  <td>
+</td>
+  <td><p>Platform specific.</p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Set the newline character for emitting files.</p>
@@ -689,8 +826,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='noEmit'>
   <td><code><a href='/tsconfig/#noEmit'>--noEmit</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Disable emitting file from a compilation.</p>
@@ -698,8 +837,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='noEmitHelpers'>
   <td><code><a href='/tsconfig/#noEmitHelpers'>--noEmitHelpers</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Disable generating custom helper functions like <code>__extends</code> in compiled output.</p>
@@ -707,8 +848,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='noEmitOnError'>
   <td><code><a href='/tsconfig/#noEmitOnError'>--noEmitOnError</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Disable emitting files if any type checking errors are reported.</p>
@@ -716,8 +859,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='noErrorTruncation'>
   <td><code><a href='/tsconfig/#noErrorTruncation'>--noErrorTruncation</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Disable truncating types in error messages.</p>
@@ -725,8 +870,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='noFallthroughCasesInSwitch'>
   <td><code><a href='/tsconfig/#noFallthroughCasesInSwitch'>--noFallthroughCasesInSwitch</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Enable error reporting for fallthrough cases in switch statements.</p>
@@ -734,8 +881,13 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='noImplicitAny'>
   <td><code><a href='/tsconfig/#noImplicitAny'>--noImplicitAny</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p><code>false</code>, unless <code>strict</code> is set</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><ul>
+<li><code>true</code> if <a href="#strict"><code>strict</code></a> is <code>true</code></li>
+<li><code>false</code> otherwise.</li>
+</ul>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Enable error reporting for expressions and declarations with an implied <code>any</code> type..</p>
@@ -743,8 +895,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='noImplicitOverride'>
   <td><code><a href='/tsconfig/#noImplicitOverride'>--noImplicitOverride</a></code></td>
-  <td><code>boolean</code></td>
-  <td></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Ensure overriding members in derived classes are marked with an override modifier.</p>
@@ -752,8 +906,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='noImplicitReturns'>
   <td><code><a href='/tsconfig/#noImplicitReturns'>--noImplicitReturns</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Enable error reporting for codepaths that do not explicitly return in a function.</p>
@@ -761,8 +917,13 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='noImplicitThis'>
   <td><code><a href='/tsconfig/#noImplicitThis'>--noImplicitThis</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p><code>false</code>, unless <code>strict</code> is set</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><ul>
+<li><code>true</code> if <a href="#strict"><code>strict</code></a> is <code>true</code></li>
+<li><code>false</code> otherwise.</li>
+</ul>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Enable error reporting when <code>this</code> is given the type <code>any</code>.</p>
@@ -770,8 +931,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='noImplicitUseStrict'>
   <td><code><a href='/tsconfig/#noImplicitUseStrict'>--noImplicitUseStrict</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Disable adding 'use strict' directives in emitted JavaScript files.</p>
@@ -779,8 +942,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='noLib'>
   <td><code><a href='/tsconfig/#noLib'>--noLib</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Disable including any library files, including the default lib.d.ts.</p>
@@ -788,8 +953,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='noPropertyAccessFromIndexSignature'>
   <td><code><a href='/tsconfig/#noPropertyAccessFromIndexSignature'>--noPropertyAccessFromIndexSignature</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Enforces using indexed accessors for keys declared using an indexed type</p>
@@ -797,8 +964,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='noResolve'>
   <td><code><a href='/tsconfig/#noResolve'>--noResolve</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Disallow <code>import</code>s, <code>require</code>s or <code>&#x3C;reference></code>s from expanding the number of files TypeScript should add to a project.</p>
@@ -806,8 +975,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='noStrictGenericChecks'>
   <td><code><a href='/tsconfig/#noStrictGenericChecks'>--noStrictGenericChecks</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Disable strict checking of generic signatures in function types.</p>
@@ -815,8 +986,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='noUncheckedIndexedAccess'>
   <td><code><a href='/tsconfig/#noUncheckedIndexedAccess'>--noUncheckedIndexedAccess</a></code></td>
-  <td><code>boolean</code></td>
-  <td></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Add <code>undefined</code> to a type when accessed using an index.</p>
@@ -824,8 +997,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='noUnusedLocals'>
   <td><code><a href='/tsconfig/#noUnusedLocals'>--noUnusedLocals</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Enable error reporting when a local variables aren't read.</p>
@@ -833,8 +1008,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='noUnusedParameters'>
   <td><code><a href='/tsconfig/#noUnusedParameters'>--noUnusedParameters</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Raise an error when a function parameter isn't read</p>
@@ -842,17 +1019,21 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='out'>
   <td><code><a href='/tsconfig/#out'>--out</a></code></td>
-  <td><code>string</code></td>
-  <td><p>n/a</p></td>
+  <td><p><code>string</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
-<p>Deprecated setting. Use <code>outFile</code> instead.</p>
+<p>Deprecated setting. Use <a href="#outFile"><code>outFile</code></a> instead.</p>
 </td></tr>
 
 <tr class='even' name='outDir'>
   <td><code><a href='/tsconfig/#outDir'>--outDir</a></code></td>
-  <td><code>string</code></td>
-  <td><p>n/a</p></td>
+  <td><p><code>string</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Specify an output folder for all emitted files.</p>
@@ -860,17 +1041,21 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='outFile'>
   <td><code><a href='/tsconfig/#outFile'>--outFile</a></code></td>
-  <td><code>string</code></td>
-  <td><p>n/a</p></td>
+  <td><p><code>string</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
-<p>Specify a file that bundles all outputs into one JavaScript file. If <code>declaration</code> is true, also designates a file that bundles all .d.ts output.</p>
+<p>Specify a file that bundles all outputs into one JavaScript file. If <a href="#declaration"><code>declaration</code></a> is true, also designates a file that bundles all .d.ts output.</p>
 </td></tr>
 
 <tr class='even' name='paths'>
   <td><code><a href='/tsconfig/#paths'>--paths</a></code></td>
-  <td><code>object</code></td>
-  <td></td>
+  <td><p><code>object</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Specify a set of entries that re-map imports to additional lookup locations.</p>
@@ -878,8 +1063,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='plugins'>
   <td><code><a href='/tsconfig/#plugins'>--plugins</a></code></td>
-  <td><code>list</code></td>
-  <td></td>
+  <td><p><code>list</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Specify a list of language service plugins to include.</p>
@@ -887,8 +1074,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='preserveConstEnums'>
   <td><code><a href='/tsconfig/#preserveConstEnums'>--preserveConstEnums</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Disable erasing <code>const enum</code> declarations in generated code.</p>
@@ -896,8 +1085,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='preserveSymlinks'>
   <td><code><a href='/tsconfig/#preserveSymlinks'>--preserveSymlinks</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Disable resolving symlinks to their realpath. This correlates to the same flag in node.</p>
@@ -905,8 +1096,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='preserveWatchOutput'>
   <td><code><a href='/tsconfig/#preserveWatchOutput'>--preserveWatchOutput</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Disable wiping the console in watch mode</p>
@@ -914,8 +1107,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='pretty'>
   <td><code><a href='/tsconfig/#pretty'>--pretty</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>true</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>true</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Enable color and formatting in output to make compiler errors easier to read</p>
@@ -923,8 +1118,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='reactNamespace'>
   <td><code><a href='/tsconfig/#reactNamespace'>--reactNamespace</a></code></td>
-  <td><code>string</code></td>
-  <td><p>"React"</p></td>
+  <td><p><code>string</code></p>
+</td>
+  <td><p><code>React</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Specify the object invoked for <code>createElement</code>. This only applies when targeting <code>react</code> JSX emit.</p>
@@ -932,8 +1129,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='removeComments'>
   <td><code><a href='/tsconfig/#removeComments'>--removeComments</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Disable emitting comments.</p>
@@ -941,8 +1140,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='resolveJsonModule'>
   <td><code><a href='/tsconfig/#resolveJsonModule'>--resolveJsonModule</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Enable importing .json files</p>
@@ -950,8 +1151,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='rootDir'>
   <td><code><a href='/tsconfig/#rootDir'>--rootDir</a></code></td>
-  <td><code>string</code></td>
-  <td><p>Computed from the list of input files</p></td>
+  <td><p><code>string</code></p>
+</td>
+  <td><p>Computed from the list of input files.</p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Specify the root folder within your source files.</p>
@@ -959,8 +1162,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='rootDirs'>
   <td><code><a href='/tsconfig/#rootDirs'>--rootDirs</a></code></td>
-  <td><code>list</code></td>
-  <td></td>
+  <td><p><code>list</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Allow multiple folders to be treated as one when resolving modules.</p>
@@ -968,8 +1173,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='skipDefaultLibCheck'>
   <td><code><a href='/tsconfig/#skipDefaultLibCheck'>--skipDefaultLibCheck</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Skip type checking .d.ts files that are included with TypeScript.</p>
@@ -977,8 +1184,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='skipLibCheck'>
   <td><code><a href='/tsconfig/#skipLibCheck'>--skipLibCheck</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Skip type checking all .d.ts files.</p>
@@ -986,8 +1195,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='sourceMap'>
   <td><code><a href='/tsconfig/#sourceMap'>--sourceMap</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Create source map files for emitted JavaScript files.</p>
@@ -995,8 +1206,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='sourceRoot'>
   <td><code><a href='/tsconfig/#sourceRoot'>--sourceRoot</a></code></td>
-  <td><code>string</code></td>
-  <td></td>
+  <td><p><code>string</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Specify the root path for debuggers to find the reference source code.</p>
@@ -1004,8 +1217,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='strict'>
   <td><code><a href='/tsconfig/#strict'>--strict</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Enable all strict type checking options.</p>
@@ -1013,8 +1228,13 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='strictBindCallApply'>
   <td><code><a href='/tsconfig/#strictBindCallApply'>--strictBindCallApply</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p><code>false</code>, unless <code>strict</code> is set</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><ul>
+<li><code>true</code> if <a href="#strict"><code>strict</code></a> is <code>true</code></li>
+<li><code>false</code> otherwise.</li>
+</ul>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Check that the arguments for <code>bind</code>, <code>call</code>, and <code>apply</code> methods match the original function.</p>
@@ -1022,8 +1242,13 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='strictFunctionTypes'>
   <td><code><a href='/tsconfig/#strictFunctionTypes'>--strictFunctionTypes</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p><code>false</code>, unless <code>strict</code> is set</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><ul>
+<li><code>true</code> if <a href="#strict"><code>strict</code></a> is <code>true</code></li>
+<li><code>false</code> otherwise.</li>
+</ul>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>When assigning functions, check to ensure parameters and the return values are subtype-compatible.</p>
@@ -1031,8 +1256,13 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='strictNullChecks'>
   <td><code><a href='/tsconfig/#strictNullChecks'>--strictNullChecks</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p><code>false</code>, unless <code>strict</code> is set</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><ul>
+<li><code>true</code> if <a href="#strict"><code>strict</code></a> is <code>true</code></li>
+<li><code>false</code> otherwise.</li>
+</ul>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>When type checking, take into account <code>null</code> and <code>undefined</code>.</p>
@@ -1040,8 +1270,13 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='strictPropertyInitialization'>
   <td><code><a href='/tsconfig/#strictPropertyInitialization'>--strictPropertyInitialization</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p><code>false</code>, unless <code>strict</code> is set</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><ul>
+<li><code>true</code> if <a href="#strict"><code>strict</code></a> is <code>true</code></li>
+<li><code>false</code> otherwise.</li>
+</ul>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Check for class properties that are declared but not set in the constructor.</p>
@@ -1049,8 +1284,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='stripInternal'>
   <td><code><a href='/tsconfig/#stripInternal'>--stripInternal</a></code></td>
-  <td><code>boolean</code></td>
-  <td></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Disable emitting declarations that have <code>@internal</code> in their JSDoc comments.</p>
@@ -1058,8 +1295,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='suppressExcessPropertyErrors'>
   <td><code><a href='/tsconfig/#suppressExcessPropertyErrors'>--suppressExcessPropertyErrors</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Disable reporting of excess property errors during the creation of object literals.</p>
@@ -1067,17 +1306,21 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='suppressImplicitAnyIndexErrors'>
   <td><code><a href='/tsconfig/#suppressImplicitAnyIndexErrors'>--suppressImplicitAnyIndexErrors</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
-<p>Suppress <code>noImplicitAny</code> errors when indexing objects that lack index signatures.</p>
+<p>Suppress <a href="#noImplicitAny"><code>noImplicitAny</code></a> errors when indexing objects that lack index signatures.</p>
 </td></tr>
 
 <tr class='odd' name='target'>
   <td><code><a href='/tsconfig/#target'>--target</a></code></td>
-  <td><code><code>`ES3` (default)</code>, <code>`ES5`</code>, <code>`ES6`/`ES2015` (synonymous)</code>, <code>`ES7`/`ES2016`</code>, <code>`ES2017`</code>, <code>`ES2018`</code>, <code>`ES2019`</code>, <code>`ES2020`</code>, or <code>`ESNext`</code></code></td>
-  <td><p>ES3</p></td>
+  <td><p><code>ES3</code>, <code>ES5</code>, <code>ES6</code>/<code>ES2015</code>, <code>ES7</code>/<code>ES2016</code>, <code>ES2017</code>, <code>ES2018</code>, <code>ES2019</code>, <code>ES2020</code>, or <code>ESNext</code></p>
+</td>
+  <td><p><code>ES3</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Set the JavaScript language version for emitted JavaScript and include compatible library declarations.</p>
@@ -1085,17 +1328,21 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='traceResolution'>
   <td><code><a href='/tsconfig/#traceResolution'>--traceResolution</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p>false</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><p><code>false</code></p>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
-<p>Log paths used during the <code>moduleResolution</code> process.</p>
+<p>Log paths used during the <a href="#moduleResolution"><code>moduleResolution</code></a> process.</p>
 </td></tr>
 
 <tr class='odd' name='tsBuildInfoFile'>
   <td><code><a href='/tsconfig/#tsBuildInfoFile'>--tsBuildInfoFile</a></code></td>
-  <td><code>string</code></td>
-  <td><p>.tsbuildinfo</p></td>
+  <td><p><code>string</code></p>
+</td>
+  <td><p><code>.tsbuildinfo</code></p>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Specify the folder for .tsbuildinfo incremental compilation files.</p>
@@ -1103,8 +1350,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='typeRoots'>
   <td><code><a href='/tsconfig/#typeRoots'>--typeRoots</a></code></td>
-  <td><code>list</code></td>
-  <td></td>
+  <td><p><code>list</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Specify multiple folders that act like <code>./node_modules/@types</code>.</p>
@@ -1112,8 +1361,10 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='types'>
   <td><code><a href='/tsconfig/#types'>--types</a></code></td>
-  <td><code>list</code></td>
-  <td></td>
+  <td><p><code>list</code></p>
+</td>
+  <td>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Specify type package names to be included without being referenced in a source file.</p>
@@ -1121,8 +1372,13 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='even' name='useDefineForClassFields'>
   <td><code><a href='/tsconfig/#useDefineForClassFields'>--useDefineForClassFields</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p><code>true</code> for ES2022 and above, including ESNext.</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><ul>
+<li><code>true</code> if <a href="#target"><code>target</code></a> is <code>ES2022</code> or higher, including <code>ESNext</code></li>
+<li><code>false</code> otherwise.</li>
+</ul>
+</td>
 </tr>
 <tr class="option-description even"><td colspan="3">
 <p>Emit ECMAScript-standard-compliant class fields.</p>
@@ -1130,8 +1386,13 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 <tr class='odd' name='useUnknownInCatchVariables'>
   <td><code><a href='/tsconfig/#useUnknownInCatchVariables'>--useUnknownInCatchVariables</a></code></td>
-  <td><code>boolean</code></td>
-  <td><p><code>false</code>, unless <code>strict</code> is set</p></td>
+  <td><p><code>boolean</code></p>
+</td>
+  <td><ul>
+<li><code>true</code> if <a href="#strict"><code>strict</code></a> is <code>true</code></li>
+<li><code>false</code> otherwise.</li>
+</ul>
+</td>
 </tr>
 <tr class="option-description odd"><td colspan="3">
 <p>Default catch clause variables as <code>unknown</code> instead of <code>any</code>.</p>

--- a/packages/tsconfig-reference/scripts/cli/generateMarkdown.ts
+++ b/packages/tsconfig-reference/scripts/cli/generateMarkdown.ts
@@ -91,22 +91,30 @@ languages.forEach((lang) => {
 
       let optType: string;
       if (typeof option.type === "string") {
-        optType = option.type;
+        optType = `\`${option.type}\``;
       } else if (option.allowedValues) {
         if ("ListFormat" in Intl) {
           // @ts-ignore
           const or = new Intl.ListFormat(lang, { type: "disjunction" });
-          optType = or.format(option.allowedValues.map((v) => `<code>${v}</code>`));
+          optType = or.format(
+            option.allowedValues.map((v) => v.replace(/^[.0-9a-z]+$/i, "`$&`"))
+          );
         } else {
-          optType = option.allowedValues.map((v) => `<code>${v}</code>`).join(", ");
+          optType = option.allowedValues
+            .map((v) => v.replace(/^[.0-9a-z]+$/i, "`$&`"))
+            .join(", ");
         }
       } else {
         optType = "";
       }
-      markdownChunks.push(`  <td><code>${optType}</code></td>`);
+      markdownChunks.push(`  <td>${parseMarkdown(optType)}</td>`);
 
       if (!opts?.noDefaults) {
-        markdownChunks.push(`  <td>${`${parseMarkdown(option.defaultValue)}`.trim()}</td>`);
+        markdownChunks.push(
+          `  <td>${parseMarkdown(
+            option.defaultValue?.replace(/^[.0-9a-z]+$/i, "`$&`")
+          )}</td>`
+        );
       }
       markdownChunks.push(`</tr>`);
 

--- a/packages/tsconfig-reference/scripts/schema/result/schema.json
+++ b/packages/tsconfig-reference/scripts/schema/result/schema.json
@@ -88,16 +88,16 @@
               "markdownDescription": "Save .tsbuildinfo files to allow for incremental compilation of projects.\n\nSee more: https://www.typescriptlang.org/tsconfig#incremental"
             },
             "assumeChangesOnlyAffectDirectDependencies": {
-              "description": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.",
+              "description": "Have recompiles in projects that use [`incremental`](#incremental) and `watch` mode assume that changes within a file will only affect files directly depending on it.",
               "type": "boolean",
               "default": false,
-              "markdownDescription": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.\n\nSee more: https://www.typescriptlang.org/tsconfig#assumeChangesOnlyAffectDirectDependencies"
+              "markdownDescription": "Have recompiles in projects that use [`incremental`](#incremental) and `watch` mode assume that changes within a file will only affect files directly depending on it.\n\nSee more: https://www.typescriptlang.org/tsconfig#assumeChangesOnlyAffectDirectDependencies"
             },
             "traceResolution": {
-              "description": "Log paths used during the `moduleResolution` process.",
+              "description": "Log paths used during the [`moduleResolution`](#moduleResolution) process.",
               "type": "boolean",
               "default": false,
-              "markdownDescription": "Log paths used during the `moduleResolution` process.\n\nSee more: https://www.typescriptlang.org/tsconfig#traceResolution"
+              "markdownDescription": "Log paths used during the [`moduleResolution`](#moduleResolution) process.\n\nSee more: https://www.typescriptlang.org/tsconfig#traceResolution"
             }
           }
         }
@@ -267,10 +267,10 @@
               "markdownDescription": "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxFragmentFactory"
             },
             "jsxImportSource": {
-              "description": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.`",
+              "description": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.",
               "type": "string",
               "default": "react",
-              "markdownDescription": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.`\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxImportSource"
+              "markdownDescription": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxImportSource"
             },
             "listFiles": {
               "description": "Print all of the files read during the compilation.",
@@ -404,9 +404,9 @@
               "markdownDescription": "Skip type checking all .d.ts files.\n\nSee more: https://www.typescriptlang.org/tsconfig#skipLibCheck"
             },
             "outFile": {
-              "description": "Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output.",
+              "description": "Specify a file that bundles all outputs into one JavaScript file. If [`declaration`](#declaration) is true, also designates a file that bundles all .d.ts output.",
               "type": "string",
-              "markdownDescription": "Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output.\n\nSee more: https://www.typescriptlang.org/tsconfig#outFile"
+              "markdownDescription": "Specify a file that bundles all outputs into one JavaScript file. If [`declaration`](#declaration) is true, also designates a file that bundles all .d.ts output.\n\nSee more: https://www.typescriptlang.org/tsconfig#outFile"
             },
             "outDir": {
               "description": "Specify an output folder for all emitted files.",
@@ -471,10 +471,10 @@
               "markdownDescription": "Disable reporting of excess property errors during the creation of object literals.\n\nSee more: https://www.typescriptlang.org/tsconfig#suppressExcessPropertyErrors"
             },
             "suppressImplicitAnyIndexErrors": {
-              "description": "Suppress `noImplicitAny` errors when indexing objects that lack index signatures.",
+              "description": "Suppress [`noImplicitAny`](#noImplicitAny) errors when indexing objects that lack index signatures.",
               "type": "boolean",
               "default": false,
-              "markdownDescription": "Suppress `noImplicitAny` errors when indexing objects that lack index signatures.\n\nSee more: https://www.typescriptlang.org/tsconfig#suppressImplicitAnyIndexErrors"
+              "markdownDescription": "Suppress [`noImplicitAny`](#noImplicitAny) errors when indexing objects that lack index signatures.\n\nSee more: https://www.typescriptlang.org/tsconfig#suppressImplicitAnyIndexErrors"
             },
             "stripInternal": {
               "description": "Disable emitting declarations that have `@internal` in their JSDoc comments.",
@@ -818,10 +818,10 @@
               "markdownDescription": "When type checking, take into account `null` and `undefined`.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictNullChecks"
             },
             "maxNodeModuleJsDepth": {
-              "description": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`.",
+              "description": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with [`allowJs`](#allowJs).",
               "type": "number",
               "default": 0,
-              "markdownDescription": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`.\n\nSee more: https://www.typescriptlang.org/tsconfig#maxNodeModuleJsDepth"
+              "markdownDescription": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with [`allowJs`](#allowJs).\n\nSee more: https://www.typescriptlang.org/tsconfig#maxNodeModuleJsDepth"
             },
             "importHelpers": {
               "description": "Allow importing helper functions from tslib once per project, instead of including them per-file.",
@@ -876,10 +876,10 @@
               "markdownDescription": "Check for class properties that are declared but not set in the constructor.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictPropertyInitialization"
             },
             "esModuleInterop": {
-              "description": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility.",
+              "description": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables [`allowSyntheticDefaultImports`](#allowSyntheticDefaultImports) for type compatibility.",
               "type": "boolean",
               "default": false,
-              "markdownDescription": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility.\n\nSee more: https://www.typescriptlang.org/tsconfig#esModuleInterop"
+              "markdownDescription": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables [`allowSyntheticDefaultImports`](#allowSyntheticDefaultImports) for type compatibility.\n\nSee more: https://www.typescriptlang.org/tsconfig#esModuleInterop"
             },
             "allowUmdGlobalAccess": {
               "description": "Allow accessing UMD globals from modules.",

--- a/packages/tsconfig-reference/scripts/tsconfig/generateMarkdown.ts
+++ b/packages/tsconfig-reference/scripts/tsconfig/generateMarkdown.ts
@@ -247,14 +247,14 @@ languages.forEach((lang) => {
         if (option.recommended) mdTableRows.push(["Recommended", "True"]);
 
         if (option.defaultValue) {
-          const value = option.defaultValue.includes(" ")
-            ? option.defaultValue
-            : "`" + option.defaultValue + "`";
+          const value = option.defaultValue.replace(/^[.0-9a-z]+$/i, "`$&`");
           mdTableRows.push(["Default", value]);
         }
 
         if (option.allowedValues) {
-          const optionValue = option.allowedValues.join(",<br/>");
+          const optionValue = option.allowedValues
+            .map((value) => value.replace(/^[.0-9a-z]+$/i, "`$&`"))
+            .join(",<br/>");
           mdTableRows.push(["Allowed", optionValue]);
         }
 

--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -163,18 +163,27 @@ export const relatedTo: [AnOption, AnOption[]][] = [
  * So err, they are like 90% reliable.
  */
 
+function trueIf(name: string) {
+  return `
+- \`true\` if [\`${name}\`](#${name}) is \`true\`
+- \`false\` otherwise.
+`;
+}
+
 export const defaultsForOptions = {
   allowJs: "false",
-  allowSyntheticDefaultImports: 'module === "system" or esModuleInterop',
+  allowSyntheticDefaultImports: `
+- \`true\` if [\`module\`](#module) is \`system\` or [\`esModuleInterop\`](#esModuleInterop) is \`true\` and [\`module\`](#module) is not \`es6\`/\`es2015\` or \`esnext\`
+- \`false\` otherwise.
+  `,
   allowUmdGlobalAccess: "false",
   allowUnreachableCode: "undefined",
   allowUnusedLabels: "undefined",
   charset: "utf8",
   checkJs: "false",
   composite: "false",
-  alwaysStrict: "`false`, unless [`strict`](#strict) is set",
-  declaration: "`false`, unless [`composite`](#composite) is set",
-  declarationDir: " n/a",
+  alwaysStrict: trueIf("strict"),
+  declaration: trueIf("composite"),
   declarationMap: "false",
   diagnostics: "false",
   disableSizeLimit: "false",
@@ -182,36 +191,49 @@ export const defaultsForOptions = {
   emitBOM: "false",
   emitDeclarationOnly: "false",
   esModuleInterop: "false",
-  exclude:
-    '`["node_modules", "bower_components", "jspm_packages"]`, plus the value of [`outDir`](#outDir) if one is specified.',
+  exclude: `
+- \`node_modules\`
+- \`bower_components\`
+- \`jspm_packages\`
+- [\`outDir\`](#outDir)
+  `,
   extendedDiagnostics: "false",
   forceConsistentCasingInFileNames: "false",
-  generateCpuProfile: " profile.cpuprofile",
+  generateCpuProfile: "profile.cpuprofile",
   importHelpers: "false",
-  include: ' `[]` if [`files`](#files) is specified, otherwise `["**/*"]`',
-  incremental: "`true` if [`composite`](#composite), `false` otherwise",
+  include: `
+- \`[]\` if [\`files\`](#files) is specified
+- \`**\` otherwise.
+  `,
+  incremental: trueIf("composite"),
   inlineSourceMap: "false",
   inlineSources: "false",
   isolatedModules: "false",
   jsx: "undefined",
-  jsxFactory: "`React.createElement`",
+  jsxFactory: "React.createElement",
   jsxImportSource: "react",
   keyofStringsOnly: "false",
   listEmittedFiles: "false",
   listFiles: "false",
-  locale: "Platform specific",
+  locale: "Platform specific.",
   maxNodeModuleJsDepth: "0",
-  moduleResolution:
-    "module === `AMD` or `UMD` or `System` or `ES6`, then `Classic`<br/><br/>Otherwise `Node`",
-  newLine: "Platform specific",
+  module: `
+- \`CommonJS\` if [\`target\`](#target) is \`ES3\` or \`ES5\`
+- \`ES6\`/\`ES2015\` otherwise.
+  `,
+  moduleResolution: `
+- \`Classic\` if [\`module\`](#module) is \`AMD\`, \`UMD\`, \`System\` or \`ES6\`/\`ES2015\`
+- \`Node\` otherwise.
+  `,
+  newLine: "Platform specific.",
   noEmit: "false",
   noEmitHelpers: "false",
   noEmitOnError: "false",
   noErrorTruncation: "false",
   noFallthroughCasesInSwitch: "false",
-  noImplicitAny: "`false`, unless [`strict`](#strict) is set",
+  noImplicitAny: trueIf("strict"),
   noImplicitReturns: "false",
-  noImplicitThis: "`false`, unless [`strict`](#strict) is set",
+  noImplicitThis: trueIf("strict"),
   noImplicitUseStrict: "false",
   noPropertyAccessFromIndexSignature: "false",
   noLib: "false",
@@ -219,61 +241,57 @@ export const defaultsForOptions = {
   noStrictGenericChecks: "false",
   noUnusedLocals: "false",
   noUnusedParameters: "false",
-  out: "n/a",
-  outDir: "n/a",
-  outFile: "n/a",
   preserveConstEnums: "false",
   preserveSymlinks: "false",
   preserveWatchOutput: "false",
   pretty: "true",
-  reactNamespace: '"React"',
+  reactNamespace: "React",
   removeComments: "false",
   resolveJsonModule: "false",
-  rootDir: "Computed from the list of input files",
+  rootDir: "Computed from the list of input files.",
   skipDefaultLibCheck: "false",
   skipLibCheck: "false",
   sourceMap: "false",
   strict: "false",
-  strictBindCallApply: "`false`, unless [`strict`](#strict) is set",
-  strictFunctionTypes: "`false`, unless [`strict`](#strict) is set",
-  useUnknownInCatchVariables: "`false`, unless [`strict`](#strict) is set",
-  strictPropertyInitialization: "`false`, unless [`strict`](#strict) is set",
-  strictNullChecks: "`false`, unless [`strict`](#strict) is set",
+  strictBindCallApply: trueIf("strict"),
+  strictFunctionTypes: trueIf("strict"),
+  useUnknownInCatchVariables: trueIf("strict"),
+  strictPropertyInitialization: trueIf("strict"),
+  strictNullChecks: trueIf("strict"),
   suppressExcessPropertyErrors: "false",
   suppressImplicitAnyIndexErrors: "false",
   target: "ES3",
   traceResolution: "false",
   tsBuildInfoFile: ".tsbuildinfo",
-  useDefineForClassFields: "`true` for ES2022 and above, including ESNext.",
+  useDefineForClassFields: `
+- \`true\` if [\`target\`](#target) is \`ES2022\` or higher, including \`ESNext\`
+- \`false\` otherwise.
+  `,
 };
 
 export const allowedValues = {
-  jsx: ["`react`", "`react-jsx`", "`react-jsxdev`", "`react-native`", "`preserve`"],
-  jsxFactory: ["Any identifier or dotted identifier"],
-  lib: ["See main content"],
+  jsx: ["react", "react-jsx", "react-jsxdev", "react-native", "preserve"],
+  jsxFactory: ["Any identifier or dotted identifier."],
   target: [
-    "`ES3` (default)",
-    "`ES5`",
-    "`ES6`/`ES2015` (synonymous)",
+    "ES3",
+    "ES5",
+    "`ES6`/`ES2015`",
     "`ES7`/`ES2016`",
-    "`ES2017`",
-    "`ES2018`",
-    "`ES2019`",
-    "`ES2020`",
-    "`ESNext`",
+    "ES2017",
+    "ES2018",
+    "ES2019",
+    "ES2020",
+    "ESNext",
   ],
   module: [
-    "`CommonJS` (default if [`target`](#target) is `ES3` or `ES5`)",
-    "",
-    "`ES6`",
-    "`ES2015`",
-    "`ES2020`",
-    "",
-    "`None`",
-    "`UMD`",
-    "`AMD`",
-    "`System`",
-    "`ESNext`",
+    "CommonJS",
+    "`ES6`/`ES2015`",
+    "ES2020",
+    "None",
+    "UMD",
+    "AMD",
+    "System",
+    "ESNext",
   ],
   importsNotUsedAsValues: ["remove", "preserve", "error"],
   watchFile: [

--- a/packages/typescriptlang-org/src/templates/documentation.scss
+++ b/packages/typescriptlang-org/src/templates/documentation.scss
@@ -340,6 +340,15 @@
     tr.even {
       background-color: var(--background-minor-highlight-color) !important;
     }
+    ul {
+      margin: 0;
+      padding: 0;
+      li {
+        list-style: none;
+        margin: 0;
+        margin-bottom: 8px;
+      }
+    }
 
     tr.option-description td {
       margin-top: 0;

--- a/packages/typescriptlang-org/src/templates/tsconfig.scss
+++ b/packages/typescriptlang-org/src/templates/tsconfig.scss
@@ -267,6 +267,15 @@
         li {
           list-style: none;
           margin-bottom: 12px;
+
+          ul {
+            padding: 0;
+            margin-bottom: 18px;
+          }
+          li {
+            margin: 0;
+            margin-bottom: 12px;
+          }
         }
         tr {
           padding: 10px 0;


### PR DESCRIPTION
Mainly what I want is to lookup the default value of [`module`](https://www.typescriptlang.org/tsconfig#module). The [old reference](https://web.archive.org/web/20190102001939/https://www.typescriptlang.org/docs/handbook/compiler-options.html) made clear that it's `es6` unless `target` is `es3` or `es5`.

While I'm at it I'd like to make the descriptions of conditional default values more consistent, instead of using prose in most cases and pseudocode (`module === "system"`) in others:
- I used lists to align the default values (e.g. `commonjs`) on the left and their conditions ("if [`target`](#target) is `es3` or `es5`") on the right.

What do you think?

I noticed some Markdown isn't parsed in the CLI reference: 
![Screenshot from 2021-09-28 09-42-36](https://user-images.githubusercontent.com/78493/135130951-a97bb446-496c-49a2-a31f-017162cd5681.png)
- I removed Markdown from singular default values and allowed values and updated the condition in `cli/generateMarkdown.ts`/`tsconfig/generateMarkdown.ts` for adding quotes s.t. singular values (`/^[.0-9a-z]+$/i`) are quoted and others aren't.
- This makes the treatment consistent between default values and allowed values (the same values are quoted/not) and between the tsconfig and CLI references (Markdown parsed where appropriate).

Finally some nitpicky edits:
- Consistently punctuated descriptions with ".".
- Removed "n/a" because it wasn't clear (to me) what's difference between these, and options without a default value?