### PR TITLE
Cut after comment

### DIFF
--- a/packages/ts-twoslasher/src/index.ts
+++ b/packages/ts-twoslasher/src/index.ts
@@ -817,6 +817,25 @@ export function twoslasher(code: string, extension: string, options: TwoSlashOpt
     tags = tags.filter(q => q.line > -1)
   }
 
+  const cutAfterString = "// ---cut-after---\n"
+
+  if (code.includes(cutAfterString)) {
+    
+    // Get the place it is, then find the end and the start of the next line
+    const cutIndex = code.indexOf(cutAfterString) + cutAfterString.length
+    const lineOffset = code.substr(0, cutIndex).split("\n").length - 1
+
+    // Kills the code shown, removing any whitespace on the end
+    code = code.split(cutAfterString).shift()!.trimEnd()
+    
+    // Cut any metadata after the cutAfterString
+    staticQuickInfos = staticQuickInfos.filter(s => s.line < lineOffset)
+    errors = errors.filter(e => e.line && e.line < lineOffset)
+    highlights = highlights.filter(e => e.line < lineOffset)
+    queries = queries.filter(q => q.line < lineOffset)
+    tags = tags.filter(q => q.line < lineOffset)
+  }
+
   return {
     code,
     extension,

--- a/packages/ts-twoslasher/test/cutting.test.ts
+++ b/packages/ts-twoslasher/test/cutting.test.ts
@@ -84,3 +84,30 @@ const c = "678"
     expect(bQueryResult!.text).toContain("const c")
   })
 })
+
+describe("supports hiding after a line", () => {
+  const file = `
+const a = "123"
+// ---cut-after---
+const b = "345"
+`
+  const result = twoslasher(file, "ts")
+
+  it("hides the right code", () => {
+    // Has the right code shipped
+    expect(result.code).toContain("const a")
+    expect(result.code).not.toContain("const b")
+  })
+
+  it("shows the right LSP results", () => {
+    expect(result.staticQuickInfos.find(info => info.text.includes("const b"))).toBeUndefined()
+
+    const bLSPResult = result.staticQuickInfos.find(info => info.text.includes("const a"))
+    expect(bLSPResult).toBeTruthy()
+
+    // b is one char long
+    expect(bLSPResult!.length).toEqual(1)
+    // Should be at char 7
+    expect(bLSPResult!.start).toEqual(7)
+  })
+})


### PR DESCRIPTION
Writing code snippets for complex React examples, we often find ourselves in the position where we're repeating "boilerplate" compositional components or wrapping raw JSX.

```tsx 
<Container>
  <ImportantComponent />
</Container>
```

or

```tsx 
const Page = () => (
  <Container>
    <ImportantComponent />
  </Container>
)
```

The `<Container>` ... `</Container>` or `const Page = () => (` ... `)` parts are unnecessary noise for our documentation in these places, but are syntactically required.

This PR adds a `---cut-after---` comment.

```tsx 
<Container>
// ---cut---
  <ImportantComponent />
// ---cut-after---
</Container>
```

```tsx 
const Page = () => (
// ---cut---
  <Container>
    <ImportantComponent />
  </Container>
// ---cut-after---
)
```

If there are other tests you'd like / a name change, let me know.