### PR TITLE
Add some allowed values

### DIFF
--- a/packages/tsconfig-reference/scripts/cli/generateJSON.ts
+++ b/packages/tsconfig-reference/scripts/cli/generateJSON.ts
@@ -86,6 +86,17 @@ filteredOptions.forEach((option) => {
 
   if (name in allowedValues) {
     option.allowedValues = allowedValues[name];
+  } else if (typeof option.type === "object") {
+    // Group and format synonyms: `es6`/`es2015`
+    const byValue: { [value: number]: string[] } = {};
+    for (const [name, value] of Object.entries(option.type)) {
+      (byValue[value] ||= []).push(name);
+    }
+    option.allowedValues = Object.values(byValue).map((synonyms) =>
+      synonyms.length > 1
+        ? synonyms.map((name) => `\`${name}\``).join("/")
+        : synonyms[0]
+    );
   }
 
   if (name in configToRelease) {

--- a/packages/tsconfig-reference/scripts/tsconfig/generateJSON.ts
+++ b/packages/tsconfig-reference/scripts/tsconfig/generateJSON.ts
@@ -176,6 +176,17 @@ allOptions.forEach((option) => {
 
   if (name in allowedValues) {
     option.allowedValues = allowedValues[name];
+  } else if (typeof option.type === "object") {
+    // Group and format synonyms: `es6`/`es2015`
+    const byValue: { [value: number]: string[] } = {};
+    for (const [name, value] of Object.entries(option.type)) {
+      (byValue[value] ||= []).push(name);
+    }
+    option.allowedValues = Object.values(byValue).map((synonyms) =>
+      synonyms.length > 1
+        ? synonyms.map((name) => `\`${name}\``).join("/")
+        : synonyms[0]
+    );
   }
 
   if (name in configToRelease) {

--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -248,34 +248,8 @@ export const defaultsForOptions = {
 };
 
 export const allowedValues = {
-  jsx: ["`react`", "`react-jsx`", "`react-jsxdev`", "`react-native`", "`preserve`"],
   jsxFactory: ["Any identifier or dotted identifier"],
   lib: ["See main content"],
-  target: [
-    "`ES3` (default)",
-    "`ES5`",
-    "`ES6`/`ES2015` (synonymous)",
-    "`ES7`/`ES2016`",
-    "`ES2017`",
-    "`ES2018`",
-    "`ES2019`",
-    "`ES2020`",
-    "`ESNext`",
-  ],
-  module: [
-    "`CommonJS` (default if [`target`](#target) is `ES3` or `ES5`)",
-    "",
-    "`ES6`",
-    "`ES2015`",
-    "`ES2020`",
-    "",
-    "`None`",
-    "`UMD`",
-    "`AMD`",
-    "`System`",
-    "`ESNext`",
-  ],
-  importsNotUsedAsValues: ["remove", "preserve", "error"],
   watchFile: [
     "fixedPollingInterval",
     "priorityPollingInterval",


### PR DESCRIPTION
Add `es2021` `target`, `newLine` allowed values (`crlf` and `lf`), by pulling them from `ts.buildOpts[].type`.

Somewhat related to #2049: The allowed values in `option.type` aren't `` ` `` quoted, but #2049 adds the quotes.