### PR TITLE
HTMLify tsconfig option summaries

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfig/generateMarkdown.ts
+++ b/packages/tsconfig-reference/scripts/tsconfig/generateMarkdown.ts
@@ -97,7 +97,6 @@ languages.forEach((lang) => {
   const fallbackLocale = join(__dirname, "..", "..", "copy", "en");
 
   const mdChunks: string[] = [];
-  const optionsOneLiners: Record<string, string> = {};
 
   const getPathInLocale = (path: string, optionalExampleContent?: string, failable = false) => {
     if (existsSync(join(locale, path))) return join(locale, path);
@@ -216,12 +215,10 @@ languages.forEach((lang) => {
         optionsSummary.push({
           id: optionName,
           display: optionFile.data.display,
-          oneliner: optionFile.data.oneline,
+          oneliner: String(parseMarkdown(optionFile.data.oneline)),
           categoryID: categoryID,
           categoryDisplay: categoryName,
         });
-
-        optionsOneLiners[optionName] = optionFile.data.oneline;
 
         mdChunks.push("<section class='compiler-option'>");
 
@@ -326,7 +323,12 @@ languages.forEach((lang) => {
   if (!existsSync(jsonDir)) mkdirSync(jsonDir);
 
   // This is used by the tsconfig popups
-  writeFileSync(join(jsonDir, lang + "-tsconfig-popup.json"), JSON.stringify(optionsOneLiners));
+  writeFileSync(
+    join(jsonDir, lang + "-tsconfig-popup.json"),
+    JSON.stringify(
+      Object.fromEntries(optionsSummary.map((data) => [data.id, data.oneliner]))
+    )
+  );
 });
 
 writeFileSync(


### PR DESCRIPTION
Noticed that we're displaying raw Markdown in the [tsconfig popups](https://github.com/microsoft/TypeScript-Website/pull/1911): 
![Screenshot from 2021-09-29 11-23-53](https://user-images.githubusercontent.com/78493/135327014-cc4fd8a3-cbe5-4bf5-8d55-6229589be671.png)

This PR renders it to HTML. Likewise affects raw Markdown in the playground tsconfig panel? 
![Screenshot from 2021-09-29 11-23-02](https://user-images.githubusercontent.com/78493/135327055-75101daf-eb49-4cb0-82a9-86c63e94ca70.png)