### PR TITLE
Fix the declared types version example to the text description

### DIFF
--- a/packages/documentation/copy/en/declaration-files/Publishing.md
+++ b/packages/documentation/copy/en/declaration-files/Publishing.md
@@ -132,7 +132,7 @@ When you want to only change the resolution for a single file at a time, you can
   "version": "1.0.0",
   "types": "./index.d.ts",
   "typesVersions": {
-    "<=4.0": { "index.d.ts": ["index.v3.d.ts"] }
+    "<4.0": { "index.d.ts": ["index.v3.d.ts"] }
   }
 }
 ```


### PR DESCRIPTION
Given the description:
> On TypeScript 4.0 and above, an import for "package-name" would resolve to ./index.d.ts and for 3.9 and below "./index.v3.d.ts.

and the used filename:
> "index.v3.d.ts"

it seems that the proposed change is correct