### PR TITLE
Extract parseMarkdown()

### DIFF
--- a/packages/tsconfig-reference/scripts/cli/generateMarkdown.ts
+++ b/packages/tsconfig-reference/scripts/cli/generateMarkdown.ts
@@ -12,9 +12,7 @@ import { join } from "path";
 import { read as readMarkdownFile } from "gray-matter";
 import * as prettier from "prettier";
 import { CompilerOptionJSON } from "./generateJSON.js";
-
-import * as remark from "remark";
-import * as remarkHTML from "remark-html";
+import { parseMarkdown } from "../tsconfigRules";
 
 const options = require(join(__dirname, "../../data/cliOpts.json")) as {
   options: CompilerOptionJSON[];
@@ -22,7 +20,6 @@ const options = require(join(__dirname, "../../data/cliOpts.json")) as {
   watch: CompilerOptionJSON[];
   cli: CompilerOptionJSON[];
 };
-const parseMarkdown = (md: string) => remark().use(remarkHTML).processSync(md);
 
 const knownTypes: Record<string, string> = {};
 
@@ -97,11 +94,13 @@ languages.forEach((lang) => {
           // @ts-ignore
           const or = new Intl.ListFormat(lang, { type: "disjunction" });
           optType = or.format(
-            option.allowedValues.map((v) => v.replace(/^[.0-9a-z]+$/i, "`$&`"))
+            option.allowedValues.map((v) =>
+              v.replace(/^[-.0-9_a-z]+$/i, "`$&`")
+            )
           );
         } else {
           optType = option.allowedValues
-            .map((v) => v.replace(/^[.0-9a-z]+$/i, "`$&`"))
+            .map((v) => v.replace(/^[-.0-9_a-z]+$/i, "`$&`"))
             .join(", ");
         }
       } else {
@@ -110,11 +109,7 @@ languages.forEach((lang) => {
       markdownChunks.push(`  <td>${parseMarkdown(optType)}</td>`);
 
       if (!opts?.noDefaults) {
-        markdownChunks.push(
-          `  <td>${parseMarkdown(
-            option.defaultValue?.replace(/^[.0-9a-z]+$/i, "`$&`")
-          )}</td>`
-        );
+        markdownChunks.push(`  <td>${parseMarkdown(option.defaultValue)}</td>`);
       }
       markdownChunks.push(`</tr>`);
 

--- a/packages/tsconfig-reference/scripts/tsconfig/generateMarkdown.ts
+++ b/packages/tsconfig-reference/scripts/tsconfig/generateMarkdown.ts
@@ -25,14 +25,13 @@ import * as assert from "assert";
 import { read as readMarkdownFile } from "gray-matter";
 import * as prettier from "prettier";
 import { CompilerOptionJSON } from "./generateJSON.js";
-import * as remark from "remark";
-import * as remarkHTML from "remark-html";
 
 import {
   typeAcquisitionCompilerOptNames,
   buildOptionCompilerOptNames,
   watchOptionCompilerOptNames,
   rootOptNames,
+  parseMarkdown,
 } from "../tsconfigRules";
 
 const options = require("../../data/tsconfigOpts.json").options as CompilerOptionJSON[];
@@ -85,8 +84,6 @@ const sections = [
   { name: "watchOptions", options: watchOptionCompilerOptNames, idPrefix: "watch" },
   { name: "typeAcquisition", options: typeAcquisitionCompilerOptNames, idPrefix: "type" },
 ];
-
-const parseMarkdown = (md: string) => remark().use(remarkHTML).processSync(md);
 
 const languages = readdirSync(join(__dirname, "..", "..", "copy")).filter(
   (f) => !f.startsWith(".")
@@ -237,31 +234,25 @@ languages.forEach((lang) => {
         mdChunks.push("</div>");
 
         // Make a markdown table of the important metadata
-        const mdTableRows = [] as [string, string][];
+        const mdTableRows = [] as [string, string | string[]][];
 
         if (option.deprecated) mdTableRows.push(["Status", "Deprecated"]);
 
         if (option.recommended) mdTableRows.push(["Recommended", "True"]);
 
         if (option.defaultValue) {
-          const value = option.defaultValue.replace(/^[.0-9a-z]+$/i, "`$&`");
-          mdTableRows.push(["Default", value]);
+          mdTableRows.push(["Default", option.defaultValue]);
         }
 
         if (option.allowedValues) {
-          const optionValue = option.allowedValues
-            .map((value) => value.replace(/^[.0-9a-z]+$/i, "`$&`"))
-            .join(",<br/>");
-          mdTableRows.push(["Allowed", optionValue]);
+          mdTableRows.push(["Allowed", option.allowedValues]);
         }
 
         if (option.related) {
-          const optionValue = option.related
-            .map(
-              (r) =>
-                `<a href='#${r}' aria-label="Jump to compiler option info for ${r}" ><code>${r}</code></a>`
-            )
-            .join(", ");
+          const optionValue = option.related.map(
+            (r) =>
+              `<a href='#${r}' aria-label="Jump to compiler option info for ${r}" ><code>${r}</code></a>`
+          );
           mdTableRows.push(["Related", optionValue]);
         }
 

--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -1,4 +1,6 @@
 import { CompilerOptionName } from "../data/_types";
+import * as remark from "remark";
+import * as remarkHTML from "remark-html";
 import * as ts from "typescript";
 
 /**
@@ -165,18 +167,18 @@ export const relatedTo: [AnOption, AnOption[]][] = [
  */
 
 function trueIf(name: string) {
-  return `
-- \`true\` if [\`${name}\`](#${name}) is \`true\`
-- \`false\` otherwise.
-`;
+  return [
+    `\`true\` if [\`${name}\`](#${name}) is \`true\``,
+    "`false` otherwise.",
+  ];
 }
 
 export const defaultsForOptions = {
   allowJs: "false",
-  allowSyntheticDefaultImports: `
-- \`true\` if [\`module\`](#module) is \`system\` or [\`esModuleInterop\`](#esModuleInterop) is \`true\` and [\`module\`](#module) is not \`es6\`/\`es2015\` or \`esnext\`
-- \`false\` otherwise.
-  `,
+  allowSyntheticDefaultImports: [
+    "`true` if [`module`](#module) is `system` or [`esModuleInterop`](#esModuleInterop) is `true` and [`module`](#module) is not `es6`/`es2015` or `esnext`",
+    "`false` otherwise.",
+  ],
   allowUmdGlobalAccess: "false",
   allowUnreachableCode: "undefined",
   allowUnusedLabels: "undefined",
@@ -192,20 +194,17 @@ export const defaultsForOptions = {
   emitBOM: "false",
   emitDeclarationOnly: "false",
   esModuleInterop: "false",
-  exclude: `
-- \`node_modules\`
-- \`bower_components\`
-- \`jspm_packages\`
-- [\`outDir\`](#outDir)
-  `,
+  exclude: [
+    "node_modules",
+    "bower_components",
+    "jspm_packages",
+    "[`outDir`](#outDir)",
+  ],
   extendedDiagnostics: "false",
   forceConsistentCasingInFileNames: "false",
   generateCpuProfile: "profile.cpuprofile",
   importHelpers: "false",
-  include: `
-- \`[]\` if [\`files\`](#files) is specified
-- \`**\` otherwise.
-  `,
+  include: ["`[]` if [`files`](#files) is specified", "`**` otherwise."],
   incremental: trueIf("composite"),
   inlineSourceMap: "false",
   inlineSources: "false",
@@ -218,15 +217,15 @@ export const defaultsForOptions = {
   listFiles: "false",
   locale: "Platform specific.",
   maxNodeModuleJsDepth: "0",
-  module: `
-- \`CommonJS\` if [\`target\`](#target) is \`ES3\` or \`ES5\`
-- \`ES6\`/\`ES2015\` otherwise.
-  `,
-  moduleResolution: `
-- \`Classic\` if [\`module\`](#module) is \`AMD\`, \`UMD\`, \`System\` or \`ES6\`/\`ES2015\`
-- Matches if [\`module\`](#module) is \`node12\` or \`nodenext\`
-- \`Node\` otherwise.
-  `,
+  module: [
+    "`CommonJS` if [`target`](#target) is `ES3` or `ES5`",
+    "`ES6`/`ES2015` otherwise.",
+  ],
+  moduleResolution: [
+    "`Classic` if [`module`](#module) is `AMD`, `UMD`, `System` or `ES6`/`ES2015`",
+    "Matches if [`module`](#module) is `node12` or `nodenext`",
+    "`Node` otherwise.",
+  ],
   newLine: "Platform specific.",
   noEmit: "false",
   noEmitHelpers: "false",
@@ -265,10 +264,10 @@ export const defaultsForOptions = {
   target: "ES3",
   traceResolution: "false",
   tsBuildInfoFile: ".tsbuildinfo",
-  useDefineForClassFields: `
-- \`true\` if [\`target\`](#target) is \`ES2022\` or higher, including \`ESNext\`
-- \`false\` otherwise.
-  `,
+  useDefineForClassFields: [
+    "`true` if [`target`](#target) is `ES2022` or higher, including `ESNext`",
+    "`false` otherwise.",
+  ],
 };
 
 export const allowedValues = {
@@ -355,3 +354,12 @@ Object.keys(releaseToConfigsMap).forEach((v) => {
     configToRelease[key] = v;
   });
 });
+
+export const parseMarkdown = (value: string | string[]) =>
+  Array.isArray(value)
+    ? `<ul>${value
+        .map((element) => `<li>${parseMarkdown(element)}</li>`)
+        .join("")}</ul>`
+    : remark()
+        .use(remarkHTML)
+        .processSync(value?.replace(/^[-.0-9_a-z]+$/i, "`$&`"));


### PR DESCRIPTION
I'd like to extract some common code from `{cli,tsconfig}/generateMarkdown.ts`:
- the code to format lists of values
- the code to quote singular values
- the `parseMarkdown()` utility

This means that:
- `{cli,tsconfig}/generateMarkdown.ts` will share the same utility
- lists of default values and allowed values will be marked up the same
- marking up lists of default values will be delegated to the utility, simplifying them slightly

The only functional change is that allowed values (and related options) are now marked up in unordered lists, same as default values are already.

While I was at it I revised the code to quote singular values to fix the following: 
![Screenshot from 2021-10-05 10-55-26](https://user-images.githubusercontent.com/78493/136076997-16509d22-72bb-4aa3-99c0-0033393c04d9.png)