### PR TITLE
Uniform tsconfig status

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfig/generateMarkdown.ts
+++ b/packages/tsconfig-reference/scripts/tsconfig/generateMarkdown.ts
@@ -234,11 +234,15 @@ languages.forEach((lang) => {
         mdChunks.push("</div>");
 
         // Make a markdown table of the important metadata
-        const mdTableRows = [] as [string, string | string[]][];
+        const mdTableRows = [] as [string, (string | string[])?][];
 
-        if (option.deprecated) mdTableRows.push(["Status", "Deprecated"]);
+        if (option.deprecated) mdTableRows.push(["Deprecated"]);
 
-        if (option.recommended) mdTableRows.push(["Recommended", "True"]);
+        if (option.recommended) mdTableRows.push(["Recommended"]);
+
+        if (option.internal) {
+          mdTableRows.push(["Internal"]);
+        }
 
         if (option.defaultValue) {
           mdTableRows.push(["Default", option.defaultValue]);
@@ -256,10 +260,6 @@ languages.forEach((lang) => {
           mdTableRows.push(["Related", optionValue]);
         }
 
-        if (option.internal) {
-          mdTableRows.push(["Status", "internal"]);
-        }
-
         if (option.releaseVersion) {
           const underscores = option.releaseVersion.replace(".", "-");
           const link = `/docs/handbook/release-notes/typescript-${underscores}.html`;
@@ -272,7 +272,12 @@ languages.forEach((lang) => {
         const table =
           "<ul class='compiler-option-md'>" +
           mdTableRows
-            .map((r) => `<li><span>${r[0]}:</span>${parseMarkdown(r[1])}</li>`)
+            .map(
+              (r) =>
+                `<li><span>${r[0]}${
+                  r.length > 1 ? ":" : ""
+                }</span>${parseMarkdown(r[1])}</li>`
+            )
             .join("\n") +
           "</ul>";
 


### PR DESCRIPTION
Currently we display "Recommended: True", "Status: Deprecated" and "Status: internal". What do you think of more uniformly displaying "Recommended", "Deprecated" and "Internal" instead?

||||
|-|-|-|
|![Screenshot from 2021-10-06 12-07-17](https://user-images.githubusercontent.com/78493/136268033-275d50b1-5fcb-4fa2-8bea-bb1c34a67bb2.png)|![Screenshot from 2021-10-06 12-08-29](https://user-images.githubusercontent.com/78493/136268032-52aebd64-0d24-467e-894e-7ec97cc5abdc.png)|![Screenshot from 2021-10-06 12-09-59](https://user-images.githubusercontent.com/78493/136268030-8bf2402a-3e6c-4ac7-ba17-e26d058f4df2.png)|
|![Screenshot from 2021-10-06 12-10-59](https://user-images.githubusercontent.com/78493/136268029-27efae5f-3bb8-415f-905f-623992a987d4.png)|![Screenshot from 2021-10-06 12-11-54](https://user-images.githubusercontent.com/78493/136268026-d5e88c6e-aa61-427b-b440-027a4ece0d03.png)|![Screenshot from 2021-10-06 12-12-41](https://user-images.githubusercontent.com/78493/136268023-7a615114-61f9-4026-9dc6-9f494bd59281.png)|