### PR TITLE
Revise preserveConstEnums default value

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -242,7 +242,7 @@ export const defaultsForOptions = {
   noStrictGenericChecks: "false",
   noUnusedLocals: "false",
   noUnusedParameters: "false",
-  preserveConstEnums: "false",
+  preserveConstEnums: trueIf("isolatedModules"),
   preserveSymlinks: "false",
   preserveWatchOutput: "false",
   pretty: "true",


### PR DESCRIPTION
I think the `preserveConstEnums` default is `true` if `isolatedModules` is `true`? https://github.com/microsoft/TypeScript/blob/f6c0231f08353cf16d22a54ff33814110e6c9d7c/src/compiler/utilities.ts#L6213-L6215