### PR TITLE
Fix return type in doSomething(f: Function)

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -689,7 +689,7 @@ It also has the special property that values of type `Function` can always be ca
 
 ```ts twoslash
 function doSomething(f: Function) {
-  f(1, 2, 3);
+  return f(1, 2, 3);
 }
 ```
 


### PR DESCRIPTION
**Description from the handbook**: The global type `Function` describes properties like `bind`, `call`, `apply`, and others present on all function values in JavaScript.
It also has the special property that values of type `Function` can always be called; these calls return `any`:


**What has been done**: Add `return` to make sure that the `Function`'s return type `any` is propagated to `doSomething`. Otherwise the return type is `void`.