### PR TITLE
fix type in documentation

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -339,7 +339,7 @@ interface Checkable {
 class NameChecker implements Checkable {
   check(s) {
     // Notice no error here
-    return s.toLowercse() === "ok";
+    return s.toLowercase() === "ok";
     //         ^?
   }
 }


### PR DESCRIPTION
the method `toLowerCase` is typed as `toLowerCse`