### PR TITLE
ATA: Fix distributed output to match package type's ESM

### DIFF
--- a/packages/ata/package.json
+++ b/packages/ata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript/ata",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "MIT",
   "homepage": "https://github.com/microsoft/TypeScript-Website",
   "repository": {

--- a/packages/ata/package.json
+++ b/packages/ata/package.json
@@ -12,7 +12,7 @@
   "type": "module",
   "types": "src/userFacingTypes.d.ts",
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --outfile=dist/index.js --platform=node && cpy src/userFacingTypes.d.ts dist/ --rename=index.d.ts && cpy src/ ../sandbox/src/vendor/ata",
+    "build": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --platform=node && cpy src/userFacingTypes.d.ts dist/ --rename=index.d.ts && cpy src/ ../sandbox/src/vendor/ata",
     "test": "jest",
     "bootstrap": "yarn build"
   },
@@ -24,5 +24,8 @@
     "esbuild": "^0.12.9",
     "esbuild-jest": "^0.5.0",
     "jest": "*"
+  },
+  "peerDependencies": {
+    "typescript": "^4.4.4"
   }
 }

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@typescript/ata": "0.9.0",
+    "@typescript/ata": "0.9.2",
     "@typescript/vfs": "1.3.5"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5519,7 +5519,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript/ata@0.9.0, @typescript/ata@workspace:packages/ata":
+"@typescript/ata@0.9.2, @typescript/ata@workspace:packages/ata":
   version: 0.0.0-use.local
   resolution: "@typescript/ata@workspace:packages/ata"
   dependencies:
@@ -5527,6 +5527,8 @@ __metadata:
     esbuild: ^0.12.9
     esbuild-jest: ^0.5.0
     jest: "*"
+  peerDependencies:
+    typescript: ^4.4.4
   languageName: unknown
   linkType: soft
 
@@ -5559,7 +5561,7 @@ __metadata:
   resolution: "@typescript/sandbox@workspace:packages/sandbox"
   dependencies:
     "@types/jest": ^25.1.3
-    "@typescript/ata": 0.9.0
+    "@typescript/ata": 0.9.2
     "@typescript/vfs": 1.3.5
     jest: "*"
     monaco-editor: ~0.20.0


### PR DESCRIPTION
fixes #2101

Existing tests pass, and importing in an ESM project (ex [ts-scratch-pad](https://github.com/jwfwessels/ts-scratch-pad)) now works.