### PR TITLE
Uniform option description punctuation

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/disableSourceOfProjectReferenceRedirect.md
+++ b/packages/tsconfig-reference/copy/en/options/disableSourceOfProjectReferenceRedirect.md
@@ -1,6 +1,6 @@
 ---
 display: "Disable Source Project Reference Redirect"
-oneline: "Disable preferring source files instead of declaration files when referencing composite projects"
+oneline: "Disable preferring source files instead of declaration files when referencing composite projects."
 ---
 
 When working with [composite TypeScript projects](/docs/handbook/project-references.html), this option provides a way to go [back to the pre-3.7](/docs/handbook/release-notes/typescript-3-7.html#build-free-editing-with-project-references) behavior where d.ts files were used to as the boundaries between modules.

--- a/packages/tsconfig-reference/copy/en/options/enable.md
+++ b/packages/tsconfig-reference/copy/en/options/enable.md
@@ -1,6 +1,6 @@
 ---
 display: "enable"
-oneline: "Disable the type acquisition for JavaScript projects"
+oneline: "Disable the type acquisition for JavaScript projects."
 ---
 
 Offers a config for disabling type-acquisition in JavaScript projects:

--- a/packages/tsconfig-reference/copy/en/options/exactOptionalPropertyTypes.md
+++ b/packages/tsconfig-reference/copy/en/options/exactOptionalPropertyTypes.md
@@ -1,6 +1,6 @@
 ---
 display: "exactOptionalPropertyTypes"
-oneline: "Differentiate between undefined and not present when type checking"
+oneline: "Differentiate between undefined and not present when type checking."
 ---
 
 With exactOptionalPropertyTypes enabled, TypeScript applies stricter rules around how it handles properties on `type` or `interfaces` which have a `?` prefix.

--- a/packages/tsconfig-reference/copy/en/options/force.md
+++ b/packages/tsconfig-reference/copy/en/options/force.md
@@ -1,6 +1,6 @@
 ---
 display: "force"
-oneline: "Build all projects, including those that appear to be up to date"
+oneline: "Build all projects, including those that appear to be up to date."
 ---
 
 Build all projects, including those that appear to be up to date

--- a/packages/tsconfig-reference/copy/en/options/jsxFactory.md
+++ b/packages/tsconfig-reference/copy/en/options/jsxFactory.md
@@ -1,6 +1,6 @@
 ---
 display: "JSX Factory"
-oneline: "Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'"
+oneline: "Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'."
 ---
 
 Changes the function called in `.js` files when compiling JSX Elements using the classic JSX runtime.

--- a/packages/tsconfig-reference/copy/en/options/noEmit.md
+++ b/packages/tsconfig-reference/copy/en/options/noEmit.md
@@ -1,6 +1,6 @@
 ---
 display: "No Emit"
-oneline: "Disable emitting file from a compilation."
+oneline: "Disable emitting files from a compilation."
 ---
 
 Do not emit compiler output files like JavaScript source code, source-maps or declarations.

--- a/packages/tsconfig-reference/copy/en/options/noPropertyAccessFromIndexSignature.md
+++ b/packages/tsconfig-reference/copy/en/options/noPropertyAccessFromIndexSignature.md
@@ -1,6 +1,6 @@
 ---
 display: "noPropertyAccessFromIndexSignature"
-oneline: "Enforces using indexed accessors for keys declared using an indexed type"
+oneline: "Enforces using indexed accessors for keys declared using an indexed type."
 ---
 
 This setting ensures consistency between accessing a field via the "dot" (`obj.key`) syntax, and "indexed" (`obj["key"]`) and the way which the property is declared in the type.

--- a/packages/tsconfig-reference/copy/en/options/noUnusedParameters.md
+++ b/packages/tsconfig-reference/copy/en/options/noUnusedParameters.md
@@ -1,6 +1,6 @@
 ---
 display: "No Unused Parameters"
-oneline: "Raise an error when a function parameter isn't read"
+oneline: "Raise an error when a function parameter isn't read."
 ---
 
 Report errors on unused parameters in functions.

--- a/packages/tsconfig-reference/copy/en/options/preserveValueImports.md
+++ b/packages/tsconfig-reference/copy/en/options/preserveValueImports.md
@@ -1,6 +1,6 @@
 ---
 display: "preserveValueImports"
-oneline: "Preserve unused imported values in the JavaScript output that would otherwise be removed"
+oneline: "Preserve unused imported values in the JavaScript output that would otherwise be removed."
 ---
 
 There are some cases where TypeScript can't detect that you're using an import. For example, take the following code:

--- a/packages/tsconfig-reference/copy/en/options/preserveWatchOutput.md
+++ b/packages/tsconfig-reference/copy/en/options/preserveWatchOutput.md
@@ -1,6 +1,6 @@
 ---
 display: "Preserve Watch Output"
-oneline: "Disable wiping the console in watch mode"
+oneline: "Disable wiping the console in watch mode."
 ---
 
 Whether to keep outdated console output in watch mode instead of clearing the screen every time a change happened.

--- a/packages/tsconfig-reference/copy/en/options/pretty.md
+++ b/packages/tsconfig-reference/copy/en/options/pretty.md
@@ -1,6 +1,6 @@
 ---
 display: "Pretty"
-oneline: "Enable color and formatting in output to make compiler errors easier to read."
+oneline: "Enable color and formatting in TypeScript's output to make compiler errors easier to read."
 ---
 
 Stylize errors and messages using color and context, this is on by default &mdash; offers you a chance to have less terse,

--- a/packages/tsconfig-reference/copy/en/options/pretty.md
+++ b/packages/tsconfig-reference/copy/en/options/pretty.md
@@ -1,6 +1,6 @@
 ---
 display: "Pretty"
-oneline: "Enable color and formatting in output to make compiler errors easier to read"
+oneline: "Enable color and formatting in output to make compiler errors easier to read."
 ---
 
 Stylize errors and messages using color and context, this is on by default &mdash; offers you a chance to have less terse,

--- a/packages/tsconfig-reference/copy/en/options/resolveJsonModule.md
+++ b/packages/tsconfig-reference/copy/en/options/resolveJsonModule.md
@@ -1,6 +1,6 @@
 ---
 display: "Resolve JSON Module"
-oneline: "Enable importing .json files"
+oneline: "Enable importing .json files."
 ---
 
 Allows importing modules with a '.json' extension, which is a common practice in node projects. This includes

--- a/packages/tsconfig-reference/copy/en/options/strict.md
+++ b/packages/tsconfig-reference/copy/en/options/strict.md
@@ -1,6 +1,6 @@
 ---
 display: "Strict"
-oneline: "Enable all strict type checking options."
+oneline: "Enable all strict type-checking options."
 ---
 
 The `strict` flag enables a wide range of type checking behavior that results in stronger guarantees of program correctness.

--- a/packages/tsconfig-reference/copy/en/options/verbose.md
+++ b/packages/tsconfig-reference/copy/en/options/verbose.md
@@ -1,6 +1,6 @@
 ---
 display: "verbose"
-oneline: "Enable verbose logging"
+oneline: "Enable verbose logging."
 ---
 
 Enable verbose logging

--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -222,7 +222,7 @@ export const defaultsForOptions = {
   newLine: "Platform specific.",
   noImplicitAny: trueIf("strict"),
   noImplicitThis: trueIf("strict"),
-  preserveConstEnums: "false",
+  preserveConstEnums: trueIf("isolatedModules"),
   reactNamespace: "React",
   rootDir: "Computed from the list of input files.",
   rootDirs: "Computed from the list of input files.",


### PR DESCRIPTION
Add periods to all option descriptions to minimize differences between these and their [corresponding descriptions in the compiler](https://github.com/microsoft/TypeScript/pull/46465/files#diff-fdf3f532dc2d3188ad1c05c8c9e064d0aa4143b8ba09b8f3313a0243f0a43effR1390).