### PR TITLE
Missing closing curly bracket in example

### DIFF
--- a/packages/documentation/copy/en/release-notes/Overview.md
+++ b/packages/documentation/copy/en/release-notes/Overview.md
@@ -5921,7 +5921,7 @@ console.log(x! + x!);
 
 function initialize() {
     x = 10;
-
+}
 ```
 
 In our example, we knew that all uses of `x` would be initialized so it makes more sense to use definite assignment assertions than non-null assertions.


### PR DESCRIPTION
Missing closing curly bracket in example in Typescript 2.7 - Definite Assignment Assertions