### PR TITLE
Add a reference to `sourcesContent`

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/inlineSources.md
+++ b/packages/tsconfig-reference/copy/en/options/inlineSources.md
@@ -3,7 +3,7 @@ display: "Inline Sources"
 oneline: "Include source code in the sourcemaps inside the emitted JavaScript."
 ---
 
-When set, TypeScript will include the original content of the `.ts` file as an embedded string in the source map.
+When set, TypeScript will include the original content of the `.ts` file as an embedded string in the source map (using the source map's `sourcesContent` property).
 This is often useful in the same cases as [`inlineSourceMap`](#inlineSourceMap).
 
 Requires either [`sourceMap`](#sourceMap) or [`inlineSourceMap`](#inlineSourceMap) to be set.


### PR DESCRIPTION
Some online discussions about source maps reference `sourcesContent` (e.g., [here](https://scotch.io/tutorials/your-source-maps-are-broken-heres-how-to-fix-them) and [here](https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/#verify-artifacts-are-uploaded)). Referencing that keyword here may help TypeScript users.