### PR TITLE
Adds support for multifile playgrounds

### DIFF
--- a/packages/typescriptlang-org/src/pages/dev/bug-workbench.tsx
+++ b/packages/typescriptlang-org/src/pages/dev/bug-workbench.tsx
@@ -131,31 +131,9 @@ const Play: React.FC<Props> = (props) => {
         sandboxEnv.setDidUpdateCompilerSettings(updateDTSEnv)
         updateDTSEnv(sandboxEnv.getCompilerOptions())
 
-        // When there are multi-file playgrounds, we should show the implicit filename, ideally this would be
-        // something more inline, but we can abuse the code lenses for now
-        main.languages.registerCodeLensProvider(sandboxEnv.language, {
-          provideCodeLenses: function (model, token) {
-            const lenses = !showFileCodeLens ? [] : [{
-              range: {
-                startLineNumber: 1,
-                startColumn: 1,
-                endLineNumber: 2,
-                endColumn: 1
-              },
-              id: "implicit-filename-first",
-              command: {
-                id: "noop",
-                title: "// @filename: input.tsx"
-              }
-            }]
-            return { lenses, dispose: () => { } };
-          }
-        })
-
-        let showFileCodeLens = false
+       
         const debouncedTwoslash = debounce(() => {
           if (dtsMap) runTwoslash()
-          showFileCodeLens = sandboxEnv.getText().includes("// @filename")
         }, 1000)
 
         sandboxEnv.editor.onDidChangeModelContent(debouncedTwoslash)

--- a/packages/typescriptlang-org/src/templates/play.tsx
+++ b/packages/typescriptlang-org/src/templates/play.tsx
@@ -109,7 +109,7 @@ const Play: React.FC<Props> = (props) => {
       }
 
       // Allow prod/staging builds to set a custom commit prefix to bust caches
-      const {sandboxRoot, playgroundRoot} = getPlaygroundUrls()
+      const {sandboxRoot, playgroundRoot, playgroundWorker} = getPlaygroundUrls()
       
       // @ts-ignore
       const re: any = global.require
@@ -152,14 +152,16 @@ const Play: React.FC<Props> = (props) => {
         const height = Math.max(window.innerHeight, 600)
         container.style.height = `${height - Math.round(container.getClientRects()[0].top) - 18}px`
 
+        const extension = (!!params.get("useJavaScript") ? "js" : params.get("filetype") || "ts") as any
         // Create the sandbox
         const sandboxEnv = await sandbox.createTypeScriptSandbox({
           text: localStorage.getItem('sandbox-history') || i("play_default_code_sample"),
           compilerOptions: {},
           domID: "monaco-editor-embed",
-          filetype: (!!params.get("useJavaScript") ? "js" : params.get("filetype") || "ts") as any,
+          filetype: extension,
           acquireTypes: !localStorage.getItem("disable-ata"),
           supportTwoslashCompilerOptions: true,
+          customTypeScriptWorkerPath: `${document.location.origin + playgroundWorker}?filetype=${extension}`,
           monacoSettings: {
             fontFamily: "var(--code-font)",
             fontLigatures: true


### PR DESCRIPTION
This brings over support which used to just live inside the bug workbench to the Playground. This also adds support for having the default input file as a js/jsx file which wasn't needed for the workbench.

![Screen Shot 2021-11-10 at 2 37 07 PM](https://user-images.githubusercontent.com/49038/141133361-b003f744-490a-4338-ad08-326cbbe6c7d5.png)


