### PR TITLE
Use latest checkout and setup-node actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,21 +7,11 @@ jobs:
 
     steps:
       # Check out, and set up the node/ruby infra
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: "13.x"
-
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: |
-            packages/typescriptlang-org/.cache
-            packages/.cache
-            **/node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: yarn
 
       - uses: microsoft/playwright-github-action@v1
 
@@ -64,10 +54,11 @@ jobs:
 
     steps:
       # Check out, and set up the node infra
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: "13.x"
+          cache: yarn
 
       # Get local dependencies
       - run: yarn install

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -11,10 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: "13.x"
+          cache: yarn
 
       - uses: microsoft/playwright-github-action@v1
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -12,6 +12,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          # Fetch the full history, to build attribution.json
+          fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
           node-version: "13.x"

--- a/.github/workflows/v2-merged-staging.yml
+++ b/.github/workflows/v2-merged-staging.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       # Check out, and set up the node/ruby infra
       - uses: actions/checkout@v2
+        with:
+          # Fetch the full history, to build attribution.json
+          fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
           node-version: "13.x"

--- a/.github/workflows/v2-merged-staging.yml
+++ b/.github/workflows/v2-merged-staging.yml
@@ -11,11 +11,12 @@ jobs:
 
     steps:
       # Check out, and set up the node/ruby infra
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: "13.x"
           registry-url: "https://registry.npmjs.org/"
+          cache: yarn
 
       # For Azure uploads
       - run: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash

--- a/.github/workflows/weekly-stats.yml
+++ b/.github/workflows/weekly-stats.yml
@@ -11,10 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: "13.x"
+          cache: yarn
 
       # Build v2
       - name: Deps


### PR DESCRIPTION
I'm seeing the CI `yarn install` step take +/- 5 minutes [currently](https://github.com/microsoft/TypeScript-Website/runs/4189840925?check_suite_focus=true#step:6:1), vs. +/- 1 minute with `actions/setup-node@v2` and a warm cache? I can't explain the difference, but seems like it might be worth updating?

Also, `actions/checkout@v2` does a shallow clone by default. The full clone [currently](https://github.com/microsoft/TypeScript-Website/runs/4189840925?check_suite_focus=true#step:2:1) only takes +/- 7 seconds, but might as well update that one too?