### PR TITLE
Correct a comment in the 'Objects vs Enums' sample

### DIFF
--- a/packages/documentation/copy/en/reference/Enums.md
+++ b/packages/documentation/copy/en/reference/Enums.md
@@ -408,7 +408,7 @@ ODirection.Up;
 // Using the enum as a parameter
 function walk(dir: EDirection) {}
 
-// It requires an extra line to pull out the keys
+// It requires an extra line to pull out the values
 type Direction = typeof ODirection[keyof typeof ODirection];
 function run(dir: Direction) {}
 


### PR DESCRIPTION
In the Objects vs Enums section there is a comment about needing an extra line to pull out keys from an object defined w/ `as const`. As far as I can tell, that line is actually for pulling out the values. This PR updates the comment.