### PR TITLE
Refine tsconfig schema

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -3,7 +3,7 @@ import * as remark from "remark";
 import * as remarkHTML from "remark-html";
 import * as ts from "typescript";
 
-interface CommandLineOption {
+export interface CommandLineOption {
   name: string;
   type:
     | "string"
@@ -13,12 +13,14 @@ interface CommandLineOption {
     | "list"
     | Map<string, number | string>;
   defaultValueDescription?: string | number | boolean | ts.DiagnosticMessage;
+  category?: ts.DiagnosticMessage;
   element: CommandLineOption;
 }
 
 declare module "typescript" {
   const optionDeclarations: CommandLineOption[];
   const optionsForWatch: CommandLineOption[];
+  const typeAcquisitionDeclarations: CommandLineOption[];
 }
 
 /**


### PR DESCRIPTION
- Remove nonexistent options.
  - `compilerOptions["fallbackPolling" | "watchDirectory" | "watchFile"]`: `error TS5023: Unknown compiler option 'fallbackPolling'.` (they exist in `watchOptions` instead).
- Remove command-line-only options.
- Support list options other than `lib`.
  - The set of list options with enumerated values is only `lib` currently, so no change.
- Update `pattern` as needed: If the schema rejects any of the enumerated values.