### PR TITLE
Fix deprecation link for index signature types

### DIFF
--- a/packages/documentation/copy/en/reference/Advanced Types.md
+++ b/packages/documentation/copy/en/reference/Advanced Types.md
@@ -16,7 +16,7 @@ deprecation_redirects: [
   interfaces-vs-type-aliases, /docs/handbook/2/everyday-types.html#differences-between-type-aliases-and-interfaces,
   enum-member-types, /docs/handbook/enums.html,
   polymorphic-this-types, /docs/handbook/2/classes.html,
-  index-types, /docs/handbook/2/indexed-access-types.html,
+  index-types, /docs/handbook/2/objects.html#index-signatures,
   index-types-and-index-signatures, /docs/handbook/2/indexed-access-types.html,
   mapped-types, /docs/handbook/2/mapped-types.html,
   inference-from-mapped-types, /docs/handbook/2/mapped-types.html,


### PR DESCRIPTION
The new handbook page for Index Access Types does not discuss Index Signatures at all.