### PR TITLE
ATA, always call finished callback after resolving dependencies

### DIFF
--- a/packages/ata/src/index.ts
+++ b/packages/ata/src/index.ts
@@ -19,7 +19,7 @@ export interface ATABootstrapConfig {
     /** A callback indicating that ATA actually has work to do */
     started?: () => void
     /** The callback when all ATA has finished */
-    finished?: (files: Map<string, string>) => void
+    finished?: (files?: Map<string, string>) => void
   }
   /** Passed to fetch as the user-agent */
   projectName: string
@@ -56,6 +56,8 @@ export const setupTypeAcquisition = (config: ATABootstrapConfig) => {
     resolveDeps(initialSourceFile, 0).then(t => {
       if (estimatedDownloaded > 0) {
         config.delegate.finished?.(fsMap)
+      } else {
+        config.delegate.finished?.()
       }
     })
   }

--- a/packages/ata/src/userFacingTypes.d.ts
+++ b/packages/ata/src/userFacingTypes.d.ts
@@ -10,7 +10,7 @@ export interface ATABootstrapConfig {
     /** A callback indicating that ATA actually has work to do */
     started?: () => void
     /** The callback when all ATA has finished */
-    finished?: (files: Map<string, string>) => void
+    finished?: (files?: Map<string, string>) => void
   }
   /** Passed to fetch as the user-agent */
   projectName: string


### PR DESCRIPTION
Currently, there is no way of knowing that ata finished if it doesn't resolve new dependencies. The `finished` callback is only called if there are newly resolved dependencies. 
This is confusing as the callbacks name implies that it would call after running Ata regardless as it's a signal of the runner completing.

PS: Thanks for the great package!