### PR TITLE
Use ESM

### DIFF
--- a/packages/tsconfig-reference/package.json
+++ b/packages/tsconfig-reference/package.json
@@ -4,14 +4,14 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "generate:json:tsconfig": "yarn ts-node -T scripts/tsconfig/generateJSON.ts",
-    "generate:json:cli": "yarn ts-node -T scripts/cli/generateJSON.ts",
-    "generate:json:schema": "yarn ts-node -T scripts/schema/generateJSON.ts",
-    "generate:json:msbuild": "yarn ts-node -T scripts/msbuild/generateJSON.ts",
+    "generate:json:tsconfig": "tsc --build && node --experimental-json-modules scripts/tsconfig/generateJSON",
+    "generate:json:cli": "tsc --build && node --experimental-json-modules scripts/cli/generateJSON",
+    "generate:json:schema": "tsc --build && node --experimental-json-modules scripts/schema/generateJSON",
+    "generate:json:msbuild": "tsc --build && node --experimental-json-modules scripts/msbuild/generateJSON",
     "generate:json": "yarn generate:json:tsconfig && yarn generate:json:cli && yarn generate:json:schema && yarn generate:json:msbuild",
-    "generate:md:tsconfig": "yarn ts-node -T scripts/tsconfig/generateMarkdown.ts",
-    "generate:md:cli": "yarn ts-node -T scripts/cli/generateMarkdown.ts",
-    "generate:md:msbuild": "yarn ts-node -T scripts/msbuild/generateMarkdown.ts",
+    "generate:md:tsconfig": "tsc --build && node --experimental-json-modules scripts/tsconfig/generateMarkdown",
+    "generate:md:cli": "tsc --build && node --experimental-json-modules scripts/cli/generateMarkdown",
+    "generate:md:msbuild": "tsc --build && node --experimental-json-modules scripts/msbuild/generateMarkdown",
     "generate:md": "yarn generate:md:tsconfig && yarn generate:md:cli && yarn generate:md:tsconfig",
     "bootstrap": "yarn scripts/schema/downloadSchemaBase.ts",
     "build": "yarn generate:json && yarn generate:md",
@@ -26,5 +26,6 @@
     "remark": "^11.0.2",
     "remark-html": "^10.0.0",
     "ts-node": "*"
-  }
+  },
+  "type": "module"
 }

--- a/packages/tsconfig-reference/scripts/cli/generateJSON.ts
+++ b/packages/tsconfig-reference/scripts/cli/generateJSON.ts
@@ -7,26 +7,33 @@
 */
 console.log("TSConfig Ref: JSON for CLI Opts");
 
-import * as ts from "typescript";
+import ts from "typescript";
 
 import { CommandLineOptionBase } from "../types";
 import { writeFileSync } from "fs";
 import { join } from "path";
-import { format } from "prettier";
+import prettier from "prettier";
 import {
   deprecated,
   internal,
   defaultsForOptions,
   allowedValues,
   configToRelease,
-} from "../tsconfigRules";
+} from "../tsconfigRules.js";
 import { CompilerOptionName } from "../../data/_types";
 
-const toJSONString = (obj) => format(JSON.stringify(obj, null, "  "), { filepath: "thing.json" });
+const toJSONString = (obj) =>
+  prettier.format(JSON.stringify(obj, null, "  "), { filepath: "thing.json" });
 const writeJSON = (name, obj) =>
-  writeFileSync(join(__dirname, "..", "..", "data", name), toJSONString(obj));
+  writeFileSync(
+    new URL(`../../data/${name}`, import.meta.url),
+    toJSONString(obj)
+  );
 const writeString = (name, text) =>
-  writeFileSync(join(__dirname, "..", "..", "data", name), format(text, { filepath: name }));
+  writeFileSync(
+    new URL(`../../data/${name}`, import.meta.url),
+    prettier.format(text, { filepath: name })
+  );
 
 export interface CompilerOptionJSON extends CommandLineOptionBase {
   releaseVersion?: string;
@@ -40,8 +47,8 @@ export interface CompilerOptionJSON extends CommandLineOptionBase {
   hostObj: string;
 }
 
-const tsconfigOpts = require(join(__dirname, "../../data/tsconfigOpts.json"))
-  .options as CompilerOptionJSON[];
+// @ts-ignore
+import tsconfigOpts from "../../data/tsconfigOpts.json";
 
 const notCompilerFlags = [
   // @ts-ignore

--- a/packages/tsconfig-reference/scripts/lint.js
+++ b/packages/tsconfig-reference/scripts/lint.js
@@ -3,20 +3,22 @@
 
 // yarn workspace tsconfig-reference lint
 
-const chalk = require("chalk");
+import chalk from "chalk";
 
 const tick = chalk.bold.greenBright("✓");
 const cross = chalk.bold.redBright("⤫");
 
-const { readdirSync, readFileSync, statSync } = require("fs");
-const { join } = require("path");
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join } from "path";
 
-const remark = require("remark");
-const remarkTwoSlash = require("remark-shiki-twoslash");
+import remark from "remark";
+import remarkTwoSlash from "remark-shiki-twoslash";
 
-const { read } = require("gray-matter");
+import matter from "gray-matter";
 
-const languages = readdirSync(join(__dirname, "..", "copy")).filter((f) => !f.startsWith("."));
+const languages = readdirSync(new URL("../copy", import.meta.url)).filter(
+  (f) => !f.startsWith(".")
+);
 
 console.log("Linting the sample code which uses twoslasher in ts-config");
 
@@ -29,15 +31,17 @@ const go = async () => {
   for (const lang of languages) {
     console.log("\n\nLanguage: " + chalk.bold(lang) + "\n");
 
-    const locale = join(__dirname, "..", "copy", lang);
+    const locale = new URL(`../copy/${lang}/`, import.meta.url);
     let options;
 
     try {
-      options = readdirSync(join(locale, "options")).filter((f) => !f.startsWith("."));
+      options = readdirSync(new URL("options", locale)).filter(
+        (f) => !f.startsWith(".")
+      );
     } catch {
       errorReports.push({
-        path: join(locale, "options"),
-        error: `Options directory ${join(locale, "options")} doesn't exist`,
+        path: new URL("options", locale),
+        error: `Options directory ${new URL("options", locale)} doesn't exist`,
       });
       continue;
     }
@@ -46,7 +50,7 @@ const go = async () => {
     for (const option of options) {
       if (filterString.length && !option.includes(filterString)) continue;
 
-      const optionPath = join(locale, "options", option);
+      const optionPath = new URL(`options/${option}`, locale);
 
       const isDir = statSync(optionPath).isDirectory();
       if (isDir) continue;

--- a/packages/tsconfig-reference/scripts/msbuild/generateJSON.ts
+++ b/packages/tsconfig-reference/scripts/msbuild/generateJSON.ts
@@ -2,17 +2,27 @@
 
 console.log("TSConfig Ref: JSON for MSBuild");
 
-import parser = require("xml-js");
+import parser from "xml-js";
 import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
-import { format } from "prettier";
+import prettier from "prettier";
 
-const toJSONString = (obj) => format(JSON.stringify(obj, null, "  "), { filepath: "thing.json" });
+const toJSONString = (obj) =>
+  prettier.format(JSON.stringify(obj, null, "  "), { filepath: "thing.json" });
 const writeJSON = (name, obj) =>
-  writeFileSync(join(__dirname, "..", "..", "data", name), toJSONString(obj));
+  writeFileSync(
+    new URL(`../../data/${name}`, import.meta.url),
+    toJSONString(obj)
+  );
 
-const targetsXMLText = readFileSync(join(__dirname, "./Microsoft.TypeScript.targets"), "utf8");
-const targetJSONtext = parser.xml2json(targetsXMLText, { compact: true, spaces: 4 });
+const targetsXMLText = readFileSync(
+  new URL("./Microsoft.TypeScript.targets", import.meta.url),
+  "utf8"
+);
+const targetJSONtext = parser.xml2json(targetsXMLText, {
+  compact: true,
+  spaces: 4,
+});
 const targets = JSON.parse(targetJSONtext) as import("./types").Target;
 
 const config = targets.Project.PropertyGroup.find((f) => f.TypeScriptBuildConfigurations?.length);

--- a/packages/tsconfig-reference/scripts/schema/downloadSchemaBase.ts
+++ b/packages/tsconfig-reference/scripts/schema/downloadSchemaBase.ts
@@ -2,15 +2,15 @@
 
 // https://json.schemastore.org/tsconfig.json
 
-const nodeFetch = require("node-fetch").default;
-const { writeFileSync, existsSync, mkdirSync } = require("fs");
-const { join } = require("path");
+import nodeFetch from "node-fetch";
+import { writeFileSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
 
 const getFileAndStoreLocally = async (url, path, editFunc) => {
   const editingFunc = editFunc ? editFunc : (text) => text;
   const packageJSON = await nodeFetch(url);
   const contents = await packageJSON.text();
-  writeFileSync(join(__dirname, path), editingFunc(contents), "utf8");
+  writeFileSync(new URL(path, import.meta.url), editingFunc(contents), "utf8");
 };
 
 getFileAndStoreLocally(

--- a/packages/tsconfig-reference/scripts/tsconfig/generateJSON.ts
+++ b/packages/tsconfig-reference/scripts/tsconfig/generateJSON.ts
@@ -8,12 +8,12 @@
 
 console.log("TSConfig Ref: JSON for TSConfig");
 
-import * as ts from "typescript";
+import ts from "typescript";
 
 import { CommandLineOptionBase } from "../types";
 import { writeFileSync } from "fs";
 import { join } from "path";
-import { format } from "prettier";
+import prettier from "prettier";
 import {
   denyList,
   relatedTo,
@@ -24,14 +24,21 @@ import {
   allowedValues,
   configToRelease,
   additionalOptionDescriptors,
-} from "../tsconfigRules";
+} from "../tsconfigRules.js";
 import { CompilerOptionName } from "../../data/_types";
 
-const toJSONString = (obj) => format(JSON.stringify(obj, null, "  "), { filepath: "thing.json" });
+const toJSONString = (obj) =>
+  prettier.format(JSON.stringify(obj, null, "  "), { filepath: "thing.json" });
 const writeJSON = (name, obj) =>
-  writeFileSync(join(__dirname, "..", "..", "data", name), toJSONString(obj));
+  writeFileSync(
+    new URL(`../../data/${name}`, import.meta.url),
+    toJSONString(obj)
+  );
 const writeString = (name, text) =>
-  writeFileSync(join(__dirname, "..", "..", "data", name), format(text, { filepath: name }));
+  writeFileSync(
+    new URL(`../../data/${name}`, import.meta.url),
+    prettier.format(text, { filepath: name })
+  );
 
 export interface CompilerOptionJSON extends CommandLineOptionBase {
   releaseVersion?: string;
@@ -195,9 +202,7 @@ allOptions.forEach((option) => {
   delete option.showInSimplifiedHelpView;
 });
 
-writeJSON("tsconfigOpts.json", {
-  options: allOptions,
-});
+writeJSON("tsconfigOpts.json", allOptions);
 
 // Improve the typing for the rules
 writeString(

--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -1,7 +1,7 @@
 import { CompilerOptionName } from "../data/_types";
-import * as remark from "remark";
-import * as remarkHTML from "remark-html";
-import * as ts from "typescript";
+import remark from "remark";
+import remarkHTML from "remark-html";
+import ts from "typescript";
 
 export interface CommandLineOption {
   name: string;

--- a/packages/tsconfig-reference/scripts/types.ts
+++ b/packages/tsconfig-reference/scripts/types.ts
@@ -1,4 +1,4 @@
-import ts = require("typescript");
+import ts from "typescript";
 
 // These are all copy-pasta'd from the TS codebase
 

--- a/packages/tsconfig-reference/tsconfig.json
+++ b/packages/tsconfig-reference/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
+    "module": "es2020",
+    "moduleResolution": "node",
     "resolveJsonModule": true,
-    "allowJs": true,
-    "target": "es2015"
+    "allowSyntheticDefaultImports": true,
+    "target": "es2019"
   }
 }


### PR DESCRIPTION
Use ESM in the tsconfig-reference workspace, to be able to use new ESM-only dependencies. Motivated by https://github.com/microsoft/TypeScript-Website/pull/2133#issuecomment-981768067, but it's a chore that will need doing sometime, independent of that PR. This PR just extracts the first commit from that one.