### PR TITLE
Eliminate the error when running the static example

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -308,6 +308,27 @@ function getFirstThree(x: number[] | string) {
 > The _union_ `number | string` is composed by taking the union _of the values_ from each type.
 > Notice that given two sets with corresponding facts about each set, only the _intersection_ of those facts applies to the _union_ of the sets themselves.
 > For example, if we had a room of tall people wearing hats, and another room of Spanish speakers wearing hats, after combining those rooms, the only thing we know about _every_ person is that they must be wearing a hat.
+> 
+> Another example of _intersection_ is the behavior of keyof of union type. If we combine several types, the result keyof of union type will be an intersection of keyof of each type.
+
+```ts twoslash
+type t1 = {
+  a: string;
+  b: number;
+};
+
+type t2 = {
+   a: boolean;
+   c: number;
+};
+
+type ts = t1 | t2 ;
+
+type CommonKeys<T extends object> = keyof T;
+
+type ck = CommonKeys<ts>; // evaluates to "a"
+```
+ 
 
 ## Type Aliases
 

--- a/packages/documentation/copy/en/reference/Mixins.md
+++ b/packages/documentation/copy/en/reference/Mixins.md
@@ -272,3 +272,4 @@ class Spec extends derived<string>() {}
 Spec.prop; // string
 Spec.anotherProp; // string
 ```
+* If you try to run this example in TS Playground you should turn of "declaration" property in TS Config. In other case you should recieve error message "Return type of exported function has or is using private name"


### PR DESCRIPTION
When you press "try" button on Static Property Mixins - you see the error  "Return type of exported function has or is using private name"

To successfully run this example - you need to turn off "declaration" property in TS Config