### PR TITLE
docs: fix property name typo [Fixes #2130]

### DIFF
--- a/packages/playground-examples/copy/en/TypeScript/Language/Type Guards.ts
+++ b/packages/playground-examples/copy/en/TypeScript/Language/Type Guards.ts
@@ -70,7 +70,7 @@ function isAnInternetOrder(order: PossibleOrders): order is InternetOrder {
 }
 
 function isATelephoneOrder(order: PossibleOrders): order is TelephoneOrder {
-  return order && "calledNumber" in order;
+  return order && "callerNumber" in order;
 }
 
 // Now we can use these functions in if statements to narrow


### PR DESCRIPTION
## Issue fixed

Closes #2130 

## Description

Playground example for 'Type Guard' had a typo where the property `callerNumber` was mistyped as `calledNumber`. This PR fixes the same. Cheers!