### PR TITLE
rename generic parameters in `Exclude<>`

### DIFF
--- a/packages/documentation/copy/en/reference/Utility Types.md
+++ b/packages/documentation/copy/en/reference/Utility Types.md
@@ -205,7 +205,7 @@ todoInfo;
 // ^?
 ```
 
-## `Exclude<Type, ExcludedUnion>`
+## `Exclude<UnionType, ExcludedMembers>`
 
 <blockquote class=bg-reading>
 
@@ -214,7 +214,7 @@ Released:
 
 </blockquote>
 
-Constructs a type by excluding from `Type` all union members that are assignable to `ExcludedUnion`.
+Constructs a type by excluding from `UnionType` all union members that are assignable to `ExcludedMembers`.
 
 ##### Example
 


### PR DESCRIPTION
A PR bourne of my own confusion. see: https://github.com/microsoft/TypeScript/issues/47178

I believed that `Exclude<>` was capable of, eg, `type not0 = Exclude< number, 0 >`. When I found this was not the case, I guessed from the examples that `Exclude` works on union types, which seems more or less correct.

Very open to better or more correct namings here, but I think `Type` as the first parameter is particularly misleading - `Type` reads very clearly to me as _any_ type, but Exclude does not work on _any_ type.