### PR TITLE
Typo in input and output

### DIFF
--- a/packages/documentation/copy/en/reference/JSX.md
+++ b/packages/documentation/copy/en/reference/JSX.md
@@ -29,7 +29,7 @@ The `react-native` mode is the equivalent of `preserve` in that it keeps all JSX
 | -------------- | --------- | ------------------------------------------------- | --------------------- |
 | `preserve`     | `<div />` | `<div />`                                         | `.jsx`                |
 | `react`        | `<div />` | `React.createElement("div")`                      | `.js`                 |
-| `react-native` | `<div />` | `<div />`                                         | `.js`                 |
+| `react-native` | `<View />`| `<View />`                                        | `.js`                 |
 | `react-jsx`    | `<div />` | `_jsx("div", {}, void 0);`                        | `.js`                 |
 | `react-jsxdev` | `<div />` | `_jsxDEV("div", {}, void 0, false, {...}, this);` | `.js`                 |
 


### PR DESCRIPTION
While I was scrolling trought TS docs i found this realy diferent thing that is the table with a <div> and <div> output for react native. Its been a while since I've not used React Native but I remeber that we used <View> that could transpile to  UIView, <div>, android.view depending on your platform, but you should refer to this block of code as <View> like discussed in this doc (RN View Doc) [https://reactnative.dev/docs/view].
If i'm wrong on this, I would like to say sorry.  This is my first Pull request to making TypeScript better. If there is any things that i could do to make this pr better I gladly would change :) thx and good holidays