### PR TITLE
fix: <code> is out of alignment in <h1>, <h2> and <h3>

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/main.scss
+++ b/packages/typescriptlang-org/src/components/layout/main.scss
@@ -165,7 +165,6 @@ html.font-open-dyslexic {
   h3 > code {
     background-color: var(--inline-code-background-color);
     font-size: 0.95em;
-    margin-top: 0.2em;
     margin-left: 0.2em;
     margin-right: 0.2em;
     padding: 2px 4px;


### PR DESCRIPTION
before:
![before](https://user-images.githubusercontent.com/2399132/147320870-a3818f2e-8c00-48c8-8187-eef0940bc978.jpg)

after:
![after](https://user-images.githubusercontent.com/2399132/147320884-e71b6d64-8c90-4f83-90b8-fd1a72e17cd9.jpg)

