### PR TITLE
CSS fix for the monaco popover

### DIFF
--- a/packages/typescriptlang-org/src/templates/play.scss
+++ b/packages/typescriptlang-org/src/templates/play.scss
@@ -1181,3 +1181,7 @@ input.good {
     transform: translateZ(0);
   }
 }
+
+.monaco-list {
+  background-color: var(--background-color);
+}


### PR DESCRIPTION
Monaco didn't style the background of the popups, so we've added CSS to handle it