### PR TITLE
Improve scrollbar appearance in dark theme

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/main.scss
+++ b/packages/typescriptlang-org/src/components/layout/main.scss
@@ -218,3 +218,7 @@ html,
   display: flex;
   flex-direction: column;
 }
+
+.dark-theme {
+  color-scheme: dark;
+}


### PR DESCRIPTION
use [`color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme) in dark theme to improve scrollbar appearance

before:

![Screen Shot 2022-01-07 at 11 31 45](https://user-images.githubusercontent.com/25996236/148490075-3481d719-f2ea-4714-a0fd-180e2d1378f5.png)

after:

![Screen Shot 2022-01-07 at 11 32 11](https://user-images.githubusercontent.com/25996236/148490080-7d3c3b02-24ed-4b3c-a90c-cd6561e53623.png)
