### PR TITLE
Fix code tags inside details tag

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Object Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Object Types.md
@@ -274,7 +274,7 @@ An index signature property type must be either 'string' or 'number'.
 
 <details>
     <summary>It is possible to support both types of indexers...</summary>
-    <p>It is possible to support both types of indexers, but the type returned from a numeric indexer must be a subtype of the type returned from the string indexer. This is because when indexing with a `number`, JavaScript will actually convert that to a `string` before indexing into an object. That means that indexing with `100` (a `number`) is the same thing as indexing with `"100"` (a `string`), so the two need to be consistent.</p>
+    <p>It is possible to support both types of indexers, but the type returned from a numeric indexer must be a subtype of the type returned from the string indexer. This is because when indexing with a <code>number</code>, JavaScript will actually convert that to a <code>string</code> before indexing into an object. That means that indexing with <code>100</code> (a <code>number</code>) is the same thing as indexing with <code>"100"</code> (a <code>string</code>), so the two need to be consistent.</p>
 
 ```ts twoslash
 // @errors: 2413


### PR DESCRIPTION
Markdown code tags are not being parsed inside the details tag.

![before](https://user-images.githubusercontent.com/20022818/148583476-28e63aa2-d17f-4f4c-a481-9e31702bb737.png)

Replacing ` `` ` with `<code />` fixes the issue, but I am not sure if there is a better solution or not.

![after](https://user-images.githubusercontent.com/20022818/148583442-4586e380-a0c3-4209-bfa7-5d5a91bc5e82.PNG)

