### PR TITLE
Clarify property renaming example

### DIFF
--- a/packages/documentation/copy/en/reference/Variable Declarations.md
+++ b/packages/documentation/copy/en/reference/Variable Declarations.md
@@ -592,7 +592,7 @@ Confusingly, the colon here does _not_ indicate the type.
 The type, if you specify it, still needs to be written after the entire destructuring:
 
 ```ts
-let { a, b }: { a: string; b: number } = o;
+let { a: newName1, b: newName2 }: { a: string; b: number } = o;
 ```
 
 ### Default values


### PR DESCRIPTION
The discussion here is about how property renaming during a destructure interacts with type definitions. But in this step of the example, the property renaming has dropped out. I think the point would be clearer if the property renaming from a few lines above remained, so the reader's attention is directed to what's meant to be new on this line (the addition of type declarations).