### PR TITLE
Clarify behavior of node12/nodenext tsconfig options

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/module.md
+++ b/packages/tsconfig-reference/copy/en/options/module.md
@@ -98,7 +98,9 @@ export const twoPi = valueOfPi * 2;
 
 If you are wondering about the difference between `ES2015` (aka `ES6`) and `ES2020`, `ES2020` adds support for dynamic `import`s, and `import.meta`.
 
-#### `node12`/`nodenext`
+#### `node12`/`nodenext` (nightly builds)
+
+Available in [nightly builds](https://www.typescriptlang.org/docs/handbook/nightly-builds.html), the experimental `node12` and `nodenext` modes integrate with Node's [native ECMAScript Module support](https://nodejs.org/api/esm.html). The emitted JavaScript uses either `CommonJS` or `ES2020` output depending on the file extension and the value of the `type` setting in the nearest `package.json`. Module resolution also works differently. You can learn more in the [handbook](https://www.typescriptlang.org/docs/handbook/esm-node.html).
 
 ```ts twoslash
 // @showEmit
@@ -108,8 +110,6 @@ import { valueOfPi } from "./constants.js";
 
 export const twoPi = valueOfPi * 2;
 ```
-
-Introduced in TypeScript 4.5, `node12` and `nodenext` declare support for Node's ECMAScript Module Support. The emitted JavaScript is the same as `ES2020` which is the same `import`/`export` syntax in the TypeScript file. You can learn more in the [4.5 release notes](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/).
 
 #### `None`
 


### PR DESCRIPTION
I found the explanation of the `module: node12` and `module: nodenext` tsconfig.json options to be confusing for someone unfamiliar with the feature:
- implies that the feature is available in v4.5, but it's currently only in nightly builds
- says that the output is the same as `ES2020`, but it actually depends on whether it's a cjs or mjs file/package
- shows the CommonJS output despite mentioning `ES2020`

In this PR, I've tried to clarify the wording and provide more links to references.

It would be nice to also show the output for both `.cjs` and `.mjs` files. The easy way of doing this (setting `@filename: index.cjs`) doesn't work since `@typescript/twoslasher` doesn't search for these extensions. Fixing this would require changes in multiple repos since `gatsby-remark-shiki-twoslash` pulls in an older version from NPM.

https://github.com/microsoft/TypeScript-Website/blob/b8fb5ab114e75fa42c8b52ee54b2c7a03205c8c4/packages/ts-twoslasher/src/index.ts#L736