### PR TITLE
Remove `node_modules` from tsconfig `exclude`

### DIFF
--- a/packages/documentation/copy/en/project-config/tsconfig.json.md
+++ b/packages/documentation/copy/en/project-config/tsconfig.json.md
@@ -55,7 +55,7 @@ Example `tsconfig.json` files:
   }
   ```
 
-- Using the [`include`](/tsconfig#include) and `exclude` properties
+- Using the [`include`](/tsconfig#include) and [`exclude`](/tsconfig#exclude) properties
 
   ```json  tsconfig
   {
@@ -68,7 +68,7 @@ Example `tsconfig.json` files:
       "sourceMap": true
     },
     "include": ["src/**/*"],
-    "exclude": ["node_modules", "**/*.spec.ts"]
+    "exclude": ["**/*.spec.ts"]
   }
   ```
 
@@ -88,7 +88,7 @@ For example, if you were writing a project which uses Node.js version 12 and abo
   },
 
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "**/*.spec.ts"]
+  "exclude": ["**/*.spec.ts"]
 }
 ```
 


### PR DESCRIPTION
Since it's excluded by default, people don't need to put it in tsconfig, so I think the current example is misleading.
 https://github.com/microsoft/TypeScript/blob/70097c490807312faceba75c9e91b9547d3e16b9/src/compiler/utilities.ts#L6418-L6420

![image](https://user-images.githubusercontent.com/251288/149462742-a4ef84f4-077f-489d-a917-bbedb1ee1df7.png)
