### PR TITLE
Grammar: single missing article

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -171,7 +171,7 @@ const longerString = longest("alice", "bob");
 const notOK = longest(10, 100);
 ```
 
-There are few interesting things to note in this example.
+There are a few interesting things to note in this example.
 We allowed TypeScript to _infer_ the return type of `longest`.
 Return type inference also works on generic functions.
 


### PR DESCRIPTION
Missing 'a'