### PR TITLE
Fix broken(?) link on Type Compatibility page

### DIFF
--- a/packages/documentation/copy/en/reference/Type Compatibility.md
+++ b/packages/documentation/copy/en/reference/Type Compatibility.md
@@ -391,7 +391,7 @@ A "<span class='black-tick'>✓</span>" indicates a combination that is compatib
 </tbody>
 </table>
 
-Reiterating [The Basics](/handbook/2/basic-types.html):
+Reiterating [The Basics](/docs/handbook/2/basic-types.html):
 
 - Everything is assignable to itself.
 - `any` and `unknown` are the same in terms of what is assignable to them, different in that `unknown` is not assignable to anything except `any`.


### PR DESCRIPTION
Add `/docs` prefix to link href because without it I'm getting `"The resource you are looking for has been removed, had its name changed, or is temporarily unavailable."`. (I'm assuming this isn't a "temporarily unavailable" situation, but if it is then disregard.)