### PR TITLE
Improved sample code for Call Signature

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -61,7 +61,8 @@ function myFunc(someArg: number) {
 myFunc.description = "default description";
 
 
-doSomething(myFunc)
+doSomething(myFunc);
+
 ```
 
 Note that the syntax is slightly different compared to a function type expression - use `:` between the parameter list and the return type rather than `=>`.

--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -61,7 +61,6 @@ function myFunc(someArg: number) {
 myFunc.description = "default description";
 
 doSomething(myFunc);
-
 ```
 
 Note that the syntax is slightly different compared to a function type expression - use `:` between the parameter list and the return type rather than `=>`.

--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -54,6 +54,13 @@ type DescribableFunction = {
 function doSomething(fn: DescribableFunction) {
   console.log(fn.description + " returned " + fn(6));
 }
+
+function myFunc(someArg: number) {
+  return someArg > 3;
+}
+myFunc.description = "default description"
+
+doSomething(myFunc)
 ```
 
 Note that the syntax is slightly different compared to a function type expression - use `:` between the parameter list and the return type rather than `=>`.

--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -60,7 +60,6 @@ function myFunc(someArg: number) {
 }
 myFunc.description = "default description";
 
-
 doSomething(myFunc);
 
 ```

--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -58,7 +58,8 @@ function doSomething(fn: DescribableFunction) {
 function myFunc(someArg: number) {
   return someArg > 3;
 }
-myFunc.description = "default description"
+myFunc.description = "default description";
+
 
 doSomething(myFunc)
 ```


### PR DESCRIPTION
The current sample code for call signature cannot be run on the playground.
It also does not explain how `doSomething` is called when using with call signature.
Thus, I improved it by adding a few more lines of code to make it runnable on the playground.