### PR TITLE
Migrate and update the excess property checking docs

### DIFF
--- a/packages/documentation/copy/en/handbook-v1/Interfaces.md
+++ b/packages/documentation/copy/en/handbook-v1/Interfaces.md
@@ -5,6 +5,8 @@ permalink: /docs/handbook/interfaces.html
 oneline: How to write an interface with TypeScript
 handbook: "true"
 deprecated_by: /docs/handbook/2/objects.html
+deprecation_redirects:
+  [excess-property-checks, /docs/handbook/2/objects.html#excess-property-checks]
 ---
 
 One of TypeScript's core principles is that type checking focuses on the _shape_ that values have.


### PR DESCRIPTION
Fixes #2240 and #1875 

Migrates and does an editing run over the handbook v1 version of the excess property check docs