### PR TITLE
Fixed global-modifying-module link

### DIFF
--- a/packages/documentation/copy/en/declaration-files/templates/global-plugin.d.ts.md
+++ b/packages/documentation/copy/en/declaration-files/templates/global-plugin.d.ts.md
@@ -144,7 +144,7 @@ console.log(y.reverseAndSort());
 
 ### Template
 
-Use the [`global-modifying-module.d.ts`](./templates/global-modifying-module.d.ts.md) template.
+Use the [`global-modifying-module.d.ts`](/docs/handbook/declaration-files/templates/global-modifying-module-d-ts.html) template.
 
 ## Consuming Dependencies
 


### PR DESCRIPTION
This fixes the link from Global Plugin page to the Global Modifying plugin page