### PR TITLE
Sync exactOptionalPropertyTypes description <- compiler

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/exactOptionalPropertyTypes.md
+++ b/packages/tsconfig-reference/copy/en/options/exactOptionalPropertyTypes.md
@@ -1,6 +1,6 @@
 ---
 display: "exactOptionalPropertyTypes"
-oneline: "Differentiate between undefined and not present when type checking."
+oneline: "Interpret optional property types as written, rather than adding `undefined`."
 ---
 
 With exactOptionalPropertyTypes enabled, TypeScript applies stricter rules around how it handles properties on `type` or `interfaces` which have a `?` prefix.


### PR DESCRIPTION
Looks like descriptions were written independently for the compiler and the website? The one from the compiler mentions property types specifically vs. type checking generally --- is that preferable?
- https://github.com/microsoft/TypeScript/pull/46465#discussion_r800856350
- https://github.com/microsoft/TypeScript/pull/46465#discussion_r800856417