### PR TITLE
Add generic parameter defaults to documentation

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Generics.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Generics.md
@@ -374,3 +374,36 @@ createInstance(Bee).keeper.hasMask;
 ```
 
 This pattern is used to power the [mixins](/docs/handbook/mixins.html) design pattern.
+
+## Generic Parameter Defaults
+
+Consider a function that creates a new `HTMLElement`. Calling the function with no arguments generates a `Div`; calling it with an element as the first argument generates an element of the argument's type. You can optionally pass a list of children as well. Previously you would have to define it as:
+
+
+```ts twoslash
+declare function create(): Container<HTMLDivElement, HTMLDivElement[]>;
+declare function create<T extends HTMLElement>(element: T): Container<T, T[]>;
+declare function create<T extends HTMLElement, U extends HTMLElement>(
+  element: T,
+  children: U[]
+): Container<T, U[]>;
+```
+
+With generic parameter defaults we can reduce it to:
+
+```ts twoslash
+declare function create<T extends HTMLElement = HTMLDivElement, U = T[]>(
+  element?: T,
+  children?: U
+): Container<T, U>;
+```
+
+A generic parameter default follows the following rules:
+
+- A type parameter is deemed optional if it has a default.
+- Required type parameters must not follow optional type parameters.
+- Default types for a type parameter must satisfy the constraint for the type parameter, if it exists.
+- When specifying type arguments, you are only required to specify type arguments for the required type parameters. Unspecified type parameters will resolve to their default types.
+- If a default type is specified and inference cannot choose a candidate, the default type is inferred.
+- A class or interface declaration that merges with an existing class or interface declaration may introduce a default for an existing type parameter.
+- A class or interface declaration that merges with an existing class or interface declaration may introduce a new type parameter as long as it specifies a default.


### PR DESCRIPTION
Copied from [the release notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html#generic-parameter-defaults) with tweaks to the first paragraph.

Fixes #2172