### PR TITLE
Hide "Was this page helpful?" popup from focus when not visible

### DIFF
--- a/packages/typescriptlang-org/src/templates/documentation.tsx
+++ b/packages/typescriptlang-org/src/templates/documentation.tsx
@@ -96,7 +96,7 @@ const HandbookTemplate: React.FC<Props> = (props) => {
       <section id="doc-layout" >
         <SidebarToggleButton />
 
-        <div className="page-popup" id="page-helpful-popup" style={{ opacity: 0 }}>
+        <div className="page-popup" id="page-helpful-popup" style={{ opacity: 0, visibility: 'hidden' }}>
           <p>Was this page helpful?</p>
           <div>
             <button className="first" id="like-button-popup" title="Like this page"><LikeUnfilledSVG /></button>

--- a/packages/typescriptlang-org/src/templates/scripts/setupLikeDislikeButtons.ts
+++ b/packages/typescriptlang-org/src/templates/scripts/setupLikeDislikeButtons.ts
@@ -57,11 +57,13 @@ export const setupLikeDislikeButtons = (slug: string, i: any) => {
       if (popup.style.opacity != popupOpacity) {
         // popup.style.display = bottomOfWindow ? "block" : "none"
         popup.style.opacity = popupOpacity
+        popup.style.visibility = bottomOfWindow ? "visible" : "hidden"
       }
 
       const navOpacity = bottomOfWindow ? "0" : "1"
       if (nav.style.opacity != navOpacity) {
         nav.style.opacity = navOpacity
+        nav.style.visibility = bottomOfWindow ? "hidden" : "visible"
       }
     },
     { passive: true, capture: true }


### PR DESCRIPTION
Elements that get hidden with `opacity: 0` still get exposed to keyboard users and are potentially focusable, even while they are invisible and are ignored by some (not all) screen readers. While `display: none` on the elements would remove the transitions, `visibility: hidden` should not have this effect in modern browsers and should correctly remove its children from focus order. The transitions should still be tested by someone else for good measure.

Other components on the website probably require similar changes to be made accessible.