### PR TITLE
Adjust twoslash inlay provider to use the new Monaco API for that

### DIFF
--- a/packages/create-typescript-playground-plugin/template/package.json
+++ b/packages/create-typescript-playground-plugin/template/package.json
@@ -26,7 +26,7 @@
     "@rollup/plugin-typescript": "^3.0.0",
     "@types/react": "^16.9.23",
     "concurrently": "^5.1.0",
-    "monaco-editor": "^0.29.1",
+    "monaco-editor": "^0.32.1",
     "node-fetch": "^2.6.0",
     "rollup": "^1.31.0",
     "serve": "^11.3.0",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/jest": "^25.1.3",
     "jest": "*",
-    "monaco-editor": "^0.29.1",
+    "monaco-editor": "^0.32.1",
     "monaco-typescript": "^3.7.0",
     "typescript": "*"
   }

--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -714,7 +714,11 @@ export const setupPlayground = (
     }
   }
 
-  if (monaco.languages.registerInlayHintsProvider) {
+  const [tsMajor, tsMinor] = sandbox.ts.version.split(".")
+  if (
+    (parseInt(tsMajor) > 4 || (parseInt(tsMajor) == 4 && parseInt(tsMinor) >= 6)) &&
+    monaco.languages.registerInlayHintsProvider
+  ) {
     monaco.languages.registerInlayHintsProvider(sandbox.language, createTwoslashInlayProvider(sandbox))
   }
 

--- a/packages/playground/src/twoslashInlays.ts
+++ b/packages/playground/src/twoslashInlays.ts
@@ -9,7 +9,10 @@ export const createTwoslashInlayProvider = (sandbox: Sandbox) => {
       const results: import("monaco-editor").languages.InlayHint[] = []
       const worker = await sandbox.getWorkerProcess()
       if (model.isDisposed()) {
-        return []
+        return {
+          hints: [],
+          dispose: () => {},
+        }
       }
 
       while ((match = queryRegex.exec(text)) !== null) {
@@ -18,7 +21,12 @@ export const createTwoslashInlayProvider = (sandbox: Sandbox) => {
         const inspectionPos = new sandbox.monaco.Position(endPos.lineNumber - 1, endPos.column)
         const inspectionOff = model.getOffsetAt(inspectionPos)
 
-        if (cancel.isCancellationRequested) return []
+        if (cancel.isCancellationRequested) {
+          return {
+            hints: [],
+            dispose: () => {},
+          }
+        }
 
         const hint = await worker.getQuickInfoAtPosition("file://" + model.uri.path, inspectionOff)
         if (!hint || !hint.displayParts) continue
@@ -31,12 +39,15 @@ export const createTwoslashInlayProvider = (sandbox: Sandbox) => {
           // @ts-ignore
           kind: 0,
           position: new sandbox.monaco.Position(endPos.lineNumber, endPos.column + 1),
-          text,
-          whitespaceBefore: true,
+          label: text,
+          paddingLeft: true,
         }
         results.push(inlay)
       }
-      return results
+      return {
+        hints: results,
+        dispose: () => {},
+      }
     },
   }
   return provider

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@types/jest": "^25.1.3",
     "jest": "*",
-    "monaco-editor": "^0.29.1",
+    "monaco-editor": "^0.32.1",
     "monaco-typescript": "^3.7.0",
     "ts-jest": "^26.4.4",
     "typescript": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5558,7 +5558,7 @@ __metadata:
     "@typescript/sandbox": 0.1.0
     esbuild: ^0.13.4
     jest: "*"
-    monaco-editor: ^0.29.1
+    monaco-editor: ^0.32.1
     monaco-typescript: ^3.7.0
     typescript: "*"
   languageName: unknown
@@ -5572,7 +5572,7 @@ __metadata:
     "@typescript/ata": 0.9.3
     "@typescript/vfs": 1.3.5
     jest: "*"
-    monaco-editor: ^0.29.1
+    monaco-editor: ^0.32.1
     monaco-typescript: ^3.7.0
     ts-jest: ^26.4.4
     typescript: "*"
@@ -20180,10 +20180,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"monaco-editor@npm:^0.29.1":
-  version: 0.29.1
-  resolution: "monaco-editor@npm:0.29.1"
-  checksum: bc1df4f0c026073fdfc5b25487c58eabc82b7341653e75e5a5fa06c7754f823d0751d1eb5f4fb1cc4a0d5d0f1ca801b724b3997e0b5acc942e68358be9d70b71
+"monaco-editor@npm:^0.32.1":
+  version: 0.32.1
+  resolution: "monaco-editor@npm:0.32.1"
+  checksum: f63e96fadca3e46ee639c3c7fead95bc03413d4b47d27ffdf5636270e2753c45391e830dd34ae5404004b8fc6a06b50a91d9ae4b593e1fc21cfc20ee00ca98c5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript-Website/issues/2247

this PR is related to this one since it also updated Monaco: https://github.com/microsoft/TypeScript-Website/pull/2267

⚠️ This PR is meant to be synced with TS 4.6 release.

cc @orta