### PR TITLE
Skip sidebar navigation with skip link on Docs pages

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/TopNav.tsx
+++ b/packages/typescriptlang-org/src/components/layout/TopNav.tsx
@@ -8,6 +8,7 @@ import { createIntlLink } from "../IntlLink";
 
 export type Props = {
   lang: string
+  skipToAnchor?: string
 }
 
 import { navCopy } from "../../copy/en/nav"
@@ -74,7 +75,7 @@ export const SiteNav = (props: Props) => {
 
   return (
     <header dir="ltr">
-      <a className="skip-to-main" href="#site-content" tabIndex={0}>{i("skip_to_content")}</a>
+      <a className="skip-to-main" href={props.skipToAnchor || '#site-content'} tabIndex={0}>{i("skip_to_content")}</a>
 
       <div id="top-menu" className="up">
         <div className="left below-small">

--- a/packages/typescriptlang-org/src/templates/documentation.tsx
+++ b/packages/typescriptlang-org/src/templates/documentation.tsx
@@ -92,7 +92,7 @@ const HandbookTemplate: React.FC<Props> = (props) => {
 
   const slug = slugger()
   return (
-    <Layout title={`${prefix} - ${post.frontmatter.title}`} description={post.frontmatter.oneline || ""} lang={props.pageContext.lang}>
+    <Layout title={`${prefix} - ${post.frontmatter.title}`} description={post.frontmatter.oneline || ""} lang={props.pageContext.lang} skipToAnchor="#handbook-content">
       <section id="doc-layout" >
         <SidebarToggleButton />
 


### PR DESCRIPTION
Fixes #2270 with the solution provided by @orta. See the issue for the longer explanation.

I was a bit weary about the possible duplication here (`#handbook-content` being present in two places), but decided to go with their suggestion given that they are a former maintainer.