### PR TITLE
code typo and grammar nits

### DIFF
--- a/packages/documentation/copy/en/reference/ESM Support for Node.md
+++ b/packages/documentation/copy/en/reference/ESM Support for Node.md
@@ -150,7 +150,7 @@ import foo = require("foo");
 ```
 
 In a CommonJS module, this just boils down to a `require()` call, and in an ES module, this imports [`createRequire`](https://nodejs.org/api/module.html#module_module_createrequire_filename) to achieve the same thing.
-This will make code less portable on runtimes like the browser (which don't support `require()`), but will often be useful for interoperability.
+This will make code less portable on runtimes like browsers (which don't support `require()`), but will often be useful for interoperability.
 In turn, you can write the above example using this syntax as follows:
 
 ```ts twoslash
@@ -176,7 +176,7 @@ You can [read more about ESM/CommonJS interop in Node.js here](https://nodejs.or
 Node.js supports [a new field for defining entry points in `package.json` called `"exports"`](https://nodejs.org/api/packages.html#packages_exports).
 This field is a more powerful alternative to defining `"main"` in `package.json`, and can control what parts of your package are exposed to consumers.
 
-Here's an `package.json` that supports separate entry-points for CommonJS and ESM:
+Here's a `package.json` that supports separate entry-points for CommonJS and ESM:
 
 ```json5
 // package.json
@@ -198,7 +198,7 @@ Here's an `package.json` that supports separate entry-points for CommonJS and ES
 }
 ```
 
-There's a lot to this feature, [which you can read more about on the Node.js documentation](https://nodejs.org/api/packages.html).
+There's a lot to this feature, [which you can read more about in the Node.js documentation](https://nodejs.org/api/packages.html).
 Here we'll try to focus on how TypeScript supports it.
 
 With TypeScript's original Node support, it would look for a `"main"` field, and then look for declaration files that corresponded to that entry.


### PR DESCRIPTION
The change with "browsers" has to occur or the "don't" needs to be changed to "doesn't" to match. (This requirement is despite the fact that "runtimes" is plural.)

The preceding sentence is very unclear but I didn't know how to change it:

> In a CommonJS module, this just boils down to a require() call, and in an ES module, this imports [createRequire](https://nodejs.org/api/module.html#module_module_createrequire_filename) to achieve the same thing.

I think perhaps it is supposed to be the following, but I didn't change it as I wasn't sure:

> In a CommonJS module, this will just be converted into a simple require() call, whereas in an ES module, a [createRequire](https://nodejs.org/api/module.html#module_module_createrequire_filename) will be imported to achieve the same thing.