### PR TITLE
Add `typings-for-npm-packages.html` into redirect paths

### DIFF
--- a/packages/typescriptlang-org/src/redirects/setupRedirects.ts
+++ b/packages/typescriptlang-org/src/redirects/setupRedirects.ts
@@ -16,6 +16,7 @@ export const handbookRedirects = {
   "/docs/handbook/writing-declaration-files.html": "/docs/handbook/declaration-files/introduction.html",
   "/docs/handbook/writing-definition-files": "/docs/handbook/declaration-files/introduction.html",
   "/docs/handbook/typings-for-npm-packages": "/docs/handbook/declaration-files/publishing.html",
+  "/docs/handbook/typings-for-npm-packages.html": "/docs/handbook/declaration-files/publishing.html",
   "/docs/handbook/release-notes": "/docs/handbook/release-notes/overview.html",
   "/docs/tutorial.html": "/docs/handbook/release-notes/overview.html",
   "/docs/handbook/release-notes/overview": "/docs/handbook/release-notes/overview.html",


### PR DESCRIPTION
The next path linked at `https://github.com/microsoft/TypeScript/wiki/Typings-for-npm-packages` is 404.

https://www.typescriptlang.org/docs/handbook/typings-for-npm-packages.html

this path was not included in the list of redirects.

https://github.com/microsoft/TypeScript-Website/blob/8a19ee4dc8d26ac7d5536664788fe88064bf7825/packages/typescriptlang-org/src/redirects/setupRedirects.ts#L18

It's referenced in many other projects, not just the wiki above, so I'd like to include it in the list of redirects. I added this.