### PR TITLE
Fix generateTypesForFilesInDocs.js on Windows

### DIFF
--- a/packages/documentation/scripts/generateTypesForFilesInDocs.js
+++ b/packages/documentation/scripts/generateTypesForFilesInDocs.js
@@ -6,20 +6,20 @@
 // yarn workspace documentation create-handbook-nav
 
 const fs = require("fs");
-const { join, basename } = require("path");
+const path = require("path")
 const { format } = require("prettier");
 
 // prettier-ignore
 const getFilePaths = folderPath => {
-  const entryPaths = fs.readdirSync(folderPath).map(entry => join(folderPath, entry));
+  const entryPaths = fs.readdirSync(folderPath).map(entry => path.join(folderPath, entry));
   const filePaths = entryPaths.filter(entryPath => fs.statSync(entryPath).isFile());
   const dirPaths = entryPaths.filter(entryPath => !filePaths.includes(entryPath));
   const dirFiles = dirPaths.reduce((prev, curr) => prev.concat(getFilePaths(curr)), []);
-  return [...filePaths, ...dirFiles].filter((f) => !basename(f).startsWith("."));
+  return [...filePaths, ...dirFiles].filter((f) => !path.basename(f).startsWith("."));
 };
 
-const allFiles = getFilePaths(join(__dirname, "..", "copy", "en"));
-const enRoot = join(__dirname, "..", "copy", "en");
+const allFiles = getFilePaths(path.join(__dirname, "..", "copy", "en"));
+const enRoot = path.join(__dirname, "..", "copy", "en");
 
 // From:   '/Users/ortatherox/dev/typescript/new-website/packages/documentation/copy/en/Advanced Types.md',
 // To:     'Advanced Types.md',
@@ -29,7 +29,7 @@ const code = `
   export type AllDocsPages = "${files.join('" | "')}"
 `;
 
-const typePath = join(__dirname, "types", "AllFilenames.d.ts");
+const typePath = path.join(__dirname, "types", "AllFilenames.d.ts");
 fs.writeFileSync(typePath, format(code, { filepath: typePath }));
 
 module.exports = {

--- a/packages/documentation/scripts/generateTypesForFilesInDocs.js
+++ b/packages/documentation/scripts/generateTypesForFilesInDocs.js
@@ -23,7 +23,7 @@ const enRoot = path.join(__dirname, "..", "copy", "en");
 
 // From:   '/Users/ortatherox/dev/typescript/new-website/packages/documentation/copy/en/Advanced Types.md',
 // To:     'Advanced Types.md',
-const files = allFiles.map((f) => f.replace(enRoot + "/", ""));
+const files = allFiles.map((f) => path.relative(enRoot, f).replace(/\\/g, "/"));
 
 const code = `
   export type AllDocsPages = "${files.join('" | "')}"


### PR DESCRIPTION
Without this, `yarn bootstrap` (which the top-level README.md tells you to run) will garble AllFilenames.d.ts, and generateDocsNavigationPerLanguage.js will no longer type-check.

