### PR TITLE
Clarified misleading instructions regarding enabling strictNullChecks.

### DIFF
--- a/packages/playground-examples/copy/en/TypeScript/Type Primitives/Nullable Types.ts
+++ b/packages/playground-examples/copy/en/TypeScript/Type Primitives/Nullable Types.ts
@@ -47,7 +47,7 @@ const searchResults = {
 type PotentialString = string | undefined | null;
 
 // The PotentialString discards the undefined and null. If
-// you go up to the settings and turn on strict mode and come
+// you go up to the TS Config and enable strictNullChecks and come
 // back, you'll see that hovering on PotentialString now shows
 // the full union.
 

--- a/packages/playground-examples/copy/en/TypeScript/Type Primitives/Nullable Types.ts
+++ b/packages/playground-examples/copy/en/TypeScript/Type Primitives/Nullable Types.ts
@@ -47,7 +47,7 @@ const searchResults = {
 type PotentialString = string | undefined | null;
 
 // The PotentialString discards the undefined and null. If
-// you go up to the TS Config and enable strictNullChecks and come
+// you open the "TS Config" menu, enable strictNullChecks, and come
 // back, you'll see that hovering on PotentialString now shows
 // the full union.
 


### PR DESCRIPTION
The existing language 

> you go up to the settings and turn on strict mode and come

is confusing, (a) because there is a Settings section on the page, but that is settings for the playground environment sidebar tabs, etc, and it doesn't contain any settings related to strict mode and (b) the correct setting is in the "TS Config" section of the page and is named `strictNullChecks` – if you go to TS Config and examine the `strict` setting, it is already enabled and is not the setting that the author intended the user to toggle. 