### PR TITLE
Fix the way to refer to imported items

### DIFF
--- a/packages/documentation/copy/en/reference/Experimental ESM Support for Node.md
+++ b/packages/documentation/copy/en/reference/Experimental ESM Support for Node.md
@@ -140,7 +140,7 @@ export function helper() {
 import { helper } from "./foo.cjs";
 
 // prints "hello world!"
-foo.helper();
+helper();
 ```
 
 There isn't always a way for TypeScript to know whether these named imports will be synthesized, but TypeScript will err on being permissive and use some heuristics when importing from a file that is definitely a CommonJS module.


### PR DESCRIPTION
The way to refer to the imported item is wrong.

Since we are importing `helper` named from the foo module, I think it is correct to write `helper();`.