### PR TITLE
Improve Grunt section

### DIFF
--- a/packages/documentation/copy/en/project-config/Integrating with Build Tools.md
+++ b/packages/documentation/copy/en/project-config/Integrating with Build Tools.md
@@ -118,9 +118,7 @@ module.exports = function (grunt) {
         src: "src/main.ts",
         dest: "dist/main.js",
         options: {
-          configure(bundler) {
-            bundler.plugin(require("tsify"));
-          },
+          plugin: ["tsify"],
         },
       },
     },

--- a/packages/documentation/copy/en/project-config/Integrating with Build Tools.md
+++ b/packages/documentation/copy/en/project-config/Integrating with Build Tools.md
@@ -128,6 +128,8 @@ module.exports = function (grunt) {
 };
 ```
 
+More details: [jmreidy/grunt-browserify](https://github.com/jmreidy/grunt-browserify), [TypeStrong/tsify](https://github.com/TypeStrong/tsify)
+
 ## Gulp
 
 ### Install

--- a/packages/documentation/copy/en/project-config/Integrating with Build Tools.md
+++ b/packages/documentation/copy/en/project-config/Integrating with Build Tools.md
@@ -74,13 +74,15 @@ More details: [smrq/tsify](https://github.com/smrq/tsify)
 
 ## Grunt
 
-### Install
+### Using `grunt-ts` (no longer maintained)
+
+#### Install
 
 ```sh
-npm install grunt-ts
+npm install grunt-ts --save-dev
 ```
 
-### Basic Gruntfile.js
+#### Basic Gruntfile.js
 
 ```js
 module.exports = function (grunt) {
@@ -97,6 +99,36 @@ module.exports = function (grunt) {
 ```
 
 More details: [TypeStrong/grunt-ts](https://github.com/TypeStrong/grunt-ts)
+
+### Using `grunt-browserify` combined with `tsify`
+
+#### Install
+
+```sh
+npm install grunt-browserify tsify --save-dev
+```
+
+#### Basic Gruntfile.js
+
+```js
+module.exports = function (grunt) {
+  grunt.initConfig({
+    browserify: {
+      all: {
+        src: "src/main.ts",
+        dest: "dist/main.js",
+        options: {
+          configure(bundler) {
+            bundler.plugin(require("tsify"));
+          },
+        },
+      },
+    },
+  });
+  grunt.loadNpmTasks("grunt-browserify");
+  grunt.registerTask("default", ["browserify"]);
+};
+```
 
 ## Gulp
 


### PR DESCRIPTION
Currently, in `Grunt` section, it recommended `grunt-ts`, but it is no longer maintained, using some out-date, vulnerable dependencies. I add a second approach which uses `grunt-browserify` combined with `tsify`