### PR TITLE
Adds code owners self merge to the repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+packages/**/* @orta

--- a/.github/workflows/codeowners-merge.yml
+++ b/.github/workflows/codeowners-merge.yml
@@ -1,0 +1,19 @@
+name: Codeowners merging
+on:
+  pull_request_target: { types: [opened] }
+  issue_comment: { types: [created] }
+  pull_request_review: { types: [submitted] }
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Run Codeowners merge check
+        uses: OSS-Docs-Tools/code-owner-self-merge@1.6.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          quiet: true
+          if_no_maintainers_add_label: 'maintainers'


### PR DESCRIPTION
Adds the same infra as used on the lib DOM repo, and localization repos for the last 2 years. First, what _cannot_ be merged by folks in the CODEOWNERS:

 - Things which affect node modules installs
 - Infra build scripts
 - GitHub yml stuff
 - LICENSE
 - PRs which are not green

If you'd like to trust but verify, [this is the locked code for the self-merge](https://github.com/OSS-Docs-Tools/code-owner-self-merge/blob/1.6.5/index.js) ~300 lines of JavaScript.

Nearly all "_make this edit to the docs_"  PRs only affect a markdown doc, so this can be used to handle the small PRs but not to ship an update of the TypeScript release for example (because that affects the yarn lockfile).  