### PR TITLE
Fix mistyped parameter name in `JSDoc Reference.md`

### DIFF
--- a/packages/documentation/copy/en/javascript/JSDoc Reference.md
+++ b/packages/documentation/copy/en/javascript/JSDoc Reference.md
@@ -391,7 +391,7 @@ Finally, you can specify a default for a type parameter:
 /** @template [T=object] */
 class Cache {
     /** @param {T} initial */
-    constructor(T) {
+    constructor(initial) {
     }
 }
 let c = new Cache()


### PR DESCRIPTION
Fix mistyped parameter name.