### PR TITLE
Clarify tsBuildInfoFile isn't a folder

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/tsBuildInfoFile.md
+++ b/packages/tsconfig-reference/copy/en/options/tsBuildInfoFile.md
@@ -1,10 +1,10 @@
 ---
 display: "TS Build Info File"
-oneline: "Specify the folder for .tsbuildinfo incremental compilation files."
+oneline: "The file to store `.tsbuildinfo` incremental build information in."
 ---
 
 This setting lets you specify a file for storing incremental compilation information as a part of composite projects which enables faster
 building of larger TypeScript codebases. You can read more about composite projects [in the handbook](/docs/handbook/project-references.html).
 
-This option offers a way to configure the place where TypeScript keeps track of the files it stores on the disk to
-indicate a project's build state &mdash; by default, they are in the same folder as your emitted JavaScript.
+By default it is in the same folder as your emitted JavaScript and has a `.tsbuildinfo` file extension.
+The default file name is based on the `outFile` option or your tsconfig file name.


### PR DESCRIPTION
I copied the description from the 1.0 config reference, roughly: https://web.archive.org/web/20200606234156/https://www.typescriptlang.org/docs/handbook/compiler-options.html#:~:text=specify%20what%20file%20to%20store%20incremental%20build%20information%20in.

I also elaborated slightly on the default value, based on the implementation in getTsBuildInfoEmitOutputFilePath(): https://github.com/microsoft/TypeScript/blob/918f0ef4040b372df357c5439601576baaeeec4c/src/compiler/emitter.ts#L53

Thanks @uhyo for [reporting the issue](https://github.com/microsoft/TypeScript/issues/48053) and @Blopaa and @Uda-Titor for corrections to the compiler repo.