### PR TITLE
Fix broken link in docs

### DIFF
--- a/packages/documentation/copy/en/declaration-files/Templates.md
+++ b/packages/documentation/copy/en/declaration-files/Templates.md
@@ -5,7 +5,7 @@ permalink: /docs/handbook/declaration-files/templates.html
 oneline: "Different d.ts module template examples"
 ---
 
-[global-modifying-module.d.ts](./templates/global-modifying-module.d.ts.md)
+[global-modifying-module.d.ts](/docs/handbook/declaration-files/templates/global-modifying-module.d.ts.html)
 
 - [global-plugin.d.ts](/docs/handbook/declaration-files/templates/global-plugin-d-ts.html)
 - [global.d.ts](/docs/handbook/declaration-files/templates/global-d-ts.html)

--- a/packages/documentation/copy/en/declaration-files/Templates.md
+++ b/packages/documentation/copy/en/declaration-files/Templates.md
@@ -5,7 +5,7 @@ permalink: /docs/handbook/declaration-files/templates.html
 oneline: "Different d.ts module template examples"
 ---
 
-[global-modifying-module.d.ts](/docs/handbook/declaration-files/templates/global-modifying-module.d.ts.html)
+[global-modifying-module.d.ts](/docs/handbook/declaration-files/templates/global-modifying-module-d-ts.html)
 
 - [global-plugin.d.ts](/docs/handbook/declaration-files/templates/global-plugin-d-ts.html)
 - [global.d.ts](/docs/handbook/declaration-files/templates/global-d-ts.html)


### PR DESCRIPTION

1. Was on https://www.typescriptlang.org/docs/handbook/declaration-files/library-structures.html
2. Clicked "Templates" and was brought here: https://www.typescriptlang.org/docs/handbook/declaration-files/templates.html
3. Clicked "global-modifying-module.d.ts" and got 404.

The link should go here I am assuming:

https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-modifying-module-d-ts.html

