### PR TITLE
Remove incorrect operator identification

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Basics.md
+++ b/packages/documentation/copy/en/handbook-v2/Basics.md
@@ -362,7 +362,7 @@ greet("Maddison", new Date());
 Notice two things here:
 
 1. Our `person` and `date` parameters no longer have type annotations.
-2. Our "template string" - that string that used backticks (the `` ` `` character) - was converted to plain strings with concatenations (`+`).
+2. Our "template string" - that string that used backticks (the `` ` `` character) - was converted to plain strings with concatenations.
 
 More on that second point later, but let's now focus on that first point.
 Type annotations aren't part of JavaScript (or ECMAScript to be pedantic), so there really aren't any browsers or other runtimes that can just run TypeScript unmodified.


### PR DESCRIPTION
The resulting compiled file uses `.concat()` and not `+`. Remove `+` from prose.