### PR TITLE
Fixing typo in why-create-typescript.tsx

### DIFF
--- a/packages/typescriptlang-org/src/templates/pages/why-create-typescript.tsx
+++ b/packages/typescriptlang-org/src/templates/pages/why-create-typescript.tsx
@@ -161,7 +161,7 @@ understand how every change affects the rest of the program.</p>
 
                                 <p>Typically, the need to ensure there are no bugs in your code can be handled by writing automated tests, then by manually verifying that the code works as you expect and finally having another person validate that it seems correct.</p>
 
-                                <p>Not many companies are the size of Microsoft, however a lot of all problems writing JavaScript in large codebases are the same. Many JavaScript apps build apps which are made up of hundreds of thousands of files. A single change
+                                <p>Not many companies are the size of Microsoft, however a lot of all problems writing JavaScript in large codebases are the same. Many JavaScript apps are made up of hundreds of thousands of files. A single change
                                 to one individual file can affect the behaviour of any number of other files, like throwing a pebble into a pond
 and causing ripples to spread out to the bank.</p>
 


### PR DESCRIPTION
Removed superfluous (and incorrect) wording in the why-create-typescript page.