### PR TITLE
CommonJs file module's path should be relative

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Modules.md
+++ b/packages/documentation/copy/en/handbook-v2/Modules.md
@@ -296,7 +296,7 @@ module.exports = {
 };
 // @filename: index.ts
 // ---cut---
-const maths = require("maths");
+const maths = require("./maths");
 maths.pi;
 //    ^?
 ```
@@ -320,7 +320,7 @@ module.exports = {
 };
 // @filename: index.ts
 // ---cut---
-const { squareTwo } = require("maths");
+const { squareTwo } = require("./maths");
 squareTwo;
 // ^?
 ```


### PR DESCRIPTION
If it is not relative it is considered a core module instead of a file module. Here 'maths.js' is a file module, note a core module that we are requiring from `node_modules` or from the standard library.  For more information please refer the file module doc: https://nodejs.org/api/modules.html#file-modules