### PR TITLE
explain `number` being a type in terms of practice

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -21,7 +21,7 @@ Each has a corresponding type in TypeScript.
 As you might expect, these are the same names you'd see if you used the JavaScript `typeof` operator on a value of those types:
 
 - `string` represents string values like `"Hello, world"`
-- `number` is for numbers like `42`. JavaScript does not have a special runtime value for integers, so there's no equivalent to `int` or `float` - everything is simply `number`
+- `number` is for numbers like `42`. JavaScript users do not commonly distinguish between integers and fractional or floating-point numbers, so there's no equivalent to `int` or `float` - everything is simply `number`
 - `boolean` is for the two values `true` and `false`
 
 > The type names `String`, `Number`, and `Boolean` (starting with capital letters) are legal, but refer to some special built-in types that will very rarely appear in your code. _Always_ use `string`, `number`, or `boolean` for types.
@@ -34,7 +34,6 @@ We'll learn more about the syntax `T<U>` when we cover _generics_.
 
 > Note that `[number]` is a different thing; refer to the section on [Tuples](/docs/handbook/2/objects.html#tuple-types).
 
-
 ## `any`
 
 TypeScript also has a special type, `any`, that you can use whenever you don't want a particular value to cause typechecking errors.
@@ -44,7 +43,7 @@ When a value is of type `any`, you can access any properties of it (which will i
 ```ts twoslash
 let obj: any = { x: 0 };
 // None of the following lines of code will throw compiler errors.
-// Using `any` disables all further type checking, and it is assumed 
+// Using `any` disables all further type checking, and it is assumed
 // you know the environment better than TypeScript.
 obj.foo();
 obj();
@@ -500,7 +499,7 @@ If this happens, you can use two assertions, first to `any` (or `unknown`, which
 declare const expr: any;
 type T = { a: 1; b: 2; c: 3 };
 // ---cut---
-const a = (expr as any) as T;
+const a = expr as any as T;
 ```
 
 ## Literal Types

--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -34,6 +34,7 @@ We'll learn more about the syntax `T<U>` when we cover _generics_.
 
 > Note that `[number]` is a different thing; refer to the section on [Tuples](/docs/handbook/2/objects.html#tuple-types).
 
+
 ## `any`
 
 TypeScript also has a special type, `any`, that you can use whenever you don't want a particular value to cause typechecking errors.
@@ -43,7 +44,7 @@ When a value is of type `any`, you can access any properties of it (which will i
 ```ts twoslash
 let obj: any = { x: 0 };
 // None of the following lines of code will throw compiler errors.
-// Using `any` disables all further type checking, and it is assumed
+// Using `any` disables all further type checking, and it is assumed 
 // you know the environment better than TypeScript.
 obj.foo();
 obj();
@@ -499,7 +500,7 @@ If this happens, you can use two assertions, first to `any` (or `unknown`, which
 declare const expr: any;
 type T = { a: 1; b: 2; c: 3 };
 // ---cut---
-const a = expr as any as T;
+const a = (expr as any) as T;
 ```
 
 ## Literal Types


### PR DESCRIPTION
Previously it was said that

> Ultimately, a static type system has to make the call over what code should be flagged as an error in its system, even if it's "valid" JavaScript that won't immediately throw an error.

So "JavaScript does not have a special runtime value for integers" is not a reason for int and float not to exist—that is a choice made by TypeScript, not one imposed by JavaScript.

I've tried to provide an alternate reason instead, in terms of what TypeScript users are likely to want to do.