### PR TITLE
qualify when experimenting with inference is safe

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -84,7 +84,7 @@ let myName = "Alice";
 ```
 
 For the most part you don't need to explicitly learn the rules of inference.
-If you're starting out, try using fewer type annotations than you think - you might be surprised how few you need for TypeScript to fully understand what's going on.
+If you're starting out and have `noImplicitAny` turned on, try using fewer type annotations than you think - you might be surprised how few you need for TypeScript to fully understand what's going on.
 
 ## Functions
 


### PR DESCRIPTION
Trying to remove annotations and seeing what gets inferred is a great way to understand what the type system is thinking--if `noImplicitAny` is on.  Consider `xyt` versus `xya` in the following:

```typescript
type t = "T"
function xyt(p: {x: {y: t}}[]) {
  return p[0].x.y
}
function xya(p) {
  return p[0].x.y
}
const res = xyt([{x: {y: "T"}}]).length
const bad = xya(42).length
const z = res + bad
```

A programmer exploring

> how few [annotations] you need for TypeScript to fully understand what's going on

might well change the signature from `xyt` to `xya`. With `noImplicitAny` off, this doesn't mean TypeScript understands what's going on; it means it doesn't, and silently accepted it anyway.

The conclusions one might draw about the power of inference are often invalid when `noImplicitAny` is off, as a result, and someone who wants to experiment in this way should be warned that such experiments only really give good results when it is on.