### PR TITLE
mention inferred occurrences of type params when counting them

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -320,6 +320,7 @@ function greet(s: string) {
 
 Remember, type parameters are for _relating the types of multiple values_.
 If a type parameter is only used once in the function signature, it's not relating anything.
+This includes the inferred return type; for example, if `Str` was part of the inferred return type of `greet`, it would be relating the argument and return types, so would be used _twice_ despite appearing only once in the written code.
 
 > **Rule**: If a type parameter only appears in one location, strongly reconsider if you actually need it
 


### PR DESCRIPTION
For the section "Type Parameters Should Appear Twice", I believe it is at least worth a footnote that this means "appear [in the whole inferred type signature]", not "appear [in the written code]".  For example, to borrow a later case

```ts
function identity<A>(a: A) {
    return a;
}

let z = identity(42)
```

`z: number` demonstrating that the inferred type of `identity` is `<A>(a: A) => A`, thus _relating the types of multiple values_ even though there is only one immediately apparent usage of the type parameter in the signature.