### PR TITLE
Update paths.md - baseUrl is no longer required

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/paths.md
+++ b/packages/tsconfig-reference/copy/en/options/paths.md
@@ -10,7 +10,7 @@ A series of entries which re-map imports to lookup locations relative to the [`b
 ```json tsconfig
 {
   "compilerOptions": {
-    "baseUrl": ".", // this must be specified if "paths" is specified.
+    "baseUrl": ".",
     "paths": {
       "jquery": ["node_modules/jquery/dist/jquery"] // this mapping is relative to "baseUrl"
     }


### PR DESCRIPTION
The comment stated baseUrl was required when setting paths option, TS 4.1 release notes say this is no longer required: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#paths-without-baseurl