### PR TITLE
Fixed links in "What's New" section for fragments starting with a number

### DIFF
--- a/packages/typescriptlang-org/src/templates/scripts/setupSubNavigationSidebar.ts
+++ b/packages/typescriptlang-org/src/templates/scripts/setupSubNavigationSidebar.ts
@@ -8,11 +8,12 @@ export const overrideSubNavLinksWithSmoothScroll = () => {
     link.addEventListener("click", event => {
       event.preventDefault()
 
-      let target = document.querySelector(
-        decodeURIComponent(event.target!["hash"])
-      )
+      const hash = (event.target! as HTMLAnchorElement).hash
+      const id = decodeURIComponent(hash).slice(1)
+      const target = document.querySelector(`[id="${id}"]`)
+        
       target!.scrollIntoView({ behavior: "smooth", block: "start" })
-      document.location.hash = event.target!["hash"]
+      document.location.hash = hash
     })
   })
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript-Website/issues/2369

Links in the "What's New" pages refering to sections with a fragment starting with a number weren't working.

It was due to the fact we were trying to get the anchor tag with the corresponding id, and since the id isn't meeting to the specs, trying to get it using `Document.getElementById()` was throwing an error.

There is fortunately a workaround by using `querySelector` and a CSS-like attribute selector, with the id as attribute.