### PR TITLE
Update Iterators and Generators.md

### DIFF
--- a/packages/documentation/copy/en/reference/Iterators and Generators.md
+++ b/packages/documentation/copy/en/reference/Iterators and Generators.md
@@ -53,22 +53,6 @@ for (let i of list) {
 }
 ```
 
-Another distinction is that `for..in` operates on any object; it serves as a way to inspect properties on this object.
-`for..of` on the other hand, is mainly interested in values of iterable objects. Built-in objects like `Map` and `Set` implement `Symbol.iterator` property allowing access to stored values.
-
-```ts
-let pets = new Set(["Cat", "Dog", "Hamster"]);
-pets["species"] = "mammals";
-
-for (let pet in pets) {
-  console.log(pet); // "species"
-}
-
-for (let pet of pets) {
-  console.log(pet); // "Cat", "Dog", "Hamster"
-}
-```
-
 ### Code generation
 
 #### Targeting ES5 and ES3


### PR DESCRIPTION
I suggested that the removed section in the Pull Request be merged because it is showing an incorrect usage of the `Set` object according to [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set).

In theory, what the author wanted to communicate with this section makes sense (if they were teaching JavaScript), if you ran that example in JavaScript land it would compile and make sense. But with TypeScript it will throw an error and not even compile depending on how 'strict' the compiler settings are, ie. `noEmitOnErrors = true`. Therefore it causes only confusion and should be removed in my opinion.

Perhaps there's a better way to to get the same point across that the author wanted to, but I couldn't think of any so far. I could also try to rewrite a similar / different suggestion if anyone had an idea for that. 

There's an open issue from 2020 which shows the same confusion I had when I first saw this example [link](https://github.com/microsoft/TypeScript-Website/issues/909)

The error thrown by TS for this example: 
```
Element implicitly has an 'any' type because expression of type '"species"' can't be used to index type 'Set<string>'.
  Property 'species' does not exist on type 'Set<string>'.
```