### PR TITLE
feat: add link to "DTS from JS" doc in `allowJs` in reference

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/allowJs.md
+++ b/packages/tsconfig-reference/copy/en/options/allowJs.md
@@ -37,3 +37,5 @@ console.log(defaultCardDeck);
 ```
 
 This flag can be used as a way to incrementally add TypeScript files into JS projects by allowing the `.ts` and `.tsx` files to live along-side existing JavaScript files.
+
+It can also be used along-side [`declaration`](#declaration) and [`emitDeclarationOnly`](#emitDeclarationOnly) to [create declarations for JS files](/docs/handbook/declaration-files/dts-from-js.html).


### PR DESCRIPTION
## Summary

In `allowJs` in the TSConfig Reference, link out to the ["DTS from JS" doc](https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html) in the handbook to explain the relationship to `emitDeclarationOnly`.

## Details

- `allowJs` (and `checkJs`) are marked as `relatedTo` `emitDeclarationOnly` in the reference, yet this relationship is never explained in the reference itself
  - as such, link out to the "DTS from JS" doc in the handbook, which explains the relationship and how to use them together in detail
  - hopefully this clarifies things for JS users who may be especially unfamiliar with the various `tsconfig` options

- related to an old, closed PR of mine (#1098) where I tried to remove the `relatedTo` `emitDeclarationOnly`
  - the alternative I listed there was to link to the "DTS from JS" doc, but that was never implemented, so doing that now!
  
## Review Notes

Let me know if you'd prefer the text/copy to be a bit different.
In particular, if in-line links are not preferred, then the link could be moved to a second sentence that says "See the [handbook](https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html) for more details" instead.