### PR TITLE
Update Generics.md

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Generics.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Generics.md
@@ -152,7 +152,7 @@ let myIdentity: <Type>(arg: Type) => Type = identity;
 We could also have used a different name for the generic type parameter in the type, so long as the number of type variables and how the type variables are used line up.
 
 ```ts twoslash
-function identity<Type>(arg: Type): Type {
+function identity<Input>(arg: Input): Input {
   return arg;
 }
 


### PR DESCRIPTION
There seems to be a typo in the section from lines 152-162. The code snippet in the section describes that a different name for the generic parameter can be used as long as the type variables match up.

However the code snippet in lines 155-159, do not use a different name as mentioned in the preceding paragraph in the example; it uses the `Type` generic parameter in the instead of the `Input` generic parameter in the `identity` function's declaration unlike the `myIdentity` function which uses `Input`.