### PR TITLE
More accurately describe the expected `index.d.ts` location

### DIFF
--- a/packages/documentation/copy/en/declaration-files/Publishing.md
+++ b/packages/documentation/copy/en/declaration-files/Publishing.md
@@ -33,7 +33,7 @@ For example:
 
 Note that the `"typings"` field is synonymous with `types`, and could be used as well.
 
-Also note that if your main declaration file is named `index.d.ts` and lives at the root of the package (next to the `package.json`) you do not need to mark the `types` property, though it is advisable to do so.
+Note:  TypeScript will infer the root `*.d.ts` based on the value in `main`, which means in cases like above you do not need to mark the `types` property, though it is advisable to do so.
 
 ## Dependencies
 

--- a/packages/documentation/copy/en/declaration-files/Publishing.md
+++ b/packages/documentation/copy/en/declaration-files/Publishing.md
@@ -33,7 +33,7 @@ For example:
 
 Note that the `"typings"` field is synonymous with `types`, and could be used as well.
 
-Also note that if your main declaration file is named `index.d.ts` and lives at the root of the package (next to `index.js`) you do not need to mark the `types` property, though it is advisable to do so.
+Also note that if your main declaration file is named `index.d.ts` and lives at the root of the package (next to the `package.json`) you do not need to mark the `types` property, though it is advisable to do so.
 
 ## Dependencies
 

--- a/packages/documentation/copy/en/declaration-files/Publishing.md
+++ b/packages/documentation/copy/en/declaration-files/Publishing.md
@@ -33,7 +33,6 @@ For example:
 
 Note that the `"typings"` field is synonymous with `types`, and could be used as well.
 
-Note:  TypeScript will infer the root `*.d.ts` based on the value in `main`, which means in cases like above you do not need to mark the `types` property, though it is advisable to do so.
 
 ## Dependencies
 


### PR DESCRIPTION
The docs say that the expected location for `index.d.ts` is in "the root of the package where the `index.js`" is. It's contradicting since the `index.js` is usually buried somewhere in a `dist` or `build` folder. However `package.json` is in the root.

**Does the resolver look for the `index.d.ts` file in the project root or next to the file specified by `main` property in the `package.json`?** Or both?

Either way the documentation could be more clear on that.