### PR TITLE
Change an array to an iterabale object

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -724,7 +724,7 @@ In TypeScript, the type annotation on these parameters is implicitly `any[]` ins
 
 ### Rest Arguments
 
-Conversely, we can _provide_ a variable number of arguments from a iterable object (for example, an array) using the spread syntax.
+Conversely, we can _provide_ a variable number of arguments from an iterable object (for example, an array) using the spread syntax.
 For example, the `push` method of arrays takes any number of arguments:
 
 ```ts twoslash

--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -724,7 +724,7 @@ In TypeScript, the type annotation on these parameters is implicitly `any[]` ins
 
 ### Rest Arguments
 
-Conversely, we can _provide_ a variable number of arguments from an array using the spread syntax.
+Conversely, we can _provide_ a variable number of arguments from a iterable object (for example, an array) using the spread syntax.
 For example, the `push` method of arrays takes any number of arguments:
 
 ```ts twoslash


### PR DESCRIPTION
The spread operator works on an iterabale object, not just an array