### PR TITLE
add throw to documentation of noFallthroughCasesInSwitch option

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/noFallthroughCasesInSwitch.md
+++ b/packages/tsconfig-reference/copy/en/options/noFallthroughCasesInSwitch.md
@@ -4,7 +4,7 @@ oneline: "Enable error reporting for fallthrough cases in switch statements."
 ---
 
 Report errors for fallthrough cases in switch statements.
-Ensures that any non-empty case inside a switch statement includes either `break` or `return`.
+Ensures that any non-empty case inside a switch statement includes either `break`, `return` or `throw`.
 This means you won't accidentally ship a case fallthrough bug.
 
 ```ts twoslash

--- a/packages/tsconfig-reference/copy/en/options/noFallthroughCasesInSwitch.md
+++ b/packages/tsconfig-reference/copy/en/options/noFallthroughCasesInSwitch.md
@@ -4,7 +4,7 @@ oneline: "Enable error reporting for fallthrough cases in switch statements."
 ---
 
 Report errors for fallthrough cases in switch statements.
-Ensures that any non-empty case inside a switch statement includes either `break`, `return` or `throw`.
+Ensures that any non-empty case inside a switch statement includes either `break`, `return`, or `throw`.
 This means you won't accidentally ship a case fallthrough bug.
 
 ```ts twoslash


### PR DESCRIPTION
The documentation of the `noFallthroughCasesInSwitch` option only mentions `break` and `return`. This PR adds the missing `throw`.