### PR TITLE
Add version compatibility details

### DIFF
--- a/packages/documentation/copy/en/release-notes/TypeScript 3.0.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 3.0.md
@@ -251,7 +251,7 @@ function f23<T extends unknown>(x: T) {
 function f24(x: { [x: string]: unknown }) {
   x = {};
   x = { a: 5 };
-  x = [1, 2, 3];
+  x = [1, 2, 3]; // OK in TypeScript3.0, Error when version > 3.0
   x = 123; // Error
 }
 


### PR DESCRIPTION
In 'Anything but primitive assignable to { [x: string]: unknown }', When version > 3.0, x = [1, 2, 3] will throw Error