### PR TITLE
Note that object literals may only specify known properties

### DIFF
--- a/packages/documentation/copy/en/reference/Type Compatibility.md
+++ b/packages/documentation/copy/en/reference/Type Compatibility.md
@@ -70,7 +70,7 @@ greet(dog); // OK
 Note that `dog` has an extra `owner` property, but this does not create an error.
 Only members of the target type (`Pet` in this case) are considered when checking for compatibility.
 
-Be aware, however, that [object literals](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes-func.html#other-important-typescript-types)
+Be aware, however, that [object literals](https://www.typescriptlang.org/docs/handbook/2/objects.html#excess-property-checks)
 may only specify known properties. For example, because we have explicitly specified that `dog` is
 of type `Pet`, the following code is invalid:
 

--- a/packages/documentation/copy/en/reference/Type Compatibility.md
+++ b/packages/documentation/copy/en/reference/Type Compatibility.md
@@ -68,7 +68,9 @@ greet(dog); // OK
 ```
 
 Note that `dog` has an extra `owner` property, but this does not create an error.
-Only members of the target type (`Pet` in this case) are considered when checking for compatibility.
+Only members of the target type (`Pet` in this case) are considered when
+checking for compatibility. This comparison process proceeds recursively,
+exploring the type of each member and sub-member.
 
 Be aware, however, that object literals [may only specify known properties](https://www.typescriptlang.org/docs/handbook/2/objects.html#excess-property-checks).
 For example, because we have explicitly specified that `dog` is
@@ -77,8 +79,6 @@ of type `Pet`, the following code is invalid:
 ```ts
 let dog: Pet = { name: "Lassie", owner: "Rudd Weatherwax" }; // Error
 ```
-
-This comparison process proceeds recursively, exploring the type of each member and sub-member.
 
 ## Comparing two functions
 

--- a/packages/documentation/copy/en/reference/Type Compatibility.md
+++ b/packages/documentation/copy/en/reference/Type Compatibility.md
@@ -72,7 +72,7 @@ Only members of the target type (`Pet` in this case) are considered when
 checking for compatibility. This comparison process proceeds recursively,
 exploring the type of each member and sub-member.
 
-Be aware, however, that object literals [may only specify known properties](https://www.typescriptlang.org/docs/handbook/2/objects.html#excess-property-checks).
+Be aware, however, that object literals [may only specify known properties](/docs/handbook/2/objects.html#excess-property-checks).
 For example, because we have explicitly specified that `dog` is
 of type `Pet`, the following code is invalid:
 

--- a/packages/documentation/copy/en/reference/Type Compatibility.md
+++ b/packages/documentation/copy/en/reference/Type Compatibility.md
@@ -71,7 +71,7 @@ Note that `dog` has an extra `owner` property, but this does not create an error
 Only members of the target type (`Pet` in this case) are considered when checking for compatibility.
 
 Be aware, however, that [object literals](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes-func.html#other-important-typescript-types)
-may only specifiy known properties. For example, because we have explicitly specified that `dog` is
+may only specify known properties. For example, because we have explicitly specified that `dog` is
 of type `Pet`, the following code is invalid:
 
 ```ts

--- a/packages/documentation/copy/en/reference/Type Compatibility.md
+++ b/packages/documentation/copy/en/reference/Type Compatibility.md
@@ -70,6 +70,14 @@ greet(dog); // OK
 Note that `dog` has an extra `owner` property, but this does not create an error.
 Only members of the target type (`Pet` in this case) are considered when checking for compatibility.
 
+Be aware, however, that [object literals](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes-func.html#other-important-typescript-types)
+may only specifiy known properties. For example, because we have explicitly specified that `dog` is
+of type `Pet`, the following code is invalid:
+
+```ts
+let dog: Pet = { name: "Lassie", owner: "Rudd Weatherwax" }; // Error
+```
+
 This comparison process proceeds recursively, exploring the type of each member and sub-member.
 
 ## Comparing two functions

--- a/packages/documentation/copy/en/reference/Type Compatibility.md
+++ b/packages/documentation/copy/en/reference/Type Compatibility.md
@@ -70,8 +70,8 @@ greet(dog); // OK
 Note that `dog` has an extra `owner` property, but this does not create an error.
 Only members of the target type (`Pet` in this case) are considered when checking for compatibility.
 
-Be aware, however, that [object literals](https://www.typescriptlang.org/docs/handbook/2/objects.html#excess-property-checks)
-may only specify known properties. For example, because we have explicitly specified that `dog` is
+Be aware, however, that object literals [may only specify known properties](https://www.typescriptlang.org/docs/handbook/2/objects.html#excess-property-checks).
+For example, because we have explicitly specified that `dog` is
 of type `Pet`, the following code is invalid:
 
 ```ts


### PR DESCRIPTION
Re: microsoft/TypeScript#49500

I'm not super happy with the object literals link, but it was the best I could find in the official docs. To anyone reviewing this, please update if there is a better link available.