### PR TITLE
Fixes #2378 : updates the mentioned output code

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Basics.md
+++ b/packages/documentation/copy/en/handbook-v2/Basics.md
@@ -376,13 +376,13 @@ Most TypeScript-specific code gets erased away, and likewise, here our type anno
 One other difference from the above was that our template string was rewritten from
 
 ```js
-`Hello ${person}, today is ${date.toDateString()}!`;
+`Hello ${person}, today is ${date.toDateString()}!`
 ```
 
 to
 
 ```js
-"Hello " + person + ", today is " + date.toDateString() + "!";
+"Hello ".concat(person, ", today is ").concat(date.toDateString(), "!")
 ```
 
 Why did this happen?
@@ -398,7 +398,7 @@ So running `tsc --target es2015 hello.ts` gives us the following output:
 
 ```js
 function greet(person, date) {
-  console.log(`Hello ${person}, today is ${date.toDateString()}!`);
+    console.log(`Hello ${person}, today is ${date.toDateString()}!`);
 }
 greet("Maddison", new Date());
 ```

--- a/packages/documentation/copy/en/handbook-v2/Basics.md
+++ b/packages/documentation/copy/en/handbook-v2/Basics.md
@@ -398,7 +398,7 @@ So running `tsc --target es2015 hello.ts` gives us the following output:
 
 ```js
 function greet(person, date) {
-    console.log(`Hello ${person}, today is ${date.toDateString()}!`);
+  console.log(`Hello ${person}, today is ${date.toDateString()}!`);
 }
 greet("Maddison", new Date());
 ```


### PR DESCRIPTION
Fixes issue #2378.

After the TypeScript version 4.5.5 it started to use `concat()` function. Try it [here](https://www.typescriptlang.org/play?strict=false&alwaysStrict=false&target=1&jsx=0&module=0&ts=4.7.4#code/PTAEAEGcAsHsHcCiBbAlgFwFAgughgE4DmApugFygmQCsmAZgK4B2AxuqrM6EQSWQAoADiQKQulSOgKpmRADSgAJnnQlKAEVUkAlKADemUKFZdxAGxIA6c7CICABgAkS526AAk+kWK4BfRXRYFQBPUFRIT30VNSsgrTUAZWlZex0-AEIHHQBuTD9MTF5+dAEAIgBZPCUlCK4yxWYSeFAEkgEdXKA).

***

Also, by default, the command `tsc --target es2015 hello.ts` yields four space indentation.