### PR TITLE
Fixes #2131: code snippets are clipped in the PDF

### DIFF
--- a/packages/handbook-epub/script/createPDF.ts
+++ b/packages/handbook-epub/script/createPDF.ts
@@ -87,6 +87,10 @@ pre .error-behind {
   color: white;
 }
 
+.code-container .line {
+  white-space: pre-wrap;
+}
+
     `;
   return css + thisCSS;
 };


### PR DESCRIPTION
The transpiled code is also getting clipped.
We simply need to enable wrapping on the code lines so that it'll work with .epub(variable page widths) as well.

## Screen shots

**Before fix**:
![img](https://i.imgur.com/xbeEQpe.png)

***After fix**:
![img](https://i.imgur.com/0KefjlD.png)

### Transpiled code

**Before fix:**
![before fix](https://i.imgur.com/Mo82Y06.png)

**After fix:**
![img](https://i.imgur.com/hoRsyWs.png)