### PR TITLE
Handbook: update code snippets to make look consistent

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -398,24 +398,24 @@ Almost all features of an `interface` are available in `type`, the key distincti
         <p>Extending an interface</p>
         <code><pre>
 interface Animal {
-  name: string
+  name: string;
 }<br/>
 interface Bear extends Animal {
-  honey: boolean
+  honey: boolean;
 }<br/>
-const bear = getBear() 
-bear.name
-bear.honey
+const bear = getBear();
+bear.name;
+bear.honey;
         </pre></code>
       </td>
       <td>
         <p>Extending a type via intersections</p>
         <code><pre>
 type Animal = {
-  name: string
+  name: string;
 }<br/>
 type Bear = Animal & { 
-  honey: boolean 
+  honey: boolean;
 }<br/>
 const bear = getBear();
 bear.name;
@@ -428,10 +428,10 @@ bear.honey;
         <p>Adding new fields to an existing interface</p>
         <code><pre>
 interface Window {
-  title: string
+  title: string;
 }<br/>
 interface Window {
-  ts: TypeScriptAPI
+  ts: TypeScriptAPI;
 }<br/>
 const src = 'const a = "Hello World"';
 window.ts.transpileModule(src, {});
@@ -441,10 +441,10 @@ window.ts.transpileModule(src, {});
         <p>A type cannot be changed after being created</p>
         <code><pre>
 type Window = {
-  title: string
+  title: string;
 }<br/>
 type Window = {
-  ts: TypeScriptAPI
+  ts: TypeScriptAPI;
 }<br/>
 <span style="color: #A31515"> // Error: Duplicate identifier 'Window'.</span><br/>
         </pre></code>


### PR DESCRIPTION
It looks odd because some lines in the code snippets do not end with semicolon `;`.
To make it consistent with rest of the book(and the website documentation) the PR updates the code.

![img](https://i.imgur.com/2auKko5.png)