### PR TITLE
Fix incorrect type for `compilerOptions.types`

### DIFF
--- a/packages/documentation/copy/en/javascript/Creating DTS files From JS.md
+++ b/packages/documentation/copy/en/javascript/Creating DTS files From JS.md
@@ -72,11 +72,11 @@ You want to make sure these files are included in your package if you have the f
 TypeScript replicates the node resolution for modules in a `package.json`, with an additional step for finding .d.ts files.
 Roughly, the resolution will first check the optional `types` field, then the `"main"` field, and finally will try `index.d.ts` in the root.
 
-| Package.json              | Location of default .d.ts      |
-| :------------------------ | :----------------------------- |
-| No "types" field          | checks "main", then index.d.ts |
-| "types": "main.d.ts"      | main.d.ts                      |
-| "types": "./dist/main.js" | ./dist/main.d.ts               |
+| Package.json                  | Location of default .d.ts      |
+| :---------------------------- | :----------------------------- |
+| No "types" field              | checks "main", then index.d.ts |
+| "types": \["main.d.ts"\]      | main.d.ts                      |
+| "types": \["./dist/main.js"\] | ./dist/main.d.ts               |
 
 If absent, then "main" is used
 


### PR DESCRIPTION
The attribute is expected to be an array of types, even when a single type is provided. This is inconsistent with [the `tsconfig` docs](https://www.typescriptlang.org/tsconfig#types)

![](https://i.imgur.com/ZV3JL1u.png)