### PR TITLE
Support publishing @typescript/sandbox package to NPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,5 +76,5 @@ packages/documentation/output/attribution.json
 .yarn/install-state.gz
 
 packages/sandbox/src/releases.json
-packages/sandbox/src/releases.ts
+packages/sandbox/src/release_data.ts
 packages/typescriptlang-org/src/lib/documentationNavigation.ts

--- a/packages/create-typescript-playground-plugin/template/scripts/getDTS.js
+++ b/packages/create-typescript-playground-plugin/template/scripts/getDTS.js
@@ -35,7 +35,7 @@ const go = async () => {
     host + "/js/playground/ds/createDesignSystem.d.ts",
     join(ds, "createDesignSystem.d.ts"),
     text => {
-      const renameImport = text.replace("typescriptlang-org/static/js/sandbox", "../sandbox")
+      const renameImport = text.replace("@typescript/sandbox", "../sandbox")
       return renameImport
     }
   )

--- a/packages/playground/src/ds/createDesignSystem.ts
+++ b/packages/playground/src/ds/createDesignSystem.ts
@@ -1,4 +1,4 @@
-import type { Sandbox } from "typescriptlang-org/static/js/sandbox"
+import type { Sandbox } from "@typescript/sandbox"
 import type { DiagnosticRelatedInformation, Node } from "typescript"
 
 export type LocalStorageOption = {

--- a/packages/playground/src/navigation.ts
+++ b/packages/playground/src/navigation.ts
@@ -4,7 +4,7 @@ type StoryContent =
   | { type: "code"; code: string; params: string; title: string }
   | { type: "hr" }
 
-import type { Sandbox } from "typescriptlang-org/static/js/sandbox"
+import type { Sandbox } from "@typescript/sandbox"
 import type { UI } from "./createUI"
 
 /**

--- a/packages/playground/src/sidebar/runtime.ts
+++ b/packages/playground/src/sidebar/runtime.ts
@@ -1,4 +1,4 @@
-import { Sandbox } from "typescriptlang-org/static/js/sandbox"
+import { Sandbox } from "@typescript/sandbox"
 import { PlaygroundPlugin, PluginFactory } from ".."
 import { createUI, UI } from "../createUI"
 import { localize } from "../localizeWithFallback"

--- a/packages/playground/src/sidebar/showErrors.ts
+++ b/packages/playground/src/sidebar/showErrors.ts
@@ -1,5 +1,5 @@
 import type { IDisposable } from "monaco-editor"
-import type { Sandbox } from "typescriptlang-org/static/js/sandbox"
+import type { Sandbox } from "@typescript/sandbox"
 import { PlaygroundPlugin, PluginFactory, Playground } from ".."
 import { localize } from "../localizeWithFallback"
 

--- a/packages/playground/src/twoslashInlays.ts
+++ b/packages/playground/src/twoslashInlays.ts
@@ -1,4 +1,4 @@
-import { Sandbox } from "typescriptlang-org/static/js/sandbox"
+import { Sandbox } from "@typescript/sandbox"
 
 export const createTwoslashInlayProvider = (sandbox: Sandbox) => {
   const provider: import("monaco-editor").languages.InlayHintsProvider = {

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -17,10 +17,8 @@ This project is useful to you if:
 
 ## Builds
 
-This library currently ships as an AMD module. This is the same format that vscode/monaco use, and so you can use
-the same runtime loader patterns for importing into your web page. It is not a goal to provide ESM builds so people
-can run JS packagers over the project. If someone can make that work and have tests which validate it doesn't break,
-we'll accept it.
+This library is published to the CDN as an AMD module. This is the same format that vscode/monaco use, and so you can use
+the same runtime loader patterns for importing into your web page. This package is also available as an ESM and CJS module on NPM.
 
 ## Installation
 

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -37,7 +37,7 @@
     "@typescript/vfs": "1.3.5"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^22.0.1",
+    "@rollup/plugin-commonjs": "^13.0.1",
     "@types/jest": "^25.1.3",
     "jest": "*",
     "monaco-editor": "^0.32.1",

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -15,6 +15,13 @@
   "main": "./dist/index.js",
   "module": "./dist/sandbox.esm.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/sandbox.esm.js",
+      "default": "./dist/index.js"
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,16 +1,27 @@
 {
   "name": "@typescript/sandbox",
   "version": "0.1.0",
-  "main": "dist/index.js",
-  "private": true,
   "license": "MIT",
-  "types": "../../typescriptlang-org/static/js/sandbox/index.d.ts",
+  "author": "TypeScript team",
+  "homepage": "https://github.com/microsoft/TypeScript-Website",
+  "repository": {
+    "url": "https://github.com/microsoft/TypeScript-Website.git",
+    "directory": "packages/sandbox",
+    "type": "git"
+  },
+  "bugs": {
+    "url": "https://github.com/microsoft/TypeScript-Website/issues"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/sandbox.esm.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
     "bootstrap": "node script/downloadReleases.js",
-    "build": "tsc",
+    "build": "tsdx build --tsconfig tsconfig.lib.json && yarn make-for-website",
+    "make-for-website": "tsc",
     "test": "jest"
   },
   "jest": {
@@ -26,11 +37,13 @@
     "@typescript/vfs": "1.3.5"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^22.0.1",
     "@types/jest": "^25.1.3",
     "jest": "*",
     "monaco-editor": "^0.32.1",
     "monaco-typescript": "^3.7.0",
     "ts-jest": "^26.4.4",
+    "tsdx": "^0.14.1",
     "typescript": "*"
   }
 }

--- a/packages/sandbox/script/downloadReleases.js
+++ b/packages/sandbox/script/downloadReleases.js
@@ -52,7 +52,7 @@ export const supportedReleases = ["${supportedVersions.join('", "')}"] as const
 /** A type of all versions **/
 export type ReleaseVersions = "${[possibleBeta, possibleRc, ...versions].join('" | "')}"
 `
-  const path = join(__dirname, "..", "src", "releases.ts")
+  const path = join(__dirname, "..", "src", "release_data.ts")
   writeFileSync(path, format(code, { filepath: path }), "utf8")
 
   const jsonPath = join(__dirname, "..", "src", "releases.json")

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -6,7 +6,7 @@ import {
   createURLQueryWithCompilerOptions,
 } from "./compilerOptions"
 import lzstring from "./vendor/lzstring.min"
-import { supportedReleases } from "./releases"
+import { supportedReleases } from "./release_data"
 import { getInitialCode } from "./getInitialCode"
 import { extractTwoSlashCompilerOptions, twoslashCompletions } from "./twoslashSupport"
 import * as tsvfs from "./vendor/typescript-vfs"

--- a/packages/sandbox/src/monacoTSVersions.ts
+++ b/packages/sandbox/src/monacoTSVersions.ts
@@ -1,4 +1,4 @@
-import { supportedReleases, ReleaseVersions } from './releases'
+import { supportedReleases, ReleaseVersions } from './release_data'
 
 /** The versions you can get for the sandbox */
 export type SupportedTSVersions = ReleaseVersions | 'Latest'

--- a/packages/sandbox/tsconfig.lib.json
+++ b/packages/sandbox/tsconfig.lib.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "module": "esnext",
+  }
+}

--- a/packages/sandbox/tsdx.config.js
+++ b/packages/sandbox/tsdx.config.js
@@ -1,0 +1,11 @@
+const commonjs = require("@rollup/plugin-commonjs");
+
+// Modify the default tsdx rollup config
+module.exports = {
+  rollup(config, options) {
+    // Required to import lzstring
+    config.plugins.push(commonjs());
+
+    return config;
+  },
+};

--- a/packages/typescriptlang-org/src/components/workbench/plugins/about.ts
+++ b/packages/typescriptlang-org/src/components/workbench/plugins/about.ts
@@ -1,4 +1,4 @@
-type Sandbox = import("../../../../static/js/sandbox").Sandbox
+type Sandbox = import("@typescript/sandbox").Sandbox
 type Factory = import("../../../../static/js/playground").PluginFactory
 type PluginUtils = import("../../../../static/js/playground").PluginUtils
 

--- a/packages/typescriptlang-org/src/components/workbench/plugins/docs.ts
+++ b/packages/typescriptlang-org/src/components/workbench/plugins/docs.ts
@@ -1,4 +1,4 @@
-type Sandbox = import("../../../../static/js/sandbox").Sandbox
+type Sandbox = import("@typescript/sandbox").Sandbox
 type Factory = import("../../../../static/js/playground").PluginFactory
 type PluginUtils = import("../../../../static/js/playground").PluginUtils
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4503,20 +4503,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/plugin-commonjs@npm:^22.0.1":
-  version: 22.0.1
-  resolution: "@rollup/plugin-commonjs@npm:22.0.1"
+"@rollup/plugin-commonjs@npm:^13.0.1":
+  version: 13.0.2
+  resolution: "@rollup/plugin-commonjs@npm:13.0.2"
   dependencies:
-    "@rollup/pluginutils": ^3.1.0
+    "@rollup/pluginutils": ^3.0.8
     commondir: ^1.0.1
-    estree-walker: ^2.0.1
-    glob: ^7.1.6
-    is-reference: ^1.2.1
-    magic-string: ^0.25.7
-    resolve: ^1.17.0
+    estree-walker: ^1.0.1
+    glob: ^7.1.2
+    is-reference: ^1.1.2
+    magic-string: ^0.25.2
+    resolve: ^1.11.0
   peerDependencies:
-    rollup: ^2.68.0
-  checksum: 6326227b688d1069ab2146b6f08c3d189da94bb77388691d7496001148041388542ddcbc6ffa7e9e97419c67e9cf3256a2414d770b4539998b4bc5d807404198
+    rollup: ^2.3.4
+  checksum: bed46b5f871551b972e95447212a5ccb3d040cb718c720abb387c417d25fe6aab7a0a31c28d07d568e880b81e690cdbb7df606585a2f6b78900f5f76c444107f
   languageName: node
   linkType: hard
 
@@ -4559,7 +4559,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/pluginutils@npm:^3.0.0, @rollup/pluginutils@npm:^3.0.9, @rollup/pluginutils@npm:^3.1.0":
+"@rollup/pluginutils@npm:^3.0.0, @rollup/pluginutils@npm:^3.0.8, @rollup/pluginutils@npm:^3.0.9, @rollup/pluginutils@npm:^3.1.0":
   version: 3.1.0
   resolution: "@rollup/pluginutils@npm:3.1.0"
   dependencies:
@@ -5585,7 +5585,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@typescript/sandbox@workspace:packages/sandbox"
   dependencies:
-    "@rollup/plugin-commonjs": ^22.0.1
+    "@rollup/plugin-commonjs": ^13.0.1
     "@types/jest": ^25.1.3
     "@typescript/ata": 0.9.3
     "@typescript/vfs": 1.3.5
@@ -12257,13 +12257,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"estree-walker@npm:^2.0.1":
-  version: 2.0.2
-  resolution: "estree-walker@npm:2.0.2"
-  checksum: 6151e6f9828abe2259e57f5fd3761335bb0d2ebd76dc1a01048ccee22fabcfef3c0859300f6d83ff0d1927849368775ec5a6d265dde2f6de5a1be1721cd94efc
-  languageName: node
-  linkType: hard
-
 "esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
@@ -16821,15 +16814,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-reference@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "is-reference@npm:1.2.1"
-  dependencies:
-    "@types/estree": "*"
-  checksum: e7b48149f8abda2c10849ea51965904d6a714193d68942ad74e30522231045acf06cbfae5a4be2702fede5d232e61bf50b3183acdc056e6e3afe07fcf4f4b2bc
-  languageName: node
-  linkType: hard
-
 "is-regex@npm:^1.0.4, is-regex@npm:^1.1.2":
   version: 1.1.2
   resolution: "is-regex@npm:1.1.2"
@@ -19273,15 +19257,6 @@ fsevents@^1.2.7:
   dependencies:
     sourcemap-codec: ^1.4.4
   checksum: 41c1b81f8bc9b579db932c6ae1711339e8af32995f99253f6ae0318571f94b0479222a78f8af41c4a4578977f7305087692d2f0814d3c5cd0b82e267e56f657a
-  languageName: node
-  linkType: hard
-
-"magic-string@npm:^0.25.7":
-  version: 0.25.9
-  resolution: "magic-string@npm:0.25.9"
-  dependencies:
-    sourcemap-codec: ^1.4.8
-  checksum: 9a0e55a15c7303fc360f9572a71cffba1f61451bc92c5602b1206c9d17f492403bf96f946dfce7483e66822d6b74607262e24392e87b0ac27b786e69a40e9b1a
   languageName: node
   linkType: hard
 
@@ -25770,13 +25745,6 @@ resolve@^2.0.0-next.3:
   version: 1.4.6
   resolution: "sourcemap-codec@npm:1.4.6"
   checksum: c8797dbe3767e6741f0d65e740ea5e1f7cb23395d6311d9202b827de8f85b862e106450c888f25a06b2ba11c638b58c2bf71ea81eb597e6f35de568a425a6836
-  languageName: node
-  linkType: hard
-
-"sourcemap-codec@npm:^1.4.8":
-  version: 1.4.8
-  resolution: "sourcemap-codec@npm:1.4.8"
-  checksum: b57981c05611afef31605732b598ccf65124a9fcb03b833532659ac4d29ac0f7bfacbc0d6c5a28a03e84c7510e7e556d758d0bb57786e214660016fb94279316
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4503,6 +4503,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/plugin-commonjs@npm:^22.0.1":
+  version: 22.0.1
+  resolution: "@rollup/plugin-commonjs@npm:22.0.1"
+  dependencies:
+    "@rollup/pluginutils": ^3.1.0
+    commondir: ^1.0.1
+    estree-walker: ^2.0.1
+    glob: ^7.1.6
+    is-reference: ^1.2.1
+    magic-string: ^0.25.7
+    resolve: ^1.17.0
+  peerDependencies:
+    rollup: ^2.68.0
+  checksum: 6326227b688d1069ab2146b6f08c3d189da94bb77388691d7496001148041388542ddcbc6ffa7e9e97419c67e9cf3256a2414d770b4539998b4bc5d807404198
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-json@npm:^4.0.0":
   version: 4.0.1
   resolution: "@rollup/plugin-json@npm:4.0.1"
@@ -5568,6 +5585,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@typescript/sandbox@workspace:packages/sandbox"
   dependencies:
+    "@rollup/plugin-commonjs": ^22.0.1
     "@types/jest": ^25.1.3
     "@typescript/ata": 0.9.3
     "@typescript/vfs": 1.3.5
@@ -5575,6 +5593,7 @@ __metadata:
     monaco-editor: ^0.32.1
     monaco-typescript: ^3.7.0
     ts-jest: ^26.4.4
+    tsdx: ^0.14.1
     typescript: "*"
   languageName: unknown
   linkType: soft
@@ -12238,6 +12257,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-walker@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "estree-walker@npm:2.0.2"
+  checksum: 6151e6f9828abe2259e57f5fd3761335bb0d2ebd76dc1a01048ccee22fabcfef3c0859300f6d83ff0d1927849368775ec5a6d265dde2f6de5a1be1721cd94efc
+  languageName: node
+  linkType: hard
+
 "esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
@@ -16795,6 +16821,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"is-reference@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "is-reference@npm:1.2.1"
+  dependencies:
+    "@types/estree": "*"
+  checksum: e7b48149f8abda2c10849ea51965904d6a714193d68942ad74e30522231045acf06cbfae5a4be2702fede5d232e61bf50b3183acdc056e6e3afe07fcf4f4b2bc
+  languageName: node
+  linkType: hard
+
 "is-regex@npm:^1.0.4, is-regex@npm:^1.1.2":
   version: 1.1.2
   resolution: "is-regex@npm:1.1.2"
@@ -19238,6 +19273,15 @@ fsevents@^1.2.7:
   dependencies:
     sourcemap-codec: ^1.4.4
   checksum: 41c1b81f8bc9b579db932c6ae1711339e8af32995f99253f6ae0318571f94b0479222a78f8af41c4a4578977f7305087692d2f0814d3c5cd0b82e267e56f657a
+  languageName: node
+  linkType: hard
+
+"magic-string@npm:^0.25.7":
+  version: 0.25.9
+  resolution: "magic-string@npm:0.25.9"
+  dependencies:
+    sourcemap-codec: ^1.4.8
+  checksum: 9a0e55a15c7303fc360f9572a71cffba1f61451bc92c5602b1206c9d17f492403bf96f946dfce7483e66822d6b74607262e24392e87b0ac27b786e69a40e9b1a
   languageName: node
   linkType: hard
 
@@ -25726,6 +25770,13 @@ resolve@^2.0.0-next.3:
   version: 1.4.6
   resolution: "sourcemap-codec@npm:1.4.6"
   checksum: c8797dbe3767e6741f0d65e740ea5e1f7cb23395d6311d9202b827de8f85b862e106450c888f25a06b2ba11c638b58c2bf71ea81eb597e6f35de568a425a6836
+  languageName: node
+  linkType: hard
+
+"sourcemap-codec@npm:^1.4.8":
+  version: 1.4.8
+  resolution: "sourcemap-codec@npm:1.4.8"
+  checksum: b57981c05611afef31605732b598ccf65124a9fcb03b833532659ac4d29ac0f7bfacbc0d6c5a28a03e84c7510e7e556d758d0bb57786e214660016fb94279316
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Overview

I was recently working on a project (https://github.com/oliverdunk/web-extension-playground) and to use the `@typescript/sandbox` package, I had to load it from the CDN and then vendor the types: https://github.com/oliverdunk/web-extension-playground/blob/main/src/utils/sandbox.ts#L39. I spoke to @andrewbranch about this, and he encouraged me to open a PR making this package publishable to NPM.

## Description

The changes here are fairly simple:

- Use tsdx (already used by `@typescript/vfs`) to build both a CJS and ESM bundle
- Add `@rollup/plugin-commonjs` to allow lzstring to be correctly loaded
- Update the package.json file to add more useful metadata for NPM

A potentially surprising change here is the rename from `releases.ts` to `release_data.ts`. Since there was both `releases.ts` and `releases.json` in the same directory, Rollup was resolving `import ... from "./releases` as a JSON import and failing the build. I looked at solving this but it ended up with a lot of deep configuration overriding to prefer TS files over JSON and didn't feel worth the effort when I could easily rename one of the files.

## Publishing to NPM

I did a bit of investigation to see how packages are published to NPM and what setup would be needed. This appears to be handled by a package called pleb: https://github.com/microsoft/TypeScript-Website/blob/v2/.github/workflows/v2-merged-staging.yml#L65. As far as I can tell, simply removing the private field from the package.json (as done here) should be enough to get things going.

Note: The README mentioned wanting tests to ensure a packaged build wouldn't break. I'm not quite sure what that would look like so I haven't done it here. I'm happy to add them if it's something we want and there is a clear idea about how to do it. At the same time, I can't see anything like that for the other packages so I feel like it might be fine without.