### PR TITLE
Correct types for index signature properties

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Object Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Object Types.md
@@ -270,7 +270,7 @@ const secondItem = myArray[1];
 Above, we have a `StringArray` interface which has an index signature.
 This index signature states that when a `StringArray` is indexed with a `number`, it will return a `string`.
 
-An index signature property type must be either 'string' or 'number'.
+Only some types are allowed for index signature properties: `string`, `number`, `symbol`, template string patterns, and union types consisting only of these.
 
 <details>
     <summary>It is possible to support both types of indexers...</summary>


### PR DESCRIPTION
Since TypeScript 4.4 not only `number` and `string` are allowed, but also `symbol`, template string patterns, and union types consisting only of these. https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-4.html#symbol-and-template-string-pattern-index-signatures

Fixes #2525.