### PR TITLE
Add publishConfig to @typescript/sandbox package

### DIFF
--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -31,6 +31,9 @@
     "make-for-website": "tsc",
     "test": "jest"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",


### PR DESCRIPTION
Adds a publishConfig to @typescript/sandbox to resolve the failure here: https://github.com/microsoft/TypeScript-Website/runs/7153933507. This was introduced by https://github.com/microsoft/TypeScript-Website/pull/2437.