### PR TITLE
Handle printing objects without `constructor` property.

### DIFF
--- a/packages/playground/src/sidebar/runtime.ts
+++ b/packages/playground/src/sidebar/runtime.ts
@@ -214,7 +214,7 @@ function rewireLoggingToElement(
     } else if (typeof arg === "string") {
       textRep = '"' + htmlEscape(arg) + '"'
     } else if (isObj) {
-      const name = arg.constructor && arg.constructor.name
+      const name = arg.constructor && arg.constructor.name || ""
       // No one needs to know an obj is an obj
       const nameWithoutObject = name && name === "Object" ? "" : htmlEscape(name)
       const prefix = nameWithoutObject ? `${nameWithoutObject}: ` : ""


### PR DESCRIPTION
Objects created with `Object.create(null)` do not have a `constructor`
property. This change fixes the `objectToText` function to allow this
kind of object to be passed into `console.log` in the sandbox.

Fixes microsoft/TypeScript#49752