### PR TITLE
fix errors for generic class examples

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Generics.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Generics.md
@@ -216,8 +216,8 @@ Generic classes have a generic type parameter list in angle brackets (`<>`) foll
 ```ts twoslash
 // @strict: false
 class GenericNumber<NumType> {
-  zeroValue: NumType;
-  add: (x: NumType, y: NumType) => NumType;
+  zeroValue?: NumType;
+  add?: (x: NumType, y: NumType) => NumType;
 }
 
 let myGenericNumber = new GenericNumber<number>();
@@ -233,8 +233,8 @@ We could have instead used `string` or even more complex objects.
 ```ts twoslash
 // @strict: false
 class GenericNumber<NumType> {
-  zeroValue: NumType;
-  add: (x: NumType, y: NumType) => NumType;
+  zeroValue?: NumType;
+  add?: (x: NumType, y: NumType) => NumType;
 }
 // ---cut---
 let stringNumeric = new GenericNumber<string>();


### PR DESCRIPTION
When I tried generic class examples in playground, I encountered the error which you can see in screenshot below so I made the properties optional to fix it.

<img width="777" alt="Screenshot 2022-07-21 at 10 57 30" src="https://user-images.githubusercontent.com/45823795/180174005-048caf49-b028-4efa-8278-3d80c1f75258.png">
.