### PR TITLE
ATA: Resolve import statements with filepath in module specifier

### DIFF
--- a/packages/ata/src/edgeCases.ts
+++ b/packages/ata/src/edgeCases.ts
@@ -1,5 +1,5 @@
 /** Converts some of the known global imports to node so that we grab the right info */
-export const mapModuleNameToModule = (name: string) => {
+export const mapModuleNameToModule = (moduleSpecifier: string) => {
   // in node repl:
   // > require("module").builtinModules
   const builtInNodeMods = [
@@ -57,9 +57,13 @@ export const mapModuleNameToModule = (name: string) => {
     "zlib",
   ]
 
-  if (builtInNodeMods.includes(name.replace("node:", ""))) {
+  if (builtInNodeMods.includes(moduleSpecifier.replace("node:", ""))) {
     return "node"
   }
 
-  return name
+  // strip module filepath e.g. lodash/identity => lodash
+  const [a = "", b = ""] = moduleSpecifier.split("/")
+  const moduleName = a.startsWith("@") ? `${a}/${b}` : a
+
+  return moduleName
 }

--- a/packages/ata/tests/edgeCases.spec.ts
+++ b/packages/ata/tests/edgeCases.spec.ts
@@ -1,11 +1,16 @@
 import { mapModuleNameToModule } from "../src/edgeCases"
 
 describe(mapModuleNameToModule, () => {
-    it("gives node for known identifiers", () => {
-        expect(mapModuleNameToModule("fs")).toEqual("node")
-    })
+  it("gives node for known identifiers", () => {
+    expect(mapModuleNameToModule("fs")).toEqual("node")
+  })
 
-    it("handles the weird node: prefix", () => {
-        expect(mapModuleNameToModule("node:fs")).toEqual("node")
-    })
+  it("handles the weird node: prefix", () => {
+    expect(mapModuleNameToModule("node:fs")).toEqual("node")
+  })
+
+  it("strips module filepaths", () => {
+    expect(mapModuleNameToModule("lodash/identity")).toEqual("lodash")
+    expect(mapModuleNameToModule("@org/lodash/identity")).toEqual("@org/lodash")
+  })
 })


### PR DESCRIPTION
**Problem:** 

Given an import statements with a filepath in the module specifier e.g. `import add from lodash/add`, ATA will incorrectly search for types for the full module specifier (`lodash/add`, which doesn't exists), rather than the module name (`lodash`). 

**Changes:**

- Given `import add from "lodash/add"`, types are resolved for `lodash`
- Given `import add from "@org/lodash/add"`, types are resolved for `@org/lodash`
