### PR TITLE
Remove aria-hidden='true' from code sample popover

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/SiteFooter-PlaygroundSamples.tsx
+++ b/packages/typescriptlang-org/src/components/layout/SiteFooter-PlaygroundSamples.tsx
@@ -50,7 +50,7 @@ export const PlaygroundSamples = (props: Props) => {
   }, []);
 
   return (
-    <div id="playground-samples-popover" aria-hidden="true" aria-label="Code Samples Submenu" tabIndex={-1}>
+    <div id="playground-samples-popover" aria-label="Code Samples Submenu" tabIndex={-1}>
       <RenderExamples defaultSection="TypeScript" sections={["JavaScript", "TypeScript"]} />
       <div className="arrow-down" />
     </div>)


### PR DESCRIPTION
It looks like it's not needed since `visibility: false` does the same thing when it's hidden and when it's not hidden it should be visible to screen readers.