### PR TITLE
Update the url for tsup

### DIFF
--- a/packages/typescriptlang-org/src/templates/pages/docs/bootstrap.tsx
+++ b/packages/typescriptlang-org/src/templates/pages/docs/bootstrap.tsx
@@ -33,7 +33,7 @@ const Index: React.FC<Props> = (props) => {
         <ButtonGrid
           buttons={[
             {
-              href: "https://tsup.egoist.sh",
+              href: "https://tsup.egoist.dev",
               blurb: i("doc_node_npm_tsup_blurb"),
               title: "tsup",
             },


### PR DESCRIPTION
I'm the maintainer of tsup, its website has been move to tsup.egoist.dev (old one still works for now)