### PR TITLE
Fix: void type is not a subtype of undefined type

### DIFF
--- a/packages/documentation/copy/en/get-started/TS for Functional Programmers.md
+++ b/packages/documentation/copy/en/get-started/TS for Functional Programmers.md
@@ -77,7 +77,7 @@ TypeScript has corresponding primitive types for the built-in types:
 | `unknown`      | the top type.                                               |
 | `never`        | the bottom type.                                            |
 | object literal | eg `{ property: Type }`                                     |
-| `void`         | a subtype of `undefined` intended for use as a return type. |
+| `void`         | a supertype of `undefined` intended for use as a return type. |
 | `T[]`          | mutable arrays, also written `Array<T>`                     |
 | `[T, T]`       | tuples, which are fixed-length but mutable                  |
 | `(t: T) => U`  | functions                                                   |

--- a/packages/documentation/copy/en/get-started/TS for Functional Programmers.md
+++ b/packages/documentation/copy/en/get-started/TS for Functional Programmers.md
@@ -72,15 +72,15 @@ TypeScript has corresponding primitive types for the built-in types:
 
 ### Other important TypeScript types
 
-| Type           | Explanation                                                 |
-| -------------- | ----------------------------------------------------------- |
-| `unknown`      | the top type.                                               |
-| `never`        | the bottom type.                                            |
-| object literal | eg `{ property: Type }`                                     |
+| Type           | Explanation                                                   |
+| -------------- | ------------------------------------------------------------- |
+| `unknown`      | the top type.                                                 |
+| `never`        | the bottom type.                                              |
+| object literal | eg `{ property: Type }`                                       |
 | `void`         | a supertype of `undefined` intended for use as a return type. |
-| `T[]`          | mutable arrays, also written `Array<T>`                     |
-| `[T, T]`       | tuples, which are fixed-length but mutable                  |
-| `(t: T) => U`  | functions                                                   |
+| `T[]`          | mutable arrays, also written `Array<T>`                       |
+| `[T, T]`       | tuples, which are fixed-length but mutable                    |
+| `(t: T) => U`  | functions                                                     |
 
 Notes:
 


### PR DESCRIPTION
The current docs says `void` type is a subtype of `undefined`.
> a subtype of `undefined` intended for use as a return type.

However, `undefined` type is assignable to `void` type, but not vice-versa.
```ts
const v: void = undefined; // OK
const u: undefined = v; // [Error]
//    ^: Type 'void' is not assignable to type 'undefined'.
```
And also, the archived specification says `void` type is a supertype of `null` type and `undefined` type.
>The only possible values for the Void type are null and undefined. The Void type is a subtype of the Any type and **a supertype of the Null and Undefined types**, but otherwise Void is unrelated to all other types.
>( https://github.com/microsoft/TypeScript/blob/main/doc/spec-ARCHIVED.md#325-the-void-type )

It seems a mistake.