### PR TITLE
chore: add missing key to button list in dev/twoslash page

### DIFF
--- a/packages/typescriptlang-org/src/pages/dev/twoslash.tsx
+++ b/packages/typescriptlang-org/src/pages/dev/twoslash.tsx
@@ -298,6 +298,7 @@ const Index: React.FC<Props> = props => {
                 />
                 <div id="example-buttons">
                   {codeSamples.map(code => {
+                    
                     const setExample = e => {
                       if (e.target.classList.contains("disabled")) return
 
@@ -307,7 +308,7 @@ const Index: React.FC<Props> = props => {
                       window.sandbox.setText(code.code)
                     }
                     return (
-                      <div className="button disabled" onClick={setExample}>
+                      <div className="button disabled" key={code.name} onClick={setExample}>
                         {code.name}
                       </div>
                     )


### PR DESCRIPTION
List items should be indexed by a key in React.

While nothing major in this specific example, as the order of the items does not change dynamically, I still wanted to get rid of the warning to reduce noise while working on the website.

Due to the lack of a unique identifier other than the text content of the button itself I decided to use that for indexing, which is consistent with similar keys found in [#1](https://github.com/microsoft/TypeScript-Website/blob/v2/packages/typescriptlang-org/src/components/ShowExamples.tsx#L116), [#2](https://github.com/microsoft/TypeScript-Website/blob/v2/packages/typescriptlang-org/src/components/search/SearchResultsDisplay.tsx#L111) or [#3](https://github.com/microsoft/TypeScript-Website/blob/v2/packages/typescriptlang-org/src/templates/tsconfigReference.tsx#L160)