### PR TITLE
Rewrite gatsby-focus-wrapper id for playground handbook

### DIFF
--- a/packages/playground/src/navigation.ts
+++ b/packages/playground/src/navigation.ts
@@ -210,6 +210,9 @@ const setStoryViaHref = (href: string, sandbox: Sandbox) => {
         const gatsby = doc.getElementById('___gatsby')
         if (gatsby) {
           gatsby.id = "___inner_g"
+          if (gatsby.firstChild && (gatsby.firstChild as HTMLElement).id === "gatsby-focus-wrapper") {
+            (gatsby.firstChild as HTMLElement).id = "gatsby-playground-handbook-inner"
+          }
           setStory(gatsby, sandbox)
         }
         return


### PR DESCRIPTION
It shouldn't have a top-level one since it's a nested page, even though it's generated like a top-level page.