### PR TITLE
Repair wording (#2480, #204)

### DIFF
--- a/packages/typescriptlang-org/src/copy/en/playground.ts
+++ b/packages/typescriptlang-org/src/copy/en/playground.ts
@@ -39,7 +39,7 @@ export const playCopy = {
   play_sidebar_plugins_plugin_dev_option:
     "Connect to <code>localhost:5000</code>",
   play_sidebar_plugins_plugin_dev_copy:
-    "Automatically try connect to a playground plugin in development mode. You can get started with <a href='/dev/playground-plugins/' title='Link to the page about Playground Plugins'>making a plugin here</a>.",
+    "Automatically try to connect to a playground plugin in development mode. You can get started with <a href='/dev/playground-plugins/' title='Link to the page about Playground Plugins'>making a plugin here</a>.",
   play_export_report_issue: "Report GitHub issue on TypeScript",
   play_export_tweet_md: "Tweet link to Playground",
   play_export_copy_md: "Copy as Markdown Issue",


### PR DESCRIPTION
<q><del>Automatically try connect to a playground plugin in development mode</del></q> ¹ ² should read<br><q>Automatically try <ins>to</ins> connect to a playground plugin in development mode</q> to fix #2480.

---
1. added at [`b5da66fdd8`](https://github.com/microsoft/TypeScript-Website/commit/dc0991bebecfe66035b7ebe08d94a393cb1d7506#diff-138c610cfb6ee86a0fe2520c0f4c938eb5f0460e0704aa9c740cccec6a6f2547R60) into [./packages/playground/src/sidebar/options.ts](https://github.com/microsoft/TypeScript-Website/blob/dc0991bebecfe66035b7ebe08d94a393cb1d7506/packages/playground/src/sidebar/options.ts#L60) ([#204](https://github.com/microsoft/TypeScript-Website/pull/204))
1. currently ([`f8188e4214`](https://github.com/microsoft/TypeScript-Website/tree/f8188e42144b467e54f7e88009f92807f5d583c3)) in [./packages/typescriptlang-org/src/copy/en/playground.ts](https://github.com/microsoft/TypeScript-Website/blob/f8188e42144b467e54f7e88009f92807f5d583c3/packages/typescriptlang-org/src/copy/en/playground.ts#L42)