### PR TITLE
Wrong compiled example of Downleveling section

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Basics.md
+++ b/packages/documentation/copy/en/handbook-v2/Basics.md
@@ -382,7 +382,7 @@ One other difference from the above was that our template string was rewritten f
 to
 
 ```js
-"Hello " + person + ", today is " + date.toDateString() + "!";
+"Hello ".concat(person, ", today is ").concat(date.toDateString(), "!")
 ```
 
 Why did this happen?


### PR DESCRIPTION
The downleveling section compares the original template string in the "Explicit Types" section with the compiled one at the "Erased Types" section in which the target used is es5.

And while es5 actually outputs:
<img width="874" alt="Screen Shot 2022-08-18 at 03 41 34" src="https://user-images.githubusercontent.com/19880748/185273651-7bbd7a3f-4152-44de-9564-ca3adca3545c.png">

here's what the comparison says
<img width="866" alt="Screen Shot 2022-08-18 at 03 43 57" src="https://user-images.githubusercontent.com/19880748/185273778-2e8df770-b1de-4f7c-870c-b0a13c2c5f46.png">
