### PR TITLE
eliminate spurious semicolon differences in examples

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -403,7 +403,7 @@ interface Animal {
 interface Bear extends Animal {
   honey: boolean
 }<br/>
-const bear = getBear() 
+const bear = getBear();
 bear.name;
 bear.honey;
         </pre></code>

--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -404,8 +404,8 @@ interface Bear extends Animal {
   honey: boolean
 }<br/>
 const bear = getBear() 
-bear.name
-bear.honey
+bear.name;
+bear.honey;
         </pre></code>
       </td>
       <td>


### PR DESCRIPTION
The presence or absence of semicolons doesn't matter, but a newbie may not realize that and get hung up on the difference.