### PR TITLE
make interface/type code example clearer and valid

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -403,7 +403,7 @@ interface Animal {
 interface Bear extends Animal {
   honey: boolean
 }<br/>
-const bear = getBear() 
+const bear = { name: "Fozzy", honey: false }
 bear.name
 bear.honey
         </pre></code>
@@ -417,7 +417,7 @@ type Animal = {
 type Bear = Animal & { 
   honey: boolean 
 }<br/>
-const bear = getBear();
+const bear = { name: "Fozzy", honey: false };
 bear.name;
 bear.honey;
         </pre></code>


### PR DESCRIPTION
replace getBear() with an actual object instantiation so someone can copy the code into the playground and have it be valid without editing