### PR TITLE
fix: minor typo in Classes.md

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -339,7 +339,7 @@ interface Checkable {
 class NameChecker implements Checkable {
   check(s) {
     // Notice no error here
-    return s.toLowercse() === "ok";
+    return s.toLowercase() === "ok";
     //         ^?
   }
 }


### PR DESCRIPTION
Corrects `s.toLowerCse()` -> `s.toLowerCase()` in Classes.md

Thank you!