### PR TITLE
Clearly differentiate between annotation example for "Parameters" & "Return Value"

### DIFF
--- a/packages/documentation/copy/en/get-started/TS for JS Programmers.md
+++ b/packages/documentation/copy/en/get-started/TS for JS Programmers.md
@@ -109,12 +109,12 @@ interface User {
   id: number;
 }
 // ---cut---
-function getAdminUser(): User {
-  //...
+function deleteUser(user: User) {
+  // ...annotate parameter
 }
 
-function deleteUser(user: User) {
-  // ...
+function getAdminUser(): User {
+  // ...annotate return value
 }
 ```
 


### PR DESCRIPTION
Since the documentation is targeted at TypeScript beginners, I think examples shouldn't leave things to "assumption" and be as clear as possible.

The preceding statement states **"You can use interfaces to annotate parameters and return values to functions:"**
However, the following examples are listed in the **opposite order** and do not **specify whether you're annotating parameter or return value**.

The minor edit easily clarifies this.