### PR TITLE
Fix typo of word noting to nothing

### DIFF
--- a/packages/documentation/copy/en/declaration-files/Consumption.md
+++ b/packages/documentation/copy/en/declaration-files/Consumption.md
@@ -15,7 +15,7 @@ As an example, getting the declarations for a library like lodash takes nothing 
 npm install --save-dev @types/lodash
 ```
 
-It is worth noting that if the npm package already includes its declaration file as described in [Publishing](/docs/handbook/declaration-files/publishing.html), downloading the corresponding `@types` package is not needed.
+It is worth nothing that if the npm package already includes its declaration file as described in [Publishing](/docs/handbook/declaration-files/publishing.html), downloading the corresponding `@types` package is not needed.
 
 ## Consuming
 

--- a/packages/documentation/copy/en/handbook-v2/Narrowing.md
+++ b/packages/documentation/copy/en/handbook-v2/Narrowing.md
@@ -186,7 +186,7 @@ function printAll(strs: string | string[] | null) {
 
 We wrapped the entire body of the function in a truthy check, but this has a subtle downside: we may no longer be handling the empty string case correctly.
 
-TypeScript doesn't hurt us here at all, but this is behavior worth noting if you're less familiar with JavaScript.
+TypeScript doesn't hurt us here at all, but this is behavior worth nothing if you're less familiar with JavaScript.
 TypeScript can often help you catch bugs early on, but if you choose to do _nothing_ with a value, there's only so much that it can do without being overly prescriptive.
 If you want, you can make sure you handle situations like these with a linter.
 

--- a/packages/documentation/copy/en/handbook-v2/Object Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Object Types.md
@@ -603,7 +603,7 @@ function setContents<Type>(box: Box<Type>, newContents: Type) {
 }
 ```
 
-It is worth noting that type aliases can also be generic. We could have defined our new `Box<Type>` interface, which was:
+It is worth nothing that type aliases can also be generic. We could have defined our new `Box<Type>` interface, which was:
 
 ```ts twoslash
 interface Box<Type> {

--- a/packages/documentation/copy/en/reference/ESM Support for Node.md
+++ b/packages/documentation/copy/en/reference/ESM Support for Node.md
@@ -166,7 +166,7 @@ import foo = require("./foo.cjs");
 foo.helper()
 ```
 
-Finally, it's worth noting that the only way to import ESM files from a CJS module is using dynamic `import()` calls.
+Finally, it's worth nothing that the only way to import ESM files from a CJS module is using dynamic `import()` calls.
 This can present challenges, but is the behavior in Node.js today.
 
 You can [read more about ESM/CommonJS interop in Node.js here](https://nodejs.org/api/esm.html#esm_interoperability_with_commonjs).

--- a/packages/documentation/copy/en/reference/Namespaces and Modules.md
+++ b/packages/documentation/copy/en/reference/Namespaces and Modules.md
@@ -21,7 +21,7 @@ Modules can contain both code and declarations.
 Modules also have a dependency on a module loader (such as CommonJs/Require.js) or a runtime which supports ES Modules.
 Modules provide for better code reuse, stronger isolation and better tooling support for bundling.
 
-It is also worth noting that, for Node.js applications, modules are the default and **we recommended modules over namespaces in modern code**.
+It is also worth nothing that, for Node.js applications, modules are the default and **we recommended modules over namespaces in modern code**.
 
 Starting with ECMAScript 2015, modules are native part of the language, and should be supported by all compliant engine implementations.
 Thus, for new projects modules would be the recommended code organization mechanism.

--- a/packages/documentation/copy/en/release-notes/Overview.md
+++ b/packages/documentation/copy/en/release-notes/Overview.md
@@ -1116,7 +1116,7 @@ For one, when labeling a tuple element, all other elements in the tuple must als
 type Bar = [first: string, number];
 ```
 
-It's worth noting - labels don't require us to name our variables differently when destructuring.
+It's worth nothing - labels don't require us to name our variables differently when destructuring.
 They're purely there for documentation and tooling.
 
 ```ts
@@ -1271,7 +1271,7 @@ let values: string[];
 
 (look, we're not proud of _all_ the code we write...)
 
-On the rare case that you use getters or setters with side-effects, it's worth noting that these operators only perform assignments if necessary.
+On the rare case that you use getters or setters with side-effects, it's worth nothing that these operators only perform assignments if necessary.
 In that sense, not only is the right side of the operator "short-circuited" - the assignment itself is too.
 
 ```ts
@@ -2064,7 +2064,7 @@ console.log(instance.cHelper()); // prints '10'
 console.log(instance.dHelper()); // prints '20'
 ```
 
-Another thing worth noting is that accessing a private field on any other type will result in a `TypeError`!
+Another thing worth nothing is that accessing a private field on any other type will result in a `TypeError`!
 
 ```ts
 class Square {

--- a/packages/documentation/copy/en/release-notes/TypeScript 3.8.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 3.8.md
@@ -143,7 +143,7 @@ console.log(instance.cHelper()); // prints '10'
 console.log(instance.dHelper()); // prints '20'
 ```
 
-Another thing worth noting is that accessing a private field on any other type will result in a `TypeError`!
+Another thing worth nothing is that accessing a private field on any other type will result in a `TypeError`!
 
 ```ts
 class Square {

--- a/packages/documentation/copy/en/release-notes/TypeScript 4.0.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 4.0.md
@@ -247,7 +247,7 @@ For one, when labeling a tuple element, all other elements in the tuple must als
 type Bar = [first: string, number];
 ```
 
-It's worth noting - labels don't require us to name our variables differently when destructuring.
+It's worth nothing - labels don't require us to name our variables differently when destructuring.
 They're purely there for documentation and tooling.
 
 ```ts twoslash
@@ -402,7 +402,7 @@ let values: string[];
 
 (look, we're not proud of _all_ the code we write...)
 
-On the rare case that you use getters or setters with side-effects, it's worth noting that these operators only perform assignments if necessary.
+On the rare case that you use getters or setters with side-effects, it's worth nothing that these operators only perform assignments if necessary.
 In that sense, not only is the right side of the operator "short-circuited" - the assignment itself is too.
 
 ```ts

--- a/packages/documentation/copy/en/release-notes/TypeScript 4.7.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 4.7.md
@@ -166,7 +166,7 @@ import foo = require("./foo.cjs");
 foo.helper()
 ```
 
-Finally, it's worth noting that the only way to import ESM files from a CJS module is using dynamic `import()` calls.
+Finally, it's worth nothing that the only way to import ESM files from a CJS module is using dynamic `import()` calls.
 This can present challenges, but is the behavior in Node.js today.
 
 You can [read more about ESM/CommonJS interop in Node.js here](https://nodejs.org/api/esm.html#esm_interoperability_with_commonjs).

--- a/packages/playground-examples/copy/en/TypeScript/Language Extensions/Nominal Typing.ts
+++ b/packages/playground-examples/copy/en/TypeScript/Language Extensions/Nominal Typing.ts
@@ -28,7 +28,7 @@
 type ValidatedInputString = string & { __brand: "User Input Post Validation" };
 
 // We will use a function to transform a string to
-// a ValidatedInputString - but the point worth noting
+// a ValidatedInputString - but the point worth nothing
 // is that we're just _telling_ TypeScript that it's true.
 
 const validateUserInput = (input: string) => {

--- a/packages/tsconfig-reference/copy/en/options/extends.md
+++ b/packages/tsconfig-reference/copy/en/options/extends.md
@@ -8,7 +8,7 @@ The path may use Node.js style resolution.
 
 The configuration from the base file are loaded first, then overridden by those in the inheriting config file. All relative paths found in the configuration file will be resolved relative to the configuration file they originated in.
 
-It's worth noting that [`files`](#files), [`include`](#include) and `exclude` from the inheriting config file _overwrite_ those from the
+It's worth nothing that [`files`](#files), [`include`](#include) and `exclude` from the inheriting config file _overwrite_ those from the
 base config file, and that circularity between configuration files is not allowed.
 
 Currently, the only top-level property that is excluded from inheritance is [`references`](#references).


### PR DESCRIPTION
The purpose of this PR is to fix the typo of the word "noting" to "nothing" which is present in 11 files of the project.