### PR TITLE
Fix overload signatures of an example in Do's and Don'ts

### DIFF
--- a/packages/documentation/copy/en/declaration-files/Do's and Don'ts.md
+++ b/packages/documentation/copy/en/declaration-files/Do's and Don'ts.md
@@ -231,8 +231,8 @@ Note that we didn't make `b` optional here because the return types of the signa
 ❔ **Why:** This is important for people who are "passing through" a value to your function:
 
 ```ts
-function fn(x: string): void;
-function fn(x: number): void;
+function fn(x: string): Moment;
+function fn(x: number): Moment;
 function fn(x: number | string) {
   // When written with separate overloads, incorrectly an error
   // When written with union types, correctly OK


### PR DESCRIPTION
* Before this change, the return types of overload signatures of `fn` were void
* But the implementation of overloads actually returns Moment object