### PR TITLE
Fix broken relative link to 4.5 release notes

### DIFF
--- a/packages/documentation/copy/en/reference/Utility Types.md
+++ b/packages/documentation/copy/en/reference/Utility Types.md
@@ -13,7 +13,7 @@ TypeScript provides several utility types to facilitate common type transformati
 <blockquote class=bg-reading>
 
 Released:
-[4.5](docs/handbook/release-notes/typescript-4-5.html#the-awaited-type-and-promise-improvements)
+[4.5](/docs/handbook/release-notes/typescript-4-5.html#the-awaited-type-and-promise-improvements)
 
 </blockquote>
 


### PR DESCRIPTION
A link on [Utility Types > Awaited](https://www.typescriptlang.org/docs/handbook/utility-types.html#awaitedtype) documentation page is broken because it's missing the initial forward slash.

1. Go to https://www.typescriptlang.org/docs/handbook/utility-types.html#awaitedtype
2. Clicking on the `Released: 4.5` links to https://www.typescriptlang.org/docs/handbook/docs/handbook/release-notes/typescript-4-5.html#the-awaited-type-and-promise-improvements which does not exist.
3. It should instead link to https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#the-awaited-type-and-promise-improvements