### PR TITLE
Update *Downleveling* string concatenation example

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Basics.md
+++ b/packages/documentation/copy/en/handbook-v2/Basics.md
@@ -382,7 +382,7 @@ One other difference from the above was that our template string was rewritten f
 to
 
 ```js
-"Hello " + person + ", today is " + date.toDateString() + "!";
+"Hello ".concat(person, ", today is ").concat(date.toDateString(), "!")
 ```
 
 Why did this happen?


### PR DESCRIPTION
In [Erased Types](https://www.typescriptlang.org/docs/handbook/2/basic-types.html#erased-types), the example that renders on the screen uses the `String.prototype.concat()` method instead of the concatenation operator as the [Downleveling](https://www.typescriptlang.org/docs/handbook/2/basic-types.html#downleveling) example shows.

Here's the rendered example from *Erased Types*:

[Erased Types concatenation example](https://imgur.com/a/UjiLPmK)