### PR TITLE
Update Generics.md | Bees have six legs, not four.

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Generics.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Generics.md
@@ -345,8 +345,8 @@ A more advanced example uses the prototype property to infer and constrain relat
 
 ```ts twoslash
 // @strict: false
-class BeeKeeper {
-  hasMask: boolean = true;
+class LionKeeper {
+  hasCatnip: boolean = true;
 }
 
 class ZooKeeper {
@@ -357,11 +357,11 @@ class Animal {
   numLegs: number = 4;
 }
 
-class Bee extends Animal {
-  keeper: BeeKeeper = new BeeKeeper();
+class Lion extends Animal {
+  keeper: LionKeeper = new LionKeeper();
 }
 
-class Lion extends Animal {
+class Elephant extends Animal {
   keeper: ZooKeeper = new ZooKeeper();
 }
 
@@ -369,8 +369,8 @@ function createInstance<A extends Animal>(c: new () => A): A {
   return new c();
 }
 
-createInstance(Lion).keeper.nametag;
-createInstance(Bee).keeper.hasMask;
+createInstance(Elephant).keeper.nametag;
+createInstance(Lion).keeper.hasCatnip;
 ```
 
 This pattern is used to power the [mixins](/docs/handbook/mixins.html) design pattern.


### PR DESCRIPTION
I updated the last example given to use Lions and Elephants instead of Bees and Lions. I did this because the previous example sets Bees to have four legs. Bees are insects, and thus have six legs. A pedantic point, but I think it's helpful when examples are accurate to real-world scenarios.