### PR TITLE
Update Decorators.md - Fix TypedPropertyDescriptor error

### DIFF
--- a/packages/documentation/copy/en/reference/Decorators.md
+++ b/packages/documentation/copy/en/reference/Decorators.md
@@ -457,7 +457,7 @@ function required(target: Object, propertyKey: string | symbol, parameterIndex: 
   Reflect.defineMetadata( requiredMetadataKey, existingRequiredParameters, target, propertyKey);
 }
 
-function validate(target: any, propertyName: string, descriptor: TypedPropertyDescriptor<Function>) {
+function validate(target: any, propertyName: string, descriptor: TypedPropertyDescriptor<Function | any>) {
   let method = descriptor.value!;
 
   descriptor.value = function () {

--- a/packages/documentation/copy/en/reference/Decorators.md
+++ b/packages/documentation/copy/en/reference/Decorators.md
@@ -449,6 +449,8 @@ We can then define the `@required` and `@validate` decorators using the followin
 // @experimentalDecorators
 // @emitDecoratorMetadata
 import "reflect-metadata";
+
+type AnyFunction = (...args: any[]) => any;
 const requiredMetadataKey = Symbol("required");
 
 function required(target: Object, propertyKey: string | symbol, parameterIndex: number) {
@@ -457,14 +459,14 @@ function required(target: Object, propertyKey: string | symbol, parameterIndex: 
   Reflect.defineMetadata( requiredMetadataKey, existingRequiredParameters, target, propertyKey);
 }
 
-function validate(target: any, propertyName: string, descriptor: TypedPropertyDescriptor<Function | any>) {
+function validate(target: any, propertyName: string, descriptor: TypedPropertyDescriptor<AnyFunction>) {
   let method = descriptor.value!;
 
-  descriptor.value = function () {
+  descriptor.value = function (...args) {
     let requiredParameters: number[] = Reflect.getOwnMetadata(requiredMetadataKey, target, propertyName);
     if (requiredParameters) {
       for (let parameterIndex of requiredParameters) {
-        if (parameterIndex >= arguments.length || arguments[parameterIndex] === undefined) {
+        if (parameterIndex >= args.length || args[parameterIndex] === undefined) {
           throw new Error("Missing required argument.");
         }
       }


### PR DESCRIPTION
I found the parameter decorator example https://www.typescriptlang.org/docs/handbook/decorators.html#parameter-decorators doesn't for me. So I create this PR to fix it.

### Issue: 
* `validate` decorator raises an error about the `descriptor.value` type not matching
<img width="885" alt="image" src="https://user-images.githubusercontent.com/8935612/197407573-40d73ce0-4686-417d-8613-d451b7147be0.png">



### Solution:

* Fix the `descripor.value` type, by defining a `AnyFunction`
* Use `...args` instead of the magic `arguments`

