### PR TITLE
Fix a wrong word in handbook modules page

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Modules.md
+++ b/packages/documentation/copy/en/handbook-v2/Modules.md
@@ -25,7 +25,7 @@ Conversely, to consume a variable, function, class, interface, etc. exported fro
 ## Non-modules
 
 Before we start, it's important to understand what TypeScript considers a module.
-The JavaScript specification declares that any JavaScript files without an `export` or top-level `await` should be considered a script and not a module.
+The JavaScript specification declares that any JavaScript files without an `export` or top-level `import` should be considered a script and not a module.
 
 Inside a script file variables and types are declared to be in the shared global scope, and it's assumed that you'll either use the [`outFile`](/tsconfig#outFile) compiler option to join multiple input files into one output file, or use multiple `<script>` tags in your HTML to load these files (in the correct order!).
 


### PR DESCRIPTION
Fix a wrong word in the Non-modules section.
It should be "top-level `import`" instead of "top-level `await`"