### PR TITLE
Fix ES Modules spec date

### DIFF
--- a/packages/documentation/copy/en/declaration-files/templates/module.d.ts.md
+++ b/packages/documentation/copy/en/declaration-files/templates/module.d.ts.md
@@ -33,7 +33,7 @@ export const maxInterval: 12;
 The TypeScript playground can show you the `.d.ts` equivalent for JavaScript code. You can [try it yourself here](/play?useJavaScript=true#code/GYVwdgxgLglg9mABAcwKZQIICcsEMCeAMqmMlABYAUuOAlIgN6IBQiiW6IWSNWAdABsSZcswC+zCAgDOURAFtcADwAq5GKUQBeRAEYATM2by4AExBC+qJQAc4WKNO2NWKdNjxFhFADSvFquqk4sxAA).
 
 The `.d.ts` syntax intentionally looks like [ES Modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) syntax.
-ES Modules was ratified by TC39 in 2019, while it has been available via transpilers for a long time, however if you have a JavaScript codebase using ES Modules:
+ES Modules was ratified by TC39 in 2015 as part of ES2015 (ES6), while it has been available via transpilers for a long time, however if you have a JavaScript codebase using ES Modules:
 
 ```js
 export function getArrayLength(arr) {


### PR DESCRIPTION
The documentation quotes 2019 for when ES Modules were standardized, but that seems to refer to ES2020's dynamic import() function.  ES Modules were part of ES2015 (ES6) released in 2015.