### PR TITLE
Enclose type names with backticks in Keyof page

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Keyof Type Operator.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Keyof Type Operator.md
@@ -8,7 +8,7 @@ oneline: "Using the keyof operator in type contexts."
 ## The `keyof` type operator
 
 The `keyof` operator takes an object type and produces a string or numeric literal union of its keys.
-The following type P is the same type as "x" | "y":
+The following type `P` is the same type as `"x" | "y"`:
 
 ```ts twoslash
 type Point = { x: number; y: number };


### PR DESCRIPTION
# Page

- https://www.typescriptlang.org/docs/handbook/2/keyof-types.html

# Issue

The 2 types in this paragraph, `P` and `"x" | "y"`, don't look like code:

![image](https://user-images.githubusercontent.com/5118942/206051039-509f3ab2-0d5e-47f2-b385-0fda5aafa6a3.png)

# Changes

- Enclose those 2 types in backticks so they look like code.
