### PR TITLE
fix casing for `any`

### DIFF
--- a/packages/documentation/copy/en/reference/Type Compatibility.md
+++ b/packages/documentation/copy/en/reference/Type Compatibility.md
@@ -295,7 +295,7 @@ These differ only in that assignment extends subtype compatibility with rules to
 Different places in the language use one of the two compatibility mechanisms, depending on the situation.
 For practical purposes, type compatibility is dictated by assignment compatibility, even in the cases of the `implements` and `extends` clauses.
 
-## `Any`, `unknown`, `object`, `void`, `undefined`, `null`, and `never` assignability
+## `any`, `unknown`, `object`, `void`, `undefined`, `null`, and `never` assignability
 
 The following table summarizes assignability between some abstract types.
 Rows indicate what each is assignable to, columns indicate what is assignable to them.


### PR DESCRIPTION
## Page

- [https://www.typescriptlang.org/docs/handbook/type-compatibility.html](https://www.typescriptlang.org/docs/handbook/type-compatibility.html)

## Issue
`any` is written as `Any` inside a codeblock

<img width="863" alt="image" src="https://user-images.githubusercontent.com/54589973/206145778-8c04f601-b00b-46f2-b5f6-981ed81c6301.png">

