### PR TITLE
Note CLI ignores tsconfig if files are specified

### DIFF
--- a/packages/documentation/copy/en/project-config/Compiler Options.md
+++ b/packages/documentation/copy/en/project-config/Compiler Options.md
@@ -9,7 +9,7 @@ disable_toc: true
 ## Using the CLI
 
 Running `tsc` locally will compile the closest project defined by a `tsconfig.json`, or you can compile a set of TypeScript
-files by passing in a glob of files you want. When input files are specified on the command line, tsconfig.json files are
+files by passing in a glob of files you want. When input files are specified on the command line, `tsconfig.json` files are
 ignored.
 
 ```sh

--- a/packages/documentation/copy/en/project-config/Compiler Options.md
+++ b/packages/documentation/copy/en/project-config/Compiler Options.md
@@ -8,8 +8,9 @@ disable_toc: true
 
 ## Using the CLI
 
-Running `tsc` locally will compile the closest project defined by a `tsconfig.json`, you can compile a set of TypeScript
-files by passing in a glob of files you want.
+Running `tsc` locally will compile the closest project defined by a `tsconfig.json`, or you can compile a set of TypeScript
+files by passing in a glob of files you want. When input files are specified on the command line, tsconfig.json files are
+ignored.
 
 ```sh
 # Run a compile based on a backwards look through the fs for a tsconfig.json


### PR DESCRIPTION
Added a verbatim copy of the sentence from [here](https://github.com/microsoft/TypeScript-Website/blob/v2/packages/documentation/copy/en/project-config/tsconfig.json.md?plain=1#L23).

Redundancy in the documentation is probably not the best thing, however this is such an important note about the CLI behaviour. It doesn't seem to be reasonable to look for information about CLI behaviour on another page. If it can only be added in one place, the CLI page would be the better candidate, but coming from the perspective of the readers' expectations, it is reasonable to have this sentence on both the tsconfig and the cli pages.

 Also current first sentence suggests that providing files and using tsconfig is possible at the same time. While both parts of that sentence is true, they are not true at the same time, so an or between them helps to avoid wrong expectations.