### PR TITLE
Fix typo on 4.9

### DIFF
--- a/packages/documentation/copy/en/release-notes/TypeScript 4.9.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 4.9.md
@@ -242,7 +242,7 @@ class Person {
         return this.#__name;
     }
     set name(value: string) {
-        this.#__name = name;
+        this.#__name = value;
     }
 
     constructor(name: string) {


### PR DESCRIPTION
I think it's an unintended error in this example, is it right?