### PR TITLE
Update TypeScript 4.9.md

### DIFF
--- a/packages/documentation/copy/en/release-notes/TypeScript 4.9.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 4.9.md
@@ -217,7 +217,7 @@ This helps check that we're using valid property keys, and not accidentally chec
 
 For more information, [read the implementing pull request](https://github.com/microsoft/TypeScript/pull/50666)
 
-## <a name="auto-accessors-in-classes"> Auto-Accessors in Classes
+## Auto-Accessors in Classes
 
 TypeScript 4.9 supports an upcoming feature in ECMAScript called auto-accessors.
 Auto-accessors are declared just like properties on classes, except that they're declared with the `accessor` keyword.


### PR DESCRIPTION
Remove html <a> tag from Auto-Accessors in Classes heading which is shown as plain html in the table of content.
<img width="236" alt="Screenshot 2022-12-14 at 10 01 18" src="https://user-images.githubusercontent.com/9501442/207552103-7e754e54-4463-48a3-8d13-0a4309c49dc6.png">

And also renders the content blue.
<img width="886" alt="Screenshot 2022-12-14 at 10 01 48" src="https://user-images.githubusercontent.com/9501442/207552208-a6f48dd9-3283-48d5-a9c3-34e3b2effec4.png">
