### PR TITLE
Update link reference to ban const enums

### DIFF
--- a/packages/documentation/copy/en/reference/Enums.md
+++ b/packages/documentation/copy/en/reference/Enums.md
@@ -382,7 +382,7 @@ These pitfalls pertain to _ambient_ const enums only (basically const enums in `
 Here are two approaches to avoiding these pitfalls:
 
 A. Do not use const enums at all.
-   You can easily [ban const enums](https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md#how-can-i-ban-specific-language-feature) with the help of a linter.
+   You can easily [ban const enums](https://github.com/typescript-eslint/typescript-eslint/issues/561) with the help of a linter.
    Obviously this avoids any issues with const enums, but prevents your project from inlining its own enums.
    Unlike inlining enums from other projects, inlining a project's own enums is not problematic and has performance implications.
 B. Do not publish ambient const enums, by deconstifying them with the help of [`preserveConstEnums`](/tsconfig#preserveConstEnums).


### PR DESCRIPTION
Link was returning 404 as page: https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md#how-can-i-ban-specific-language-feature no longer exists. Updated to https://github.com/typescript-eslint/typescript-eslint/issues/561#issuecomment-593059472