### PR TITLE
Fix titles in Discord community callout

### DIFF
--- a/packages/typescriptlang-org/src/templates/pages/community.tsx
+++ b/packages/typescriptlang-org/src/templates/pages/community.tsx
@@ -62,10 +62,10 @@ export const Comm: React.FC<Props> = props => {
             </div>
 
             <div className="callout">
-              <a aria-labelledby="discord-header" className="icon discord img-circle" href="https://discord.gg/typescript" title="TypeScript Community on Stack Overflow" />
+              <a aria-labelledby="discord-header" className="icon discord img-circle" href="https://discord.gg/typescript" title="TypeScript Community on Discord" />
 
               <div className="text">
-                <a href="https://discord.gg/typescript" id="discord-header" title="TypeScript Community on Stack Overflow" >
+                <a href="https://discord.gg/typescript" id="discord-header" title="TypeScript Community on Discord" >
                   <h3 className="community-callout-headline">{i("com_online_discord_header")}</h3>
                 </a>
                 {i("com_online_discord_desc")}</div>


### PR DESCRIPTION
Current titles reference Stack Overflow, changing these to Discord.