### PR TITLE
Support preview environments for PRs from forks via manual dispatch and magic label

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,14 +36,22 @@ jobs:
         env:
           CI: true
 
-      # Deploy preview environment
+      # Deploy preview environment for non-forks
       - uses: Azure/static-web-apps-deploy@v1
+        if: github.event.base.repo.id == github.event.head.repo.id
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PROD }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          action: "upload"
-          app_location: "site"
+          action: upload
+          app_location: site
           skip_app_build: true
+
+      # Upload site artifact for forks so it can be deployed by a maintainer on-demand
+      - uses: actions/upload-artifact@v3
+        if: github.event.base.repo.id != github.event.head.repo.id
+        with:
+          name: site-${{ github.event.number }}
+          path: site/
 
       # danger for PR builds
       - if: github.event_name == 'pull_request' && github.event.base.repo.id == github.event.head.repo.id

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -89,13 +89,3 @@ jobs:
         run: |
           cd ..
           npm init typescript-playground-plugin playground-my-plugin
-
-  close_preview_environment:
-    if: github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    name: Close preview environment deployment
-    steps:
-      - uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PROD }}
-          action: "close"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,7 +6,7 @@ on:
       - v2
 
 jobs:
-  build_and_deploy:
+  tests:
     runs-on: ubuntu-latest
     if: github.event.action != 'closed'
     steps:

--- a/.github/workflows/close-preview.yml
+++ b/.github/workflows/close-preview.yml
@@ -1,0 +1,13 @@
+name: Close preview environment
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  close:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PROD }}
+          action: close

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -15,7 +15,9 @@ jobs:
         with:
           # Fetch the full history, to build attribution.json
           fetch-depth: 0
-          ref: refs/remotes/pull/${{ inputs.pr }}/merge
+      - run: |
+          git fetch origin pull/${{ inputs.pr }}/merge:pull/${{ inputs.pr }}/merge
+          git checkout pull/${{ inputs.pr }}/merge
       - uses: actions/setup-node@v2
         with:
           node-version: "14.x"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           # Fetch the full history, to build attribution.json
           fetch-depth: 0
-          ref: pull/${{ inputs.pr }}/merge # refs/remotes/pull/*/merge ?
+          ref: refs/remotes/pull/${{ inputs.pr }}/merge
       - uses: actions/setup-node@v2
         with:
           node-version: "14.x"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,5 +1,8 @@
 name: Deploy preview environment
 on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
   workflow_dispatch:
     inputs:
       pr:
@@ -11,33 +14,54 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Download site build
+        if: github.event_name == 'workflow_run'
+        uses: actions/github-script@v6
+        id: download-from-workflow-run
         with:
-          # Fetch the full history, to build attribution.json
-          fetch-depth: 0
-      - run: |
-          git fetch origin pull/${{ inputs.pr }}/merge:pull/${{ inputs.pr }}/merge
-          git checkout pull/${{ inputs.pr }}/merge
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "14.x"
-          cache: yarn
+          result-encoding: string
+          script: |
+            const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            const artifact = allArtifacts.data.artifacts.find(artifact => {
+              return artifact.name.startsWith('site-');
+            });
+            const prNumber = artifact.name.split('-')[1];
 
-      # Builds the modules, and boostraps the other modules
-      - name: Build website
-        run: |
-          yarn install
-          yarn docs-sync pull microsoft/TypeScript-Website-localizations#main 1
-          yarn bootstrap
-          yarn workspace typescriptlang-org setup-playground-cache-bust
-          yarn build
-          yarn build-site
-          cp -r packages/typescriptlang-org/public site
-        env:
-          YARN_CHECKSUM_BEHAVIOR: ignore
+            // Check if the PR has the "deploy-preview" label
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            if (!pr.data.labels.some(label => label.name === 'deploy-preview')) {
+              return;
+            }
+
+            const download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: artifact.id,
+               archive_format: 'zip',
+            });
+            return prNumber;
+
+      - name: Download site build
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/download-artifact@v3
+        with:
+          name: site-${{ inputs.pr }}
+          path: site
+
+      - run: ls -R
+        working-directory: site
 
       - name: Deploy
-        id: builddeploy
+        id: deploy
+        if: inputs.pr || steps.download-from-workflow-run.outputs.result
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PROD }}
@@ -46,4 +70,20 @@ jobs:
           app_location: "site"
           skip_app_build: true
           production_branch: v2
-          deployment_environment: pr${{ inputs.pr }}
+          deployment_environment: ${{ inputs.pr || steps.download-from-workflow-run.outputs.result }}
+
+      - name: Comment on PR
+        if: inputs.pr || steps.download-from-workflow-run.outputs.result
+        uses: actions/github-script@v6
+        env:
+          PR_NUMBER: ${{ inputs.pr || steps.download-from-workflow-run.outputs.result }}
+          SITE_URL: ${{ steps.deploy.outputs.static_web_app_url }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: process.env.PR_NUMBER,
+              body: `Azure Static Web Apps: Your stage site is ready! Visit it here: ${process.env.SITE_URL}`
+            });


### PR DESCRIPTION
I think this works around the limitations mentioned at https://github.com/Azure/static-web-apps/issues/1, but requires a maintainer to manually trigger a deployment or add a label to a PR. I think this is fine to start with, but we could make it more automatic in the future if we feel it’s safe and necessary.

I think I have to merge this in order to test it, since there are changes to CI.yml that have to run before the new workflows.