### PR TITLE
Update docs URLs

### DIFF
--- a/packages/documentation/copy/en/get-started/TS for the New Programmer.md
+++ b/packages/documentation/copy/en/get-started/TS for the New Programmer.md
@@ -167,7 +167,7 @@ This was a brief overview of the syntax and tools used in everyday TypeScript. F
 
 - Learn some of the JavaScript fundamentals, we recommend either:
 
-  - [Microsoft's JavaScript Resources](https://docs.microsoft.com/javascript/) or
+  - [Microsoft's JavaScript Resources](https://developer.microsoft.com/javascript/) or
   - [JavaScript guide at the Mozilla Web Docs](https://developer.mozilla.org/docs/Web/JavaScript/Guide)
 
 - Continue to [TypeScript for JavaScript Programmers](/docs/handbook/typescript-in-5-minutes.html)

--- a/packages/documentation/copy/en/handbook-v2/The Handbook.md
+++ b/packages/documentation/copy/en/handbook-v2/The Handbook.md
@@ -12,7 +12,7 @@ Over 20 years after its introduction to the programming community, JavaScript is
 
 The most common kinds of errors that programmers write can be described as type errors: a certain kind of value was used where a different kind of value was expected. This could be due to simple typos, a failure to understand the API surface of a library, incorrect assumptions about runtime behavior, or other errors. The goal of TypeScript is to be a static typechecker for JavaScript programs - in other words, a tool that runs before your code runs (static) and ensures that the types of the program are correct (typechecked).
 
-If you are coming to TypeScript without a JavaScript background, with the intention of TypeScript being your first language, we recommend you first start reading the documentation on either the [Microsoft Learn JavaScript tutorial](https://docs.microsoft.com/javascript/) or read [JavaScript at the Mozilla Web Docs](https://developer.mozilla.org/docs/Web/JavaScript/Guide).
+If you are coming to TypeScript without a JavaScript background, with the intention of TypeScript being your first language, we recommend you first start reading the documentation on either the [Microsoft Learn JavaScript tutorial](https://developer.microsoft.com/javascript/) or read [JavaScript at the Mozilla Web Docs](https://developer.mozilla.org/docs/Web/JavaScript/Guide).
 If you have experience in other languages, you should be able to pick up JavaScript syntax quite quickly by reading the handbook.
 
 ## How is this Handbook Structured

--- a/packages/typescriptlang-org/scripts/pingTeamsWithAppInsightData.js
+++ b/packages/typescriptlang-org/scripts/pingTeamsWithAppInsightData.js
@@ -4,7 +4,7 @@
  * run with:
     APP_INSIGHTS_ID="X" APP_INSIGHTS_API_KEY="Y" node packages/typescriptlang-org/scripts/pingTeamsWithAppInsightData.js
 
-   if process.env.STATS_WEBHOOK_INCOMING_URL is set, then the message will go into teams 
+   if process.env.STATS_WEBHOOK_INCOMING_URL is set, then the message will go into teams
   */
 
 const nodeFetch = require("node-fetch").default
@@ -88,7 +88,7 @@ const go = async () => {
   if (!process.env.STATS_WEBHOOK_INCOMING_URL) {
     console.log(JSON.stringify(card, null, "  "))
   } else {
-    // https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using#send-adaptive-cards-using-an-incoming-webhook
+    // https://learn.microsoft.com/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using#send-adaptive-cards-using-an-incoming-webhook
 
     const outer = {
       type: "message",

--- a/packages/typescriptlang-org/src/templates/pages/download.tsx
+++ b/packages/typescriptlang-org/src/templates/pages/download.tsx
@@ -47,7 +47,7 @@ const Index: React.FC<Props> = (props) => {
         <div style={{ padding: "1rem", flex: 1, minWidth: "240px" }}>
           <h3>with Visual Studio</h3>
           <p>For most project types, you can get TypeScript as a package in Nuget for your MSBuild projects, for example an ASP.NET Core app.</p>
-          <p>When using Nuget, you can <a href="https://docs.microsoft.com/visualstudio/javascript/tutorial-aspnet-with-typescript">install TypeScript through Visual Studio</a> using:</p>
+          <p>When using Nuget, you can <a href="https://learn.microsoft.com/visualstudio/javascript/tutorial-aspnet-with-typescript">install TypeScript through Visual Studio</a> using:</p>
           <ul>
             <li>
               The Manage NuGet Packages window (which you can get to by right-clicking on a project node)
@@ -56,7 +56,7 @@ const Index: React.FC<Props> = (props) => {
               The Nuget Package Manager Console (found in Tools &gt; NuGet Package Manager &gt; Package Manager Console) and then running:<br /><code style={{ fontSize: "14px" }}>Install-Package Microsoft.TypeScript.MSBuild</code>
             </li>
           </ul>
-          <p>For project types which don't support Nuget, you can use the <a href={releaseInfo.vs.stable.vs2019_download}> TypeScript Visual Studio extension</a>. You can <a href="https://docs.microsoft.com/visualstudio/ide/finding-and-using-visual-studio-extensions?view=vs-2019">install the extension</a> using <code>Extensions &gt; Manage Extensions</code> in Visual Studio.</p>
+          <p>For project types which don't support Nuget, you can use the <a href={releaseInfo.vs.stable.vs2019_download}> TypeScript Visual Studio extension</a>. You can <a href="https://learn.microsoft.com/visualstudio/ide/finding-and-using-visual-studio-extensions">install the extension</a> using <code>Extensions &gt; Manage Extensions</code> in Visual Studio.</p>
         </div>
       </section>
     </div >


### PR DESCRIPTION
docs.microsoft.com is now rebranded, so updated URLs accordingly.
Also removed the fixed URL pointing to VS 2019 to go to the latest instead.