### PR TITLE
Remove incorrect statement in Classes.md

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -250,7 +250,6 @@ TypeScript has some special inference rules for accessors:
 
 - If `get` exists but no `set`, the property is automatically `readonly`
 - If the type of the setter parameter is not specified, it is inferred from the return type of the getter
-- Getters and setters must have the same [Member Visibility](#member-visibility)
 
 Since [TypeScript 4.3](https://devblogs.microsoft.com/typescript/announcing-typescript-4-3/), it is possible to have accessors with different types for getting and setting.
 


### PR DESCRIPTION
Remove the following line:

> Getters and setters must have the same Member Visibility

...because it is not true. The following code proves that getters and setters can have different visibility [when run in the TypeScript Playground](https://www.typescriptlang.org/play?#code/MYGwhgzhAEDC0G8CwAoa0D6ICmA7A5gC4AW0AvNAAwDcq6ADgK4BGIAlsNPtodDgSQAUASkTQA9OOjFsAJ2zQSC7oUJzobGE1YcAdHXTR5hRrNyLim3VjxFitNNAC+B+rLYA3MGugQefWyEvEEZsUQQJKRl5CwU-VXVNaDdPb2x9R3QSKxsBUgpg0Id0FxRS1BxeYAAuOHJoXGwAdzgRB0qG+uBdfjtqSIskpoB7WQBrGGZgMEY-Lh41WQ0tFnZu1G7eknqARgAmfsloYGGAW3o2HCWT8-A2XBhohWZsadm4hcStdy81XSA):

```ts
class C {
  _length = 0;
  public get length() { // here the getter is public.
    return this._length;
  }
  private set length(value) { // here the setter is private.
    this._length = value;
  }
}

let c: C = new C();
let n = c.length; // this works bcause getter is public.
c.length = 12; // compiler complains here because setter is private.
```