### PR TITLE
update interfaces.md with proper string

### DIFF
--- a/packages/documentation/copy/en/handbook-v1/Interfaces.md
+++ b/packages/documentation/copy/en/handbook-v1/Interfaces.md
@@ -465,7 +465,7 @@ interface HeadersResponse {
   date: string,
   "content-length": string
 
-  // Permit any property starting with 'data-'.
+  // Permit any property starting with 'x-'.
   [headerName: `x-${string}`]: string;
 }
 


### PR DESCRIPTION
_Interfaces_ documentation at `Indexable Types with Template Strings` is referring to `x-`, but the comment is saying `data-`. This has been fixed in this PR.

![image](https://user-images.githubusercontent.com/17968732/216136797-1f705402-629b-4126-952e-1562aed0141e.png)
