### PR TITLE
Update TC39 Decorators proposal stage level

### DIFF
--- a/packages/documentation/copy/en/reference/Decorators.md
+++ b/packages/documentation/copy/en/reference/Decorators.md
@@ -14,7 +14,7 @@ translatable: true
 
 With the introduction of Classes in TypeScript and ES6, there now exist certain scenarios that require additional features to support annotating or modifying classes and class members.
 Decorators provide a way to add both annotations and a meta-programming syntax for class declarations and members.
-Decorators are a [stage 2 proposal](https://github.com/tc39/proposal-decorators) for JavaScript and are available as an experimental feature of TypeScript.
+Decorators are a [stage 3 proposal](https://github.com/tc39/proposal-decorators) for JavaScript and are available as an experimental feature of TypeScript.
 
 > NOTE&emsp; Decorators are an experimental feature that may change in future releases.
 


### PR DESCRIPTION
Since Mar 29, 2022 (https://github.com/tc39/proposal-decorators/commit/232899356421269b056e1c1e3d6c68d9c332be88) the TC39 Decorator Proposal is at stage 3.

This change updates the reference in the TypeScript documentation