### PR TITLE
Update baseUrl.md to reflect that typescript does not rewrite paths

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/baseUrl.md
+++ b/packages/tsconfig-reference/copy/en/options/baseUrl.md
@@ -25,3 +25,5 @@ console.log(helloWorld);
 
 If you get tired of imports always looking like `"../"` or `"./"`, or needing
 to change them as you move files, this is a great way to fix that.
+
+This will not change the javascript output by tsc, so additional configuration outside of typescript may be required.


### PR DESCRIPTION
A lot of the writing around `baseUrl` online totally ignores that typescript does not rewrite the paths.

While it is not uncommon to having tooling set up to do this, or otherwise not use tsc. It does mean that running the output of tsc in node will fail when this setting is used. 

Furthermore, this is explicitly in line with the projects goals as stated in https://github.com/microsoft/TypeScript/issues/26722

As this is counterintuitive to a developer without a good understanding of the philosophy of Typescript, and a fairly serious pitfall; this deserves documenting. 