### PR TITLE
Adds missing dependencies

### DIFF
--- a/packages/ts-twoslasher/package.json
+++ b/packages/ts-twoslasher/package.json
@@ -51,7 +51,11 @@
   },
   "dependencies": {
     "@typescript/vfs": "1.4.0",
+    "@types/lz-string": "^1.3.0",
     "debug": "^4.1.1",
     "lz-string": "^1.4.4"
+  },
+  "peerDependencies": {
+    "typescript": "*"
   }
 }

--- a/packages/ts-twoslasher/package.json
+++ b/packages/ts-twoslasher/package.json
@@ -50,8 +50,8 @@
     "typescript": false
   },
   "dependencies": {
-    "@typescript/vfs": "1.4.0",
     "@types/lz-string": "^1.3.0",
+    "@typescript/vfs": "1.4.0",
     "debug": "^4.1.1",
     "lz-string": "^1.4.4"
   },

--- a/packages/ts-twoslasher/package.json
+++ b/packages/ts-twoslasher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typescript/twoslash",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "license": "MIT",
   "author": "TypeScript team",
   "homepage": "https://github.com/microsoft/TypeScript-Website",

--- a/packages/typescriptlang-org/package.json
+++ b/packages/typescriptlang-org/package.json
@@ -25,7 +25,7 @@
     "@types/react-helmet": "^5.0.15",
     "@typescript/playground": "0.1.0",
     "@typescript/sandbox": "0.1.0",
-    "@typescript/twoslash": "3.2.1",
+    "@typescript/twoslash": "3.2.2",
     "gatsby": "^3.8.1",
     "gatsby-link": "3.10.0",
     "gatsby-plugin-catch-links": "^3.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5624,7 +5624,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@typescript/twoslash@3.2.1, @typescript/twoslash@workspace:packages/ts-twoslasher":
+"@typescript/twoslash@3.2.2, @typescript/twoslash@workspace:packages/ts-twoslasher":
   version: 0.0.0-use.local
   resolution: "@typescript/twoslash@workspace:packages/ts-twoslasher"
   dependencies:
@@ -5640,6 +5640,8 @@ __metadata:
     prettier: ^2.3.2
     tsdx: ^0.14.1
     tslib: ^1.10.0
+    typescript: "*"
+  peerDependencies:
     typescript: "*"
   languageName: unknown
   linkType: soft
@@ -27606,7 +27608,7 @@ resolve@^2.0.0-next.3:
     "@types/react-helmet": ^5.0.15
     "@typescript/playground": 0.1.0
     "@typescript/sandbox": 0.1.0
-    "@typescript/twoslash": 3.2.1
+    "@typescript/twoslash": 3.2.2
     concurrently: ^5.1.0
     gatsby: ^3.8.1
     gatsby-link: 3.10.0


### PR DESCRIPTION
- `lz-string` is directly [referenced in types](https://github.com/microsoft/TypeScript-Website/blob/4a670b334df7be35c480f640009ce698a7bab02b/packages/ts-twoslasher/src/index.ts#L8). While the package includes [some types](https://cdn.jsdelivr.net/npm/lz-string@1.4.4/typings/lz-string.d.ts), they aren't picked up by TS since they are in a `typings` folder (and they don't export anything anyway). Without adding `@types/lz-string` to the dependencies (or `skipLibCheck`), TS will report an error.

- similarly, `typescript` is referenced [here](https://github.com/microsoft/TypeScript-Website/blob/4a670b334df7be35c480f640009ce698a7bab02b/packages/ts-twoslasher/src/index.ts#L9) but isn't listed as a dependency. Since the intent is to use whatever version the consumer uses, it should be a peer dependency.

Fixes the two following errors:

```
../.yarn/berry/cache/@typescript-twoslash-npm-3.1.0-878bc67728-9.zip/node_modules/@typescript/twoslash/dist/index.d.ts:1:33 - error TS7016: Could not find a declaration file for module 'lz-string'. '/Users/mael.nison/.yarn/berry/cache/lz-string-npm-1.4.4-59a2091d3f-9.zip/node_modules/lz-string/libs/lz-string.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/lz-string` if it exists or add a new declaration (.d.ts) file containing `declare module 'lz-string';`

1 declare type LZ = typeof import("lz-string");
                                  ~~~~~~~~~~~

../.yarn/berry/cache/@typescript-twoslash-npm-3.1.0-878bc67728-9.zip/node_modules/@typescript/twoslash/dist/index.d.ts:8:79 - error TS2694: Namespace 'ts' has no exported member 'Map'.

8         type: "list" | "boolean" | "number" | "string" | import("typescript").Map<any>;
```