### PR TITLE
TypeScript 4.9.md - Remove the link that broke the title display on the page

### DIFF
--- a/packages/documentation/copy/en/release-notes/TypeScript 4.9.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 4.9.md
@@ -217,7 +217,7 @@ This helps check that we're using valid property keys, and not accidentally chec
 
 For more information, [read the implementing pull request](https://github.com/microsoft/TypeScript/pull/50666)
 
-## <a name="auto-accessors-in-classes"> Auto-Accessors in Classes
+## Auto-Accessors in Classes
 
 TypeScript 4.9 supports an upcoming feature in ECMAScript called auto-accessors.
 Auto-accessors are declared just like properties on classes, except that they're declared with the `accessor` keyword.


### PR DESCRIPTION
This "a" tag interfered with the normal display of the title among the anchor headings. 
```html
<a href="#a-nameauto-accessors-in-classes-auto-accessors-in-classes" class="">
    <a name="auto-accessors-in-classes"> Auto-Accessors in Classes
</a>
```
![image](https://user-images.githubusercontent.com/51912406/220733181-5353f1ee-8c0f-4df4-9335-4da8ca1f6d75.png)
