### PR TITLE
Fix typo in Object Types.md

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Object Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Object Types.md
@@ -446,7 +446,7 @@ function draw(circle: Colorful & Circle) {
 draw({ color: "blue", radius: 42 });
 
 // oops
-draw({ color: "red", raidus: 42 });
+draw({ color: "red", radius: 42 });
 ```
 
 ## Interfaces vs. Intersections


### PR DESCRIPTION
Not sure if this was an intentional typo to show the errors output when using object literals updating `raidus` to `radius`.