### PR TITLE
Clarification in the order of type annotation examples

### DIFF
--- a/packages/documentation/copy/en/get-started/TS for JS Programmers.md
+++ b/packages/documentation/copy/en/get-started/TS for JS Programmers.md
@@ -109,12 +109,13 @@ interface User {
   id: number;
 }
 // ---cut---
-function getAdminUser(): User {
-  //...
-}
 
 function deleteUser(user: User) {
   // ...
+}
+
+function getAdminUser(): User {
+  //...
 }
 ```
 


### PR DESCRIPTION
This change reorders the examples of parameter and return type annotation such that the example code provided matches the description (first listing parameter type annotation, followed by return type annotation).

I believe this change, while minor, serves to clarify the purpose of the documentation by presenting code examples of type annotation in the same order that they are presented in the English description of the features, making it more obvious which lines of code  demonstrate which feature.