### PR TITLE
Try catch gitInit

### DIFF
--- a/packages/create-typescript-playground-plugin/index.js
+++ b/packages/create-typescript-playground-plugin/index.js
@@ -35,10 +35,14 @@ const install = () => {
 }
 
 const gitInit = () => {
-  exec("git --version", { stdio: "inherit" })
-  exec("git init", { stdio: "inherit" })
-  exec("git add .", { stdio: "inherit" })
-  exec('git commit -am "Init"', { stdio: "inherit" })
+  try {
+    exec("git --version", { stdio: "inherit" })
+    exec("git init", { stdio: "inherit" })
+    exec("git add .", { stdio: "inherit" })
+    exec('git commit -am "Init"', { stdio: "inherit" })
+  } catch (e) {
+    console.error(e);
+  }
   return true
 }
 

--- a/packages/create-typescript-playground-plugin/index.js
+++ b/packages/create-typescript-playground-plugin/index.js
@@ -41,7 +41,7 @@ const gitInit = () => {
     exec("git add .", { stdio: "inherit" })
     exec('git commit -am "Init"', { stdio: "inherit" })
   } catch (e) {
-    console.error(e);
+    console.error(e)
   }
   return true
 }


### PR DESCRIPTION
The builder's git identity appears to break tests for this; I don't think this step is critical and so try/catching the problem away seems fair. If making a git repo with a single commit breaks on user machines, they can figure it out.