### PR TITLE
Make playground more accessible in dark mode

### DIFF
--- a/packages/typescriptlang-org/src/templates/play.scss
+++ b/packages/typescriptlang-org/src/templates/play.scss
@@ -796,18 +796,30 @@ main #editor-toolbar {
 
       span.ast-node-number {
         color: blue;
+        .dark-theme & {
+          color: lightskyblue;
+        }
       }
 
       span.ast-node-string {
         color: green;
+        .dark-theme & {
+          color: greenyellow;
+        }
       }
 
       span.ast-node-boolean {
         color: red;
+        .dark-theme & {
+          color: coral;
+        }
       }
 
       span.ast-node-undefined {
         color: brown;
+        .dark-theme & {
+          color: sandybrown;
+        }
       }
     }
 
@@ -842,6 +854,10 @@ main #editor-toolbar {
         font-weight: bold;
         position: relative; // for the + and -
         top: 0px;
+
+        .dark-theme & {
+          color: orchid;
+        }
 
         &:hover {
           text-decoration: underline;


### PR DESCRIPTION
I was working with some of the playground's extensions, like `Symbols`, `AST viewer` and it was extremely hard to read the information in the dark mode. The accessibility scores are quite low, too. 

I played a bit with different colors, and found some that make the playground more accessible. **The changes are only for the dark mode. The light mode styles stay the same.**

Some screenshots with comparisons:

**BEFORE**

<img width="538" alt="CleanShot 2023-03-11 at 21 54 16@2x" src="https://user-images.githubusercontent.com/9019397/224511163-2229e414-e99c-488e-86a5-af8dff542f1c.png">


**AFTER**

<img width="656" alt="CleanShot 2023-03-11 at 21 34 31@2x" src="https://user-images.githubusercontent.com/9019397/224510854-d0888863-0ec5-4cb1-aebf-64c73caba1c1.png">

---

**Node name BEFORE**


<img width="392" alt="CleanShot 2023-03-11 at 21 29 24@2x" src="https://user-images.githubusercontent.com/9019397/224510862-c5f45681-f2ad-4b9e-bdd2-f8a45a7715e2.png">

**Node name AFTER**

<img width="469" alt="CleanShot 2023-03-11 at 21 28 13@2x" src="https://user-images.githubusercontent.com/9019397/224510869-47d1854f-75bf-4f71-8698-601585bea838.png">

---

**Node string BEFORE**

<img width="639" alt="CleanShot 2023-03-11 at 21 33 53@2x" src="https://user-images.githubusercontent.com/9019397/224510855-3aef576f-771b-4a1a-b805-59332c7fb0fa.png">

**Node string AFTER**

<img width="653" alt="CleanShot 2023-03-11 at 21 33 40@2x" src="https://user-images.githubusercontent.com/9019397/224510856-4e8a261b-c790-4892-a8a8-d10ee12b9355.png">

---

**Node number BEFORE**

<img width="379" alt="CleanShot 2023-03-11 at 21 04 28@2x" src="https://user-images.githubusercontent.com/9019397/224510848-65dbd8c2-a94b-4ff4-a991-b5558dea3bce.png">

**Node number AFTER**

<img width="527" alt="CleanShot 2023-03-11 at 21 28 58@2x" src="https://user-images.githubusercontent.com/9019397/224510866-1be006a0-ca31-46ba-a86b-3d9ba8a191e4.png">