### PR TITLE
Update DOM Manipulation.md

### DIFF
--- a/packages/documentation/copy/en/tutorials/DOM Manipulation.md
+++ b/packages/documentation/copy/en/tutorials/DOM Manipulation.md
@@ -16,7 +16,7 @@ Websites are made up of HTML and/or XML documents. These documents are static, t
 
 TypeScript is a typed superset of JavaScript, and it ships type definitions for the DOM API. These definitions are readily available in any default TypeScript project. Of the 20,000+ lines of definitions in _lib.dom.d.ts_, one stands out among the rest: `HTMLElement` . This type is the backbone for DOM manipulation with TypeScript.
 
-> You can explore the source code for the [DOM type definitions](https://github.com/microsoft/TypeScript/blob/main/lib/lib.dom.d.ts)
+> You can explore the source code for the [DOM type definitions](https://github.com/microsoft/TypeScript/blob/main/src/lib/dom.generated.d.ts)
 
 ## Basic Example
 


### PR DESCRIPTION
 Since the `lib` folder has been deleted in microsoft/TypeScript#52226 , this link does not work. Now the correct link to the source is this one.

I did not add the information that this file is generated by [TypeScript-DOM-lib-generator](https://github.com/microsoft/TypeScript-DOM-lib-generator) and this file becomes `lib.dom.d.ts`, because I felt that the most important thing for the user is to have a quick look at the types, and not necessarily to analyze in depth the library .
