### PR TITLE
Make tsconfig-reference display values Title Case

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/clean.md
+++ b/packages/tsconfig-reference/copy/en/options/clean.md
@@ -1,5 +1,5 @@
 ---
-display: "clean"
+display: "Clean"
 oneline: "Delete the outputs of all projects."
 ---
 

--- a/packages/tsconfig-reference/copy/en/options/disableFilenameBasedTypeAcquisition.md
+++ b/packages/tsconfig-reference/copy/en/options/disableFilenameBasedTypeAcquisition.md
@@ -1,5 +1,5 @@
 ---
-display: "disableFilenameBasedTypeAcquisition"
+display: "Disable Filename Based Type Acquisition"
 oneline: "Disables inference for type acquisition by looking at filenames in a project."
 ---
 

--- a/packages/tsconfig-reference/copy/en/options/disableReferencedProjectLoad.md
+++ b/packages/tsconfig-reference/copy/en/options/disableReferencedProjectLoad.md
@@ -1,5 +1,5 @@
 ---
-display: "disableReferencedProjectLoad"
+display: "Disable Referenced Project Load"
 oneline: "Reduce the number of projects loaded automatically by TypeScript."
 ---
 

--- a/packages/tsconfig-reference/copy/en/options/enable.md
+++ b/packages/tsconfig-reference/copy/en/options/enable.md
@@ -1,5 +1,5 @@
 ---
-display: "enable"
+display: "Enable"
 oneline: "Disable the type acquisition for JavaScript projects."
 ---
 

--- a/packages/tsconfig-reference/copy/en/options/exactOptionalPropertyTypes.md
+++ b/packages/tsconfig-reference/copy/en/options/exactOptionalPropertyTypes.md
@@ -1,5 +1,5 @@
 ---
-display: "exactOptionalPropertyTypes"
+display: "Exact Optional Property Types"
 oneline: "Interpret optional property types as written, rather than adding `undefined`."
 ---
 

--- a/packages/tsconfig-reference/copy/en/options/excludeDirectories.md
+++ b/packages/tsconfig-reference/copy/en/options/excludeDirectories.md
@@ -1,5 +1,5 @@
 ---
-display: "excludeDirectories"
+display: "Exclude Directories"
 oneline: "Remove a list of directories from the watch process."
 ---
 

--- a/packages/tsconfig-reference/copy/en/options/excludeFiles.md
+++ b/packages/tsconfig-reference/copy/en/options/excludeFiles.md
@@ -1,5 +1,5 @@
 ---
-display: "excludeFiles"
+display: "Exclude Files"
 oneline: "Remove a list of files from the watch mode's processing."
 ---
 

--- a/packages/tsconfig-reference/copy/en/options/explainFiles.md
+++ b/packages/tsconfig-reference/copy/en/options/explainFiles.md
@@ -1,5 +1,5 @@
 ---
-display: "explainFiles"
+display: "Explain Files"
 oneline: "Print files read during the compilation including why it was included."
 ---
 

--- a/packages/tsconfig-reference/copy/en/options/fallbackPolling.md
+++ b/packages/tsconfig-reference/copy/en/options/fallbackPolling.md
@@ -1,5 +1,5 @@
 ---
-display: "fallbackPolling"
+display: "Fallback Polling"
 oneline: "Specify what approach the watcher should use if the system runs out of native file watchers."
 ---
 

--- a/packages/tsconfig-reference/copy/en/options/force.md
+++ b/packages/tsconfig-reference/copy/en/options/force.md
@@ -1,5 +1,5 @@
 ---
-display: "force"
+display: "Force"
 oneline: "Build all projects, including those that appear to be up to date."
 ---
 

--- a/packages/tsconfig-reference/copy/en/options/jsxFragmentFactory.md
+++ b/packages/tsconfig-reference/copy/en/options/jsxFragmentFactory.md
@@ -1,5 +1,5 @@
 ---
-display: "jsxFragmentFactory"
+display: "JSX Fragment Factory"
 oneline: "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'."
 ---
 

--- a/packages/tsconfig-reference/copy/en/options/jsxImportSource.md
+++ b/packages/tsconfig-reference/copy/en/options/jsxImportSource.md
@@ -1,5 +1,5 @@
 ---
-display: "jsxImportSource"
+display: "JSX Import Source"
 oneline: "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`."
 ---
 

--- a/packages/tsconfig-reference/copy/en/options/moduleDetection.md
+++ b/packages/tsconfig-reference/copy/en/options/moduleDetection.md
@@ -1,9 +1,9 @@
 ---
-display: "moduleDetection"
+display: "Module Detection"
 oneline: "Control what method is used to detect the whether a JS file is a module."
 ---
 
-There are three choices: 
+There are three choices:
 
 - `"auto"` (default) - TypeScript will not only look for import and export statements, but it will also check whether the `"type"` field in a `package.json` is set to `"module"` when running with [`module`](#module): `nodenext` or `node16`, and check whether the current file is a JSX file when running under [`jsx`](#jsx):  `react-jsx`.
 

--- a/packages/tsconfig-reference/copy/en/options/moduleSuffixes.md
+++ b/packages/tsconfig-reference/copy/en/options/moduleSuffixes.md
@@ -1,10 +1,10 @@
 ---
-display: "moduleSuffixes"
+display: "Module Suffixes"
 oneline: "List of file name suffixes to search when resolving a module."
 ---
 
 Provides a way to override the default list of file name suffixes to search when resolving a module.
- 
+
 ```json tsconfig
 {
     "compilerOptions": {
@@ -21,6 +21,6 @@ import * as foo from "./foo";
 
 TypeScript will look for the relative files `./foo.ios.ts`, `./foo.native.ts`, and finally `./foo.ts`.
 
-Note the empty string `""` in [`moduleSuffixes`](#moduleSuffixes) which is necessary for TypeScript to also look-up `./foo.ts`. 
+Note the empty string `""` in [`moduleSuffixes`](#moduleSuffixes) which is necessary for TypeScript to also look-up `./foo.ts`.
 
 This feature can be useful for React Native projects where each target platform can use a separate tsconfig.json with differing `moduleSuffixes`.

--- a/packages/tsconfig-reference/copy/en/options/noImplicitOverride.md
+++ b/packages/tsconfig-reference/copy/en/options/noImplicitOverride.md
@@ -1,5 +1,5 @@
 ---
-display: "noImplicitOverride"
+display: "No Implicit Override"
 oneline: "Ensure overriding members in derived classes are marked with an override modifier."
 ---
 

--- a/packages/tsconfig-reference/copy/en/options/noPropertyAccessFromIndexSignature.md
+++ b/packages/tsconfig-reference/copy/en/options/noPropertyAccessFromIndexSignature.md
@@ -1,5 +1,5 @@
 ---
-display: "noPropertyAccessFromIndexSignature"
+display: "No Property Access From Index Signature"
 oneline: "Enforces using indexed accessors for keys declared using an indexed type."
 ---
 

--- a/packages/tsconfig-reference/copy/en/options/noUncheckedIndexedAccess.md
+++ b/packages/tsconfig-reference/copy/en/options/noUncheckedIndexedAccess.md
@@ -1,5 +1,5 @@
 ---
-display: "noUncheckedIndexedAccess"
+display: "No Unchecked Indexed Access"
 oneline: "Add `undefined` to a type when accessed using an index."
 ---
 

--- a/packages/tsconfig-reference/copy/en/options/preserveValueImports.md
+++ b/packages/tsconfig-reference/copy/en/options/preserveValueImports.md
@@ -1,5 +1,5 @@
 ---
-display: "preserveValueImports"
+display: "Preserve Value Imports"
 oneline: "Preserve unused imported values in the JavaScript output that would otherwise be removed."
 ---
 

--- a/packages/tsconfig-reference/copy/en/options/synchronousWatchDirectory.md
+++ b/packages/tsconfig-reference/copy/en/options/synchronousWatchDirectory.md
@@ -1,5 +1,5 @@
 ---
-display: "synchronousWatchDirectory"
+display: "Synchronous Watch Directory"
 oneline: "Synchronously call callbacks and update the state of directory watchers on platforms that don`t support recursive watching natively."
 ---
 

--- a/packages/tsconfig-reference/copy/en/options/useUnknownInCatchVariables.md
+++ b/packages/tsconfig-reference/copy/en/options/useUnknownInCatchVariables.md
@@ -1,5 +1,5 @@
 ---
-display: "useUnknownInCatchVariables"
+display: "Use Unknown In Catch Variables"
 oneline: "Default catch clause variables as `unknown` instead of `any`."
 ---
  

--- a/packages/tsconfig-reference/copy/en/options/useUnknownInCatchVariables.md
+++ b/packages/tsconfig-reference/copy/en/options/useUnknownInCatchVariables.md
@@ -2,7 +2,7 @@
 display: "Use Unknown In Catch Variables"
 oneline: "Default catch clause variables as `unknown` instead of `any`."
 ---
- 
+
 In TypeScript 4.0, support was added to allow changing the type of the variable in a catch clause from `any` to `unknown`. Allowing for code like:
 
 ```ts twoslash

--- a/packages/tsconfig-reference/copy/en/options/verbose.md
+++ b/packages/tsconfig-reference/copy/en/options/verbose.md
@@ -1,5 +1,5 @@
 ---
-display: "verbose"
+display: "Verbose"
 oneline: "Enable verbose logging."
 ---
 

--- a/packages/tsconfig-reference/copy/en/options/watchDirectory.md
+++ b/packages/tsconfig-reference/copy/en/options/watchDirectory.md
@@ -1,5 +1,5 @@
 ---
-display: "watchDirectory"
+display: "Watch Directory"
 oneline: "Specify how directories are watched on systems that lack recursive file-watching functionality."
 ---
 

--- a/packages/tsconfig-reference/copy/en/options/watchFile.md
+++ b/packages/tsconfig-reference/copy/en/options/watchFile.md
@@ -1,5 +1,5 @@
 ---
-display: "watchFile"
+display: "Watch File"
 oneline: "Specify how the TypeScript watch mode works."
 ---
 


### PR DESCRIPTION
Some values were `camelCase`, this makes all titles `Title Case`.

Found using `grep -r "display: \"[a-z]" packages/tsconfig-reference/copy/en/options`

Other minor changes auto-generated and appear to fix up whitespace