### PR TITLE
Update link to library components under ts-config reference > `lib`

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/lib.md
+++ b/packages/tsconfig-reference/copy/en/options/lib.md
@@ -70,4 +70,4 @@ In TypeScript 4.5, lib files can be overriden by npm modules, find out more [in 
 | `ESNext.Intl`             |
 | `ESNext.Symbol`           |
 
-This list may be out of date, you can see the full list in the [TypeScript source code](https://github.com/microsoft/TypeScript/tree/main/lib).
+This list may be out of date, you can see the full list in the [TypeScript source code](https://github.com/microsoft/TypeScript/tree/main/src/lib).


### PR DESCRIPTION
On https://www.typescriptlang.org/tsconfig#lib the link to "TypeScript source code" for available typings files was broken.

This PR updates the link to point to `src/lib` instead, which appears to be the new path for those typings.