### PR TITLE
Update TS for Functional Programmers.md

### DIFF
--- a/packages/documentation/copy/en/get-started/TS for Functional Programmers.md
+++ b/packages/documentation/copy/en/get-started/TS for Functional Programmers.md
@@ -72,15 +72,15 @@ TypeScript has corresponding primitive types for the built-in types:
 
 ### Other important TypeScript types
 
-| Type           | Explanation                                                 |
-| -------------- | ----------------------------------------------------------- |
-| `unknown`      | the top type.                                               |
-| `never`        | the bottom type.                                            |
-| object literal | eg `{ property: Type }`                                     |
-| `void`         | a subtype of `undefined` intended for use as a return type. |
-| `T[]`          | mutable arrays, also written `Array<T>`                     |
-| `[T, T]`       | tuples, which are fixed-length but mutable                  |
-| `(t: T) => U`  | functions                                                   |
+| Type           | Explanation                                                                     |
+| -------------- | ------------------------------------------------------------------------------- |
+| `unknown`      | the top type.                                                                   |
+| `never`        | the bottom type.                                                                |
+| object literal | eg `{ property: Type }`                                                         |
+| `void`         | which is intended for use as a return type. `undefined` is a subtype of `void`. |
+| `T[]`          | mutable arrays, also written `Array<T>`                                         |
+| `[T, T]`       | tuples, which are fixed-length but mutable                                      |
+| `(t: T) => U`  | functions                                                                       |
 
 Notes:
 

--- a/packages/documentation/copy/en/get-started/TS for Functional Programmers.md
+++ b/packages/documentation/copy/en/get-started/TS for Functional Programmers.md
@@ -77,7 +77,7 @@ TypeScript has corresponding primitive types for the built-in types:
 | `unknown`      | the top type.                                                                   |
 | `never`        | the bottom type.                                                                |
 | object literal | eg `{ property: Type }`                                                         |
-| `void`         | which is intended for use as a return type. `undefined` is a subtype of `void`. |
+| `void`         | for functions with no documented return value |
 | `T[]`          | mutable arrays, also written `Array<T>`                                         |
 | `[T, T]`       | tuples, which are fixed-length but mutable                                      |
 | `(t: T) => U`  | functions                                                                       |


### PR DESCRIPTION
update the explanation of `void`.

line 80.

before: ```a subtype of `undefined` intended for use as a return type.```

after: ```which is intended for use as a return type. `undefined` is a subtype of `void`.```