### PR TITLE
Clarify documentation of ConstructorParameters

### DIFF
--- a/packages/documentation/copy/en/reference/Utility Types.md
+++ b/packages/documentation/copy/en/reference/Utility Types.md
@@ -350,10 +350,15 @@ type T1 = ConstructorParameters<FunctionConstructor>;
 //    ^?
 type T2 = ConstructorParameters<RegExpConstructor>;
 //    ^?
-type T3 = ConstructorParameters<any>;
+class C {
+  constructor(a: number, b: string) {}
+}
+type T3 = ConstructorParameters<typeof C>;
+//    ^?
+type T4 = ConstructorParameters<any>;
 //    ^?
 
-type T4 = ConstructorParameters<Function>;
+type T5 = ConstructorParameters<Function>;
 //    ^?
 ```
 


### PR DESCRIPTION
I get confused every time I use `ConstructorParameters`, because I forget it's `ConstructorParameters<typeof C>`, not `ConstructorParameters<C>` (if `C` is some class). And the documentation doesn't help, because all of its examples use builtin constructors that have special types. Of course if I spend 5 minutes thinking about it I remember that that's what makes sense, but it would be nice for the documentation to remind me more clearly so I don't have to think from first principles.

So in this commit I add an example with a user-defined class, which makes clear that you want `typeof C`.