### PR TITLE
Grammar fix in TS For The New Programmer

### DIFF
--- a/packages/documentation/copy/en/get-started/TS for the New Programmer.md
+++ b/packages/documentation/copy/en/get-started/TS for the New Programmer.md
@@ -57,7 +57,7 @@ We said earlier that some languages wouldn't allow those buggy programs to run a
 Detecting errors in code without running it is referred to as _static checking_.
 Determining what's an error and what's not based on the kinds of values being operated on is known as static _type_ checking.
 
-TypeScript checks a program for errors before execution, and does so based on the _kinds of values_, it's a _static type checker_.
+TypeScript checks a program for errors before execution, and does so based on the _kinds of values_, making it a _static type checker_.
 For example, the last example above has an error because of the _type_ of `obj`.
 Here's the error TypeScript found:
 


### PR DESCRIPTION
Original sentence structure was improper use of commas. The fix presented is sufficient, another option would be to replace the original comma with a dash.