### PR TITLE
Update Publishing.md

### DIFF
--- a/packages/documentation/copy/en/declaration-files/Publishing.md
+++ b/packages/documentation/copy/en/declaration-files/Publishing.md
@@ -179,4 +179,4 @@ That means in the above example, even though both the `>=3.2` and the `>=3.1` ma
 
 Packages under the [@types](https://www.npmjs.com/~types) organization are published automatically from [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) using the [types-publisher tool](https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/publisher).
 To get your declarations published as an @types package, please submit a pull request to [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped).
-You can find more details in the [contribution guidelines page](https://definitelytyped.org/guides/contributing.html).
+You can find more details in the [contribution guidelines page](https://definitelytyped.github.io/guides/contributing.html).


### PR DESCRIPTION
Fix link to definitely typed contributions guidelines.

The current link 404s. Also, the homepage of the old link looks like it's owned by a domain squatter.