### PR TITLE
Fix spacing inside curly brackets of `@type` usage examples

### DIFF
--- a/packages/documentation/copy/en/javascript/JSDoc Reference.md
+++ b/packages/documentation/copy/en/javascript/JSDoc Reference.md
@@ -9,8 +9,7 @@ translatable: true
 The list below outlines which constructs are currently supported
 when using JSDoc annotations to provide type information in JavaScript files.
 
-Note any tags which are not explicitly listed below (such as `
-async`) are not yet supported.
+Note any tags which are not explicitly listed below (such as `@async`) are not yet supported.
 
 #### Types
 

--- a/packages/documentation/copy/en/javascript/JSDoc Reference.md
+++ b/packages/documentation/copy/en/javascript/JSDoc Reference.md
@@ -9,7 +9,8 @@ translatable: true
 The list below outlines which constructs are currently supported
 when using JSDoc annotations to provide type information in JavaScript files.
 
-Note any tags which are not explicitly listed below (such as `@async`) are not yet supported.
+Note any tags which are not explicitly listed below (such as `
+async`) are not yet supported.
 
 #### Types
 
@@ -187,7 +188,7 @@ export type Pet = {
 
 // @filename: main.js
 /**
- * @param { import("./types").Pet } p
+ * @param {import("./types").Pet} p
  */
 function walk(p) {
   console.log(`Walking ${p.name}...`);
@@ -204,7 +205,7 @@ export type Pet = {
 // @filename: main.js
 // ---cut---
 /**
- * @typedef { import("./types").Pet } Pet
+ * @typedef {import("./types").Pet} Pet
  */
 
 /**
@@ -231,7 +232,7 @@ export const userAccount = {
 // @filename: main.js
 // ---cut---
 /**
- * @type {typeof import("./accounts").userAccount }
+ * @type {typeof import("./accounts").userAccount}
  */
 var x = require("./accounts").userAccount;
 ```


### PR DESCRIPTION
Few `@type` usage examples include spacing inside curly brackets which looks accidental. These do not match style of other samples. Perhaps should be cleaned up?