### PR TITLE
Correct spelling mistake in "Cautions" section of the Classes topic page

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -339,7 +339,7 @@ interface Checkable {
 class NameChecker implements Checkable {
   check(s) {
     // Notice no error here
-    return s.toLowercse() === "ok";
+    return s.toLowerCase() === "ok";
     //         ^?
   }
 }


### PR DESCRIPTION
I have come across a small mistake in the "Cautions" section of the Classes topic. The section currently contains a typo in the name of the toLowerCase method, which is spelled as toLowercse.