### PR TITLE
Update Narrowing.md

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Narrowing.md
+++ b/packages/documentation/copy/en/handbook-v2/Narrowing.md
@@ -25,7 +25,7 @@ function padLeft(padding: number | string, input: string) {
 ```
 
 Uh-oh, we're getting an error on `padding`.
-TypeScript is warning us that adding a `number | string` to a `number` might not give us what we want, and it's right.
+TypeScript is warning us that we're passing a value with type `number | string` to the `repeat` function, which only accepts a `number`, and it's right.
 In other words, we haven't explicitly checked if `padding` is a `number` first, nor are we handling the case where it's a `string`, so let's do exactly that.
 
 ```ts twoslash


### PR DESCRIPTION
The error here is not because we're "adding a `number | string` to a `number `", it's because we're passing a `number | string`  to `String.repeat`, which only accepts a `number`.

https://www.typescriptlang.org/play?#code/GYVwdgxgLglg9mABABwIYBMAyBTYUAUa66MYA5gFyJggC2ARtgE6IA+iAzlE6WQDSJSyEFCpce5AJSIA3gChEiJtiggmSAESINAOmXJsqAkRJTEAakFhhUANxyAvkA