### PR TITLE
Enable noImplicitThis in ThisType example #2822

### DIFF
--- a/packages/documentation/copy/en/reference/Utility Types.md
+++ b/packages/documentation/copy/en/reference/Utility Types.md
@@ -487,7 +487,7 @@ This utility does not return a transformed type. Instead, it serves as a marker 
 ##### Example
 
 ```ts twoslash
-// @noImplicitThis: false
+// @noImplicitThis: true
 type ObjectDescriptor<D, M> = {
   data?: D;
   methods?: M & ThisType<D & M>; // Type of 'this' in methods is D & M


### PR DESCRIPTION
Enable noImplicitThis and Fix example #2822.

### Fixed Example
Please make sure `this.x` and `this.y` are both number in this example. Thanks.
https://www.typescriptlang.org/play?#code/PTAEAEDsHsEkFsAOAbAlgY1QFwCoAtUBnALlCwCcBXAUwCgsBPRa0AeQCMAra9LAEWqF05VIizRyAHj4AaUAFkAfKAC8oAN61QoACYBDLHoD8pPgG4toeNSx5oOwiYWgAZKHxEcTatNcLFZqAg7t6g0ABmoADktkRRoKiQVjZ2DgmEoHx+8rQAvha04ZSQvKjQSfB6ANbUHNy80nJKABQ6guikdTz87SJiEo3+AJSm2RqWyDa6Bnqk0FzdqrrtAHT6hqAAPpsa+RNT1rb2JGELvEttQiuHqRnbuxba5DaU5EnqoCtf63pyX9cpY6gXKgPQZLJueQWXK0WiTLCnThLSo1Lq8ZqabQ-UgfAAepAADHIGITgTJLDdjjjLNp4NAAG7UABCDFa+NAkEo8HY1HIch0JI5XJ55CG420ErIBEIK1xoAA1GodLjAsEAMoUcoAc2QDDI3h0UqINIlsRlesVugYqrAGvI2t1+uYhrNJty5O07ryQwK804sqWAEYCRY-Ss9WoAEwh2hhumMlnNACsciTPqAA