### PR TITLE
fix: possible typo about moduleResolution default value

### DIFF
--- a/packages/documentation/copy/en/project-config/Compiler Options.md
+++ b/packages/documentation/copy/en/project-config/Compiler Options.md
@@ -832,7 +832,7 @@ tsc app.ts util.ts --target esnext --outfile index.js
   <td><code><a href='/tsconfig/#moduleResolution'>--moduleResolution</a></code></td>
   <td><p><code>classic</code>, <code>node10</code>/<code>node</code>, <code>node16</code>, <code>nodenext</code>, or <code>bundler</code></p>
 </td>
-  <td><p><code>Classic</code> if <a href="#module"><code>module</code></a> is <code>AMD</code>, <code>UMD</code>, <code>System</code> or <code>ES6</code>/<code>ES2015</code>, Matches if <a href="#module"><code>module</code></a> is <code>node12</code> or <code>nodenext</code>, <code>Node</code> otherwise.</p>
+  <td><p><code>Classic</code> if <a href="#module"><code>module</code></a> is <code>AMD</code>, <code>UMD</code>, <code>System</code> or <code>ES6</code>/<code>ES2015</code>, Matches if <a href="#module"><code>module</code></a> is <code>node16</code> or <code>nodenext</code>, <code>Node</code> otherwise.</p>
 </td>
 </tr>
 <tr class="option-description even"><td colspan="3">

--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -230,7 +230,7 @@ export const defaultsForOptions = {
   ],
   moduleResolution: [
     "`Classic` if [`module`](#module) is `AMD`, `UMD`, `System` or `ES6`/`ES2015`,",
-    "Matches if [`module`](#module) is `node12` or `nodenext`,",
+    "Matches if [`module`](#module) is `node16` or `nodenext`,",
     "`Node` otherwise.",
   ],
   newLine: "Platform specific.",


### PR DESCRIPTION
`module` does not have the option `node12`, which I think is a typo.