### PR TITLE
docs: Proposed link updates for TS learning paths

### DIFF
--- a/packages/documentation/copy/en/get-started/TS for Functional Programmers.md
+++ b/packages/documentation/copy/en/get-started/TS for Functional Programmers.md
@@ -593,5 +593,5 @@ consistently used in TypeScript code.
 
 This doc is a high level overview of the syntax and types you would use in everyday code. From here you should:
 
-- Read the full Handbook [from start to finish](/docs/handbook/intro.html)
+- Read the full Handbook [from start to finish](/docs/handbook/2/basic-types.html)
 - Explore the [Playground examples](/play#show-examples)

--- a/packages/documentation/copy/en/get-started/TS for JS Programmers.md
+++ b/packages/documentation/copy/en/get-started/TS for JS Programmers.md
@@ -285,5 +285,5 @@ If the object or class has all the required properties, TypeScript will say they
 
 This was a brief overview of the syntax and tools used in everyday TypeScript. From here, you can:
 
-- Read the full Handbook [from start to finish](/docs/handbook/intro.html)
+- Read the full Handbook [from start to finish](/docs/handbook/2/basic-types.html)
 - Explore the [Playground examples](/play#show-examples)

--- a/packages/documentation/copy/en/get-started/TS for OOPers.md
+++ b/packages/documentation/copy/en/get-started/TS for OOPers.md
@@ -190,5 +190,5 @@ For example, `typeof (new Car())` will be `"object"`, not `Car` or `"Car"`.
 
 This was a brief overview of the syntax and tools used in everyday TypeScript. From here, you can:
 
-- Read the full Handbook [from start to finish](/docs/handbook/intro.html)
+- Read the full Handbook [from start to finish](/docs/handbook/2/basic-types.html)
 - Explore the [Playground examples](/play#show-examples)

--- a/packages/documentation/copy/en/get-started/TS for the New Programmer.md
+++ b/packages/documentation/copy/en/get-started/TS for the New Programmer.md
@@ -171,7 +171,7 @@ This was a brief overview of the syntax and tools used in everyday TypeScript. F
   - [JavaScript guide at the Mozilla Web Docs](https://developer.mozilla.org/docs/Web/JavaScript/Guide)
 
 - Continue to [TypeScript for JavaScript Programmers](/docs/handbook/typescript-in-5-minutes.html)
-- Read the full Handbook [from start to finish](/docs/handbook/intro.html)
+- Read the full Handbook [from start to finish](/docs/handbook/2/basic-types.html)
 - Explore the [Playground examples](/play#show-examples)
 
 <!-- Note: I'll be happy to write the following... -->


### PR DESCRIPTION
While reading the TypeScript documentation, I went from [The TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/intro.html) intro page to [TypeScript for JavaScript Programmers](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html) page which then leads me back intro page in the "Next Steps" section. This PR proposes a change to direct users directly to first section of the handbook instead of the intro page.