### PR TITLE
Replace newlines with spaces when one-lining inlay hints

### DIFF
--- a/packages/playground/src/twoslashInlays.ts
+++ b/packages/playground/src/twoslashInlays.ts
@@ -32,7 +32,7 @@ export const createTwoslashInlayProvider = (sandbox: Sandbox) => {
         if (!hint || !hint.displayParts) continue
 
         // Make a one-liner
-        let text = hint.displayParts.map(d => d.text).join("").replace(/\r?\n/g, " ").replace(/  /g, "")
+        let text = hint.displayParts.map(d => d.text).join("").replace(/\s+/g, " ")
         if (text.length > 120) text = text.slice(0, 119) + "..."
 
         const inlay: import("monaco-editor").languages.InlayHint = {

--- a/packages/playground/src/twoslashInlays.ts
+++ b/packages/playground/src/twoslashInlays.ts
@@ -32,7 +32,7 @@ export const createTwoslashInlayProvider = (sandbox: Sandbox) => {
         if (!hint || !hint.displayParts) continue
 
         // Make a one-liner
-        let text = hint.displayParts.map(d => d.text).join("").replace(/\r?\n/g, "").replace(/  /g, "")
+        let text = hint.displayParts.map(d => d.text).join("").replace(/\r?\n/g, " ").replace(/  /g, "")
         if (text.length > 120) text = text.slice(0, 119) + "..."
 
         const inlay: import("monaco-editor").languages.InlayHint = {

--- a/packages/playground/src/twoslashInlays.ts
+++ b/packages/playground/src/twoslashInlays.ts
@@ -32,7 +32,7 @@ export const createTwoslashInlayProvider = (sandbox: Sandbox) => {
         if (!hint || !hint.displayParts) continue
 
         // Make a one-liner
-        let text = hint.displayParts.map(d => d.text).join("").replace(/\s+/g, " ")
+        let text = hint.displayParts.map(d => d.text).join("").replace(/\r\n\s*/g, " ")
         if (text.length > 120) text = text.slice(0, 119) + "..."
 
         const inlay: import("monaco-editor").languages.InlayHint = {

--- a/packages/playground/src/twoslashInlays.ts
+++ b/packages/playground/src/twoslashInlays.ts
@@ -32,7 +32,7 @@ export const createTwoslashInlayProvider = (sandbox: Sandbox) => {
         if (!hint || !hint.displayParts) continue
 
         // Make a one-liner
-        let text = hint.displayParts.map(d => d.text).join("").replace(/\r\n\s*/g, " ")
+        let text = hint.displayParts.map(d => d.text).join("").replace(/\r?\n\s*/g, " ")
         if (text.length > 120) text = text.slice(0, 119) + "..."
 
         const inlay: import("monaco-editor").languages.InlayHint = {


### PR DESCRIPTION
Theoretically fixes how bad this looks after #2691

![image](https://github.com/microsoft/TypeScript-Website/assets/5341706/d1819e60-6096-4ae0-a20b-bf25455e3665)
