### PR TITLE
Update Everyday Types for clarity

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -597,7 +597,7 @@ The same applies to strings:
 ```ts twoslash
 // @errors: 2345
 declare function handleRequest(url: string, method: "GET" | "POST"): void;
-// ---cut---
+
 const req = { url: "https://example.com", method: "GET" };
 handleRequest(req.url, req.method);
 ```


### PR DESCRIPTION
### The problem

I was reading [Everyday Types > Literal Inference section](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-inference) for the first time to refresh my knowledge on TypeScript, and when I came across the example, I was very confused:

![CleanShot 2023-05-21 at 11 11 07@2x](https://github.com/microsoft/TypeScript-Website/assets/5674362/57ea879f-cdd4-4071-8601-b899abbeaf11)

The confusion stems from ambiguity that I think needs to be edited to be clearer. I have some experience using TypeScript, and even so, I wasn't sure what the example's warning was about. Fairly certain that newcomers reading the doc for the first time will be more confused than me, so let's fix that for them.

### The proposed fix

I think the most suitable fix, which happens to be a one-liner, is to allow the function definition of `handleRequest` to render once on the page. The first time it is shown on the page, show the function definition, so readers will immediately understand - _oh, `handleRequest` has the following signature, and `req.method` has type `string` that is too broad_...  

```js
declare function handleRequest(url: string, method: "GET" | "POST"): void;
```

I'm not very familiar with `twoslash` but I think removing `// ---cut---` in one of the code blocks should work? 

### Counter-arguing the fix

I can see why you might not want to fix this, since technically one could view the type definition of `handleRequest` by hovering over the code like so:

<img width="958" alt="CleanShot 2023-05-21 at 11 32 49@2x" src="https://github.com/microsoft/TypeScript-Website/assets/5674362/22447e08-f8be-4cbf-b584-1c6645a0549a">

I'm just a passerby who has already benefitted from the amazing docs at typescriptlang.org, and I'm sharing that it was confusing for me, which probably means it was confusing to some others who don't know that the code blocks are souped-up code blocks where hovering shows type definitions like in an IDE. The dotted underlines are also quite hard to perceive in dark mode.

No strong opinion here – please merge if you want to, or close the PR if you don't wish to.
