### PR TITLE
fix: remove-display-table for mobile device

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -387,6 +387,7 @@ Being concerned only with the structure and capabilities of types is why we call
 Type aliases and interfaces are very similar, and in many cases you can choose between them freely.
 Almost all features of an `interface` are available in `type`, the key distinction is that a type cannot be re-opened to add new properties vs an interface which is always extendable.
 
+<div class='table-container'>
 <table class='full-width-table'>
   <tbody>
     <tr>
@@ -452,6 +453,7 @@ type Window = {
     </tr>
     </tbody>
 </table>
+</div>
 
 You'll learn more about these concepts in later chapters, so don't worry if you don't understand all of these right away.
 

--- a/packages/documentation/copy/en/reference/Advanced Types.md
+++ b/packages/documentation/copy/en/reference/Advanced Types.md
@@ -425,6 +425,7 @@ As we mentioned, type aliases can act sort of like interfaces; however, there ar
 
 Almost all features of an `interface` are available in `type`, the key distinction is that a type cannot be re-opened to add new properties vs an interface which is always extendable.
 
+<div class='table-container'>
 <table class='full-width-table'>
   <tbody>
     <tr>
@@ -490,6 +491,7 @@ type Window = {
     </tr>
     </tbody>
 </table>
+</div>
 
 Because an interface more closely maps how JavaScript objects work [by being open to extension](https://wikipedia.org/wiki/Open/closed_principle), we recommend using an interface over a type alias when possible.
 

--- a/packages/typescriptlang-org/src/templates/markdown.scss
+++ b/packages/typescriptlang-org/src/templates/markdown.scss
@@ -118,7 +118,6 @@
 
   table.full-width-table {
     width: 100%;
-    display: table;
   }
 
   .blue-tick {

--- a/packages/typescriptlang-org/src/templates/markdown.scss
+++ b/packages/typescriptlang-org/src/templates/markdown.scss
@@ -116,8 +116,13 @@
     max-width: 100%;
   }
 
+  div.table-container {
+    overflow-x: auto;
+  }
+
   table.full-width-table {
     width: 100%;
+    display: table;
   }
 
   .blue-tick {


### PR DESCRIPTION
While I reading typescript handbook with tablet PC, I found that part of document is hidden in tablet PC screen.
![스크린샷 2023-05-28 오후 6 01 08](https://github.com/microsoft/TypeScript-Website/assets/86667412/99b915ab-0675-40c9-89f6-2dc3096316be)

To fix this I remove 'display: table' property from 'table.full-width-table'
![스크린샷 2023-05-28 오후 6 03 17](https://github.com/microsoft/TypeScript-Website/assets/86667412/f5bb2165-6e6b-4a62-bc8e-ffde531ef57e)

table.full-width-table selector is used in 2 pages. (one of them is deprecated)
and after removing property, it works well.