### PR TITLE
fix: Documentation Correction for readonly Usage in 'Const Type Parameters' Section

### DIFF
--- a/packages/documentation/copy/en/release-notes/TypeScript 5.0.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 5.0.md
@@ -351,7 +351,7 @@ When inferring the type of an object, TypeScript will usually choose a type that
 For example, in this case, the inferred type of `names` is `string[]`:
 
 ```ts
-type HasNames = { readonly names: string[] };
+type HasNames = { names: readonly string[] };
 function getNamesExactly<T extends HasNames>(arg: T): T["names"] {
     return arg.names;
 }


### PR DESCRIPTION
I noticed an inconsistency in the 'const Type Parameters' section of your documentation that I believe should be addressed. The current usage of `readonly` in this section seems to be misaligned with the context and explanation provided.

The original code provided in the documentation reads:

```typescript
type HasNames = { readonly names: string[] };
function getNamesExactly<T extends HasNames>(arg: T): T["names"] {
    return arg.names;
}
```

In the context of 'const Type Parameters' and the subsequent explanation, it would be more appropriate to use `readonly` to denote immutability. Therefore, I propose the following modification:

```typescript
type HasNames = { names: readonly string[] };
function getNamesExactly<T extends HasNames>(arg: T): T["names"] {
    return arg.names;
}
```

In this revised version, `readonly` is applied to the array itself indicating that its content should not be modified, which aligns more accurately with the contextual understanding and explanation provided in this section of the documentation.

Thank you for considering this change. I look forward to your feedback.
