### PR TITLE
fix: handbook anonymous functions example - inferred type not a bug

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -141,7 +141,7 @@ Here's an example:
 
 ```ts twoslash
 // @errors: 2551
-// No type annotations here, but TypeScript can spot the bug
+// No type annotations here, but TypeScript can infer the constant to be string[]
 const names = ["Alice", "Bob", "Eve"];
 
 // Contextual typing for function

--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -141,10 +141,9 @@ Here's an example:
 
 ```ts twoslash
 // @errors: 2551
-// No type annotations here, but TypeScript can infer the constant to be string[]
 const names = ["Alice", "Bob", "Eve"];
 
-// Contextual typing for function
+// Contextual typing for function - parameter s inferred to have type string
 names.forEach(function (s) {
   console.log(s.toUpperCase());
 });


### PR DESCRIPTION
Forgive me if I've misunderstood the context of the example somehow since I'm relatively new to TypeScript and this is my first ever PR to an open-source project. However, I could not find the "bug" the first comment was talking about in this example:

```ts
// No type annotations here, but TypeScript can spot the bug
const names = ["Alice", "Bob", "Eve"];
 
// Contextual typing for function
names.forEach(function (s) {
  console.log(s.toUpperCase());
});
 
// Contextual typing also applies to arrow functions
names.forEach((s) => {
  console.log(s.toUpperCase());
});
```

so I propose changing it to explain that the type is inferred (which fits the context of the previous examples).

```ts
// No type annotations here, but TypeScript can infer the constant to be string[]
const names = ["Alice", "Bob", "Eve"];
 
// Contextual typing for function
names.forEach(function (s) {
  console.log(s.toUpperCase());
});
 
// Contextual typing also applies to arrow functions
names.forEach((s) => {
  console.log(s.toUpperCase());
});
```

Thank you for consideration.