### PR TITLE
Fix accessibility issue for css variable highlight

### DIFF
--- a/packages/typescriptlang-org/lib/themes/typescript-beta-light.json
+++ b/packages/typescriptlang-org/lib/themes/typescript-beta-light.json
@@ -298,7 +298,7 @@
         "source.coffee.embedded"
       ],
       "settings": {
-        "foreground": "#ff0000"
+        "foreground": "#e50000"
       }
     },
     {


### PR DESCRIPTION
For #2840

We wasted a bunch of time testing this before I stumbled on the problem that there's some cache somewhere that duplicates this theme, such that changing it didn't actually work. Cleaning the repo and reinstalling/rebuilding/etc actually shows that changing this _does_ work.

This color upstream is https://github.com/shikijs/shiki/blob/main/packages/shiki/themes/light-plus.json#L294 (the same as what the accessibility team/tool say to use).