### PR TITLE
Remove tsconfig bases list, redundant to linked repo

### DIFF
--- a/packages/documentation/copy/en/project-config/tsconfig.json.md
+++ b/packages/documentation/copy/en/project-config/tsconfig.json.md
@@ -94,15 +94,6 @@ For example, if you were writing a project which uses Node.js version 12 and abo
 
 This lets your `tsconfig.json` focus on the unique choices for your project, and not all of the runtime mechanics. There are a few tsconfig bases already, and we're hoping the community can add more for different environments.
 
-- [Recommended](https://www.npmjs.com/package/@tsconfig/recommended)
-- [Node 10](https://www.npmjs.com/package/@tsconfig/node10)
-- [Node 12](https://www.npmjs.com/package/@tsconfig/node12)
-- [Node 14](https://www.npmjs.com/package/@tsconfig/node14)
-- [Node 16](https://www.npmjs.com/package/@tsconfig/node16)
-- [Deno](https://www.npmjs.com/package/@tsconfig/deno)
-- [React Native](https://www.npmjs.com/package/@tsconfig/react-native)
-- [Svelte](https://www.npmjs.com/package/@tsconfig/svelte)
-
 ## Details
 
 The `"compilerOptions"` property can be omitted, in which case the compiler's defaults are used. See our full list of supported [Compiler Options](/tsconfig).


### PR DESCRIPTION
Supersedes #2599.

We already link to https://github.com/tsconfig/bases which necessarily contains a list of all available bases.