### PR TITLE
Use correct initial line number for filename comment check.

### DIFF
--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -189,7 +189,7 @@ export const setupPlayground = (
   sandbox.monaco.languages.registerCodeLensProvider(sandbox.language, {
     provideCodeLenses: function (model, token) {
       // If you have @filename on the first line, don't show the implicit filename
-      const lenses = !showFileCodeLens && !model.getLineContent(0).startsWith("// @filename")
+      const lenses = !showFileCodeLens && !model.getLineContent(1).startsWith("// @filename")
         ? []
         : [
             {


### PR DESCRIPTION
If not, the playground will error out with

```
editor.main.js:3689  Uncaught Error: Illegal value for lineNumber

Error: Illegal value for lineNumber
    at TextModel.getLineContent (editor.main.js:131725:23)
    at Object.provideCodeLenses (index.ts:192:50)
    at editor.main.js:83778:65
    at Generator.next (<anonymous>)
    at index.js:30:71
    at new Promise (<anonymous>)
    at __awaiter (index.js:26:12)
    at editor.main.js:83775:60
    at Array.map (<anonymous>)
    at editor.main.js:83775:39
    at editor.main.js:3689:31
```