### PR TITLE
docs(include): `**` => `**/*`

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -222,7 +222,7 @@ export const defaultsForOptions = {
     "jspm_packages",
     "[`outDir`](#outDir)",
   ],
-  include: ["`[]` if [`files`](#files) is specified,", "`**` otherwise."],
+  include: ["`[]` if [`files`](#files) is specified,", "`**/* otherwise."],
   incremental: trueIf("composite"),
   jsxFactory: "React.createElement",
   locale: "Platform specific.",


### PR DESCRIPTION
Using `include: ['**']` throws:
![image](https://github.com/microsoft/TypeScript-Website/assets/28700378/fc80b114-e87b-47d8-9784-d30044bd4329)
Therefore, changed to `**/*`.