### PR TITLE
Fix 'Get Started' url in the footer

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/SiteFooter.tsx
+++ b/packages/typescriptlang-org/src/components/layout/SiteFooter.tsx
@@ -64,7 +64,7 @@ const popularPages = [
 const useTypeScriptLinks = [
   {
     title: "Get Started",
-    url: "/docs/home",
+    url: "/docs",
   },
   {
     title: "Download",


### PR DESCRIPTION
The 'Get Started' url points at the `/docs/home` address, which leads to an empty page. As there is no dedicated `Get Starter` page, the best option is to point to the home page of the documentation.

Current link: https://www.typescriptlang.org/docs/home
Updated link: https://www.typescriptlang.org/docs