### PR TITLE
Update hybrid esm package.json example

### DIFF
--- a/packages/documentation/copy/en/reference/ESM Support for Node.md
+++ b/packages/documentation/copy/en/reference/ESM Support for Node.md
@@ -237,7 +237,7 @@ If you need to point to a different location for your type declarations, you can
     },
 
     // Fall-back for older versions of TypeScript
-    "types": "./types/index.d.ts",
+    "types": "./types/index.d.cts",
 
     // CJS fall-back for older versions of Node.js
     "main": "./commonjs/index.cjs"


### PR DESCRIPTION
Change fall-back "types" field to point to the `.d.cts` file so Typescript correctly resolves the CommonJS types

addresses https://github.com/microsoft/TypeScript/issues/54620