### PR TITLE
Update README.md for src= syntax

### DIFF
--- a/packages/playground/README.md
+++ b/packages/playground/README.md
@@ -23,7 +23,7 @@ Automatic Type Acquisition is a feature which lives in the sandbox and not the p
 The Playground supports a set of query inputs from the URL. The hash is used to reflect the code:
 
 - `#code/PRA` - A base64 and zipped version of the code which should live in the editor
-- `#src/The%20code` - URLEncoded way to have the code for the editor
+- `#src=The%20code` - URLEncoded way to have the code for the editor
 - `#example/generic-functions` - Grab the code from an example with the id generic-functions
 
 Or to trigger some action by default:


### PR DESCRIPTION
The playground supports the old URI encoded `src=` syntax, not `src/`

https://github.com/microsoft/TypeScript-Website/blob/23dde940b881552762c58d272238959128d72cfe/packages/sandbox/src/getInitialCode.ts#L10-L13