### PR TITLE
Clarify moduleDetection tsconfig option

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/moduleDetection.md
+++ b/packages/tsconfig-reference/copy/en/options/moduleDetection.md
@@ -1,7 +1,10 @@
 ---
 display: "Module Detection"
-oneline: "Control what method is used to detect the whether a JS file is a module."
+oneline: "Specify what method is used to detect whether a file is a script or a module."
 ---
+
+This setting controls how TypeScript determines whether a file is a
+[script or a module](/docs/handbook/2/modules.html#how-javascript-modules-are-defined).
 
 There are three choices:
 


### PR DESCRIPTION
Readers might otherwise confuse "module" as referring to ES modules specifically since "type": "module" in package.json only refers to ES modules.

/cc @fatcerberus