### PR TITLE
copy/en/get-started: make `type/value` distinction

### DIFF
--- a/packages/documentation/copy/en/get-started/TS for JS Programmers.md
+++ b/packages/documentation/copy/en/get-started/TS for JS Programmers.md
@@ -128,7 +128,7 @@ With TypeScript, you can create complex types by combining simple ones. There ar
 
 ### Unions
 
-With a union, you can declare that a type could be one of many types. For example, you can describe a `boolean` type as being either `true` or `false`:
+With a union, you can declare that a type could be one of many types (and/or values). For example, you can describe a `boolean` type as being either `true` or `false`:
 
 ```ts twoslash
 type MyBool = true | false;


### PR DESCRIPTION
This change tries to make the distinction between a type and a value more explicit. Indeed, in the TS world, something such as `"a string"` could be well regarded as a type, but it is more naturally known as a value. Given that this piece of information is in a learners' section, I believe that the change is worth making as it could be confusing.