### PR TITLE
Disable blank GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,4 @@
+blank_issues_enabled: false
 contact_links:
   - name: TypeScript Compiler issues
     url: https://github.community/

--- a/.github/ISSUE_TEMPLATE/critical-issue.md
+++ b/.github/ISSUE_TEMPLATE/critical-issue.md
@@ -1,6 +1,6 @@
 ---
 name: Critical Issue
-about: Report a critical issue with the website
+about: Report a critical issue with the website (for non-critical issues we appreciate PRs)
 title: "CRITICAL: "
 ---
 <!--


### PR DESCRIPTION
As per #2804 non-critical issues currently aren't tracked.

This disables the:

>  Don’t see your issue here? Open a blank issue. 

on https://github.com/microsoft/TypeScript-Website/issues/new/choose