### PR TITLE
fix: Restore accidentally lost heading hierarchies

### DIFF
--- a/packages/documentation/copy/en/declaration-files/Do's and Don'ts.md
+++ b/packages/documentation/copy/en/declaration-files/Do's and Don'ts.md
@@ -7,7 +7,7 @@ oneline: "Recommendations for writing d.ts files"
 
 ## General Types
 
-## `Number`, `String`, `Boolean`, `Symbol` and `Object`
+### `Number`, `String`, `Boolean`, `Symbol` and `Object`
 
 ❌ **Don't** ever use the types `Number`, `String`, `Boolean`, `Symbol`, or `Object`
 These types refer to non-primitive boxed objects that are almost never used appropriately in JavaScript code.
@@ -26,12 +26,12 @@ function reverse(s: string): string;
 
 Instead of `Object`, use the non-primitive `object` type ([added in TypeScript 2.2](../release-notes/typescript-2-2.html#object-type)).
 
-## Generics
+### Generics
 
 ❌ **Don't** ever have a generic type which doesn't use its type parameter.
 See more details in [TypeScript FAQ page](https://github.com/Microsoft/TypeScript/wiki/FAQ#why-doesnt-type-inference-work-on-this-interface-interface-foot--).
 
-## any
+### any
 
 ❌ **Don't** use `any` as a type unless you are in the process of migrating a JavaScript project to TypeScript. The compiler _effectively_ treats `any` as "please turn off type checking for this thing". It is similar to putting an `@ts-ignore` comment around every usage of the variable. This can be very helpful when you are first migrating a JavaScript project to TypeScript as you can set the type for stuff you haven't migrated yet as `any`, but in a full TypeScript project you are disabling type checking for any parts of your program that use it.
 
@@ -41,7 +41,7 @@ In cases where you don't know what type you want to accept, or when you want to 
 
 ## Callback Types
 
-## Return Types of Callbacks
+### Return Types of Callbacks
 
 <!-- TODO: Reword; these examples make no sense in the context of a declaration file -->
 
@@ -72,7 +72,7 @@ function fn(x: () => void) {
 }
 ```
 
-## Optional Parameters in Callbacks
+### Optional Parameters in Callbacks
 
 ❌ **Don't** use optional parameters in callbacks unless you really mean it:
 
@@ -97,7 +97,7 @@ interface Fetcher {
 }
 ```
 
-## Overloads and Callbacks
+### Overloads and Callbacks
 
 ❌ **Don't** write separate overloads that differ only on callback arity:
 
@@ -125,7 +125,7 @@ Providing a shorter callback first allows incorrectly-typed functions to be pass
 
 ## Function Overloads
 
-## Ordering
+### Ordering
 
 ❌ **Don't** put more general overloads before more specific overloads:
 
@@ -154,7 +154,7 @@ var x = fn(myElem); // x: string, :)
 ❔ **Why:** TypeScript chooses the _first matching overload_ when resolving function calls.
 When an earlier overload is "more general" than a later one, the later one is effectively hidden and cannot be called.
 
-## Use Optional Parameters
+### Use Optional Parameters
 
 ❌ **Don't** write several overloads that differ only in trailing parameters:
 
@@ -203,7 +203,7 @@ var x: Example;
 x.diff("something", true ? undefined : "hour");
 ```
 
-## Use Union Types
+### Use Union Types
 
 ❌ **Don't** write overloads that differ by type in only one argument position:
 

--- a/packages/documentation/copy/en/declaration-files/Library Structures.md
+++ b/packages/documentation/copy/en/declaration-files/Library Structures.md
@@ -22,7 +22,7 @@ We'll give hints on how to identify structure both based on its _usage_ and its 
 Depending on the library's documentation and organization, one might be easier than the other.
 We recommend using whichever is more comfortable to you.
 
-## What should you look for?
+### What should you look for?
 
 Question to ask yourself while looking at a library you are trying to type.
 
@@ -34,9 +34,9 @@ Question to ask yourself while looking at a library you are trying to type.
 
    Does it add a global object? Does it use `require` or `import`/`export` statements?
 
-## Smaller samples for different types of libraries
+### Smaller samples for different types of libraries
 
-## Modular Libraries
+### Modular Libraries
 
 Almost every modern Node.js library falls into the module family.
 These type of libraries only work in a JS environment with a module loader.
@@ -71,7 +71,7 @@ define(..., ['someLib'], function(someLib) {
 
 As with global modules, you might see these examples in the documentation of [a UMD](#umd) module, so be sure to check the code or documentation.
 
-### Identifying a Module Library from Code
+#### Identifying a Module Library from Code
 
 Modular libraries will typically have at least some of the following:
 
@@ -83,7 +83,7 @@ They will rarely have:
 
 - Assignments to properties of `window` or `global`
 
-### Templates For Modules
+#### Templates For Modules
 
 There are four templates available for modules,
 [`module.d.ts`](/docs/handbook/declaration-files/templates/module-d-ts.html), [`module-class.d.ts`](/docs/handbook/declaration-files/templates/module-class-d-ts.html), [`module-function.d.ts`](/docs/handbook/declaration-files/templates/module-function-d-ts.html) and [`module-plugin.d.ts`](/docs/handbook/declaration-files/templates/module-plugin-d-ts.html).
@@ -113,7 +113,7 @@ const jest = require("jest");
 require("jest-matchers-files");
 ```
 
-## Global Libraries
+### Global Libraries
 
 A _global_ library is one that can be accessed from the global scope (i.e. without using any form of `import`).
 Many libraries simply expose one or more global variables for use.
@@ -135,7 +135,7 @@ Today, most popular globally-accessible libraries are actually written as UMD li
 UMD library documentation is hard to distinguish from global library documentation.
 Before writing a global declaration file, make sure the library isn't actually UMD.
 
-### Identifying a Global Library from Code
+#### Identifying a Global Library from Code
 
 Global library code is usually extremely simple.
 A global "Hello, world" library might look like this:
@@ -178,17 +178,17 @@ You _won't_ see:
 - Calls to `define(...)`
 - Documentation describing how to `require` or import the library
 
-### Examples of Global Libraries
+#### Examples of Global Libraries
 
 Because it's usually easy to turn a global library into a UMD library, very few popular libraries are still written in the global style.
 However, libraries that are small and require the DOM (or have _no_ dependencies) may still be global.
 
-### Global Library Template
+#### Global Library Template
 
 The template file [`global.d.ts`](/docs/handbook/declaration-files/templates/global-plugin-d-ts.html) defines an example library `myLib`.
 Be sure to read the ["Preventing Name Conflicts" footnote](#preventing-name-conflicts).
 
-## _UMD_
+### _UMD_
 
 A _UMD_ module is one that can _either_ be used as module (through an import), or as a global (when run in an environment without a module loader).
 Many popular libraries, such as [Moment.js](https://momentjs.com/), are written this way.
@@ -205,7 +205,7 @@ whereas in a vanilla browser environment you would write:
 console.log(moment.format());
 ```
 
-### Identifying a UMD library
+#### Identifying a UMD library
 
 [UMD modules](https://github.com/umdjs/umd) check for the existence of a module loader environment.
 This is an easy-to-spot pattern that looks something like this:
@@ -227,12 +227,12 @@ If you see tests for `typeof define`, `typeof window`, or `typeof module` in the
 Documentation for UMD libraries will also often demonstrate a "Using in Node.js" example showing `require`,
 and a "Using in the browser" example showing using a `<script>` tag to load the script.
 
-### Examples of UMD libraries
+#### Examples of UMD libraries
 
 Most popular libraries are now available as UMD packages.
 Examples include [jQuery](https://jquery.com/), [Moment.js](https://momentjs.com/), [lodash](https://lodash.com/), and many more.
 
-### Template
+#### Template
 
 Use the [`module-plugin.d.ts`](/docs/handbook/declaration-files/templates/module-plugin-d-ts.html) template.
 
@@ -241,7 +241,7 @@ Use the [`module-plugin.d.ts`](/docs/handbook/declaration-files/templates/module
 There are several kinds of dependencies your library might have.
 This section shows how to import them into the declaration file.
 
-## Dependencies on Global Libraries
+### Dependencies on Global Libraries
 
 If your library depends on a global library, use a `/// <reference types="..." />` directive:
 
@@ -251,7 +251,7 @@ If your library depends on a global library, use a `/// <reference types="..." /
 function getThing(): someLib.thing;
 ```
 
-## Dependencies on Modules
+### Dependencies on Modules
 
 If your library depends on a module, use an `import` statement:
 
@@ -261,9 +261,9 @@ import * as moment from "moment";
 function getThing(): moment;
 ```
 
-## Dependencies on UMD libraries
+### Dependencies on UMD libraries
 
-### From a Global Library
+#### From a Global Library
 
 If your global library depends on a UMD module, use a `/// <reference types` directive:
 
@@ -273,7 +273,7 @@ If your global library depends on a UMD module, use a `/// <reference types` dir
 function getThing(): moment;
 ```
 
-### From a Module or UMD Library
+#### From a Module or UMD Library
 
 If your module or UMD library depends on a UMD library, use an `import` statement:
 
@@ -285,7 +285,7 @@ Do _not_ use a `/// <reference` directive to declare a dependency to a UMD libra
 
 ## Footnotes
 
-## Preventing Name Conflicts
+### Preventing Name Conflicts
 
 Note that it's possible to define many types in the global scope when writing a global declaration file.
 We strongly discourage this as it leads to possible unresolvable name conflicts when many declaration files are in a project.
@@ -308,7 +308,7 @@ interface CatsKittySettings {}
 
 This guidance also ensures that the library can be transitioned to UMD without breaking declaration file users.
 
-## The Impact of ES6 on Module Call Signatures
+### The Impact of ES6 on Module Call Signatures
 
 Many popular libraries, such as Express, expose themselves as a callable function when imported.
 For example, the typical Express usage looks like this:

--- a/packages/documentation/copy/en/declaration-files/templates/global-plugin.d.ts.md
+++ b/packages/documentation/copy/en/declaration-files/templates/global-plugin.d.ts.md
@@ -151,7 +151,7 @@ Use the [`global-modifying-module.d.ts`](/docs/handbook/declaration-files/templa
 There are several kinds of dependencies your library might have.
 This section shows how to import them into the declaration file.
 
-## Dependencies on Global Libraries
+### Dependencies on Global Libraries
 
 If your library depends on a global library, use a `/// <reference types="..." />` directive:
 
@@ -161,7 +161,7 @@ If your library depends on a global library, use a `/// <reference types="..." /
 function getThing(): someLib.thing;
 ```
 
-## Dependencies on Modules
+### Dependencies on Modules
 
 If your library depends on a module, use an `import` statement:
 
@@ -171,9 +171,9 @@ import * as moment from "moment";
 function getThing(): moment;
 ```
 
-## Dependencies on UMD libraries
+### Dependencies on UMD libraries
 
-### From a Global Library
+#### From a Global Library
 
 If your global library depends on a UMD module, use a `/// <reference types` directive:
 
@@ -183,7 +183,7 @@ If your global library depends on a UMD module, use a `/// <reference types` dir
 function getThing(): moment;
 ```
 
-### From a Module or UMD Library
+#### From a Module or UMD Library
 
 If your module or UMD library depends on a UMD library, use an `import` statement:
 
@@ -195,7 +195,7 @@ Do _not_ use a `/// <reference` directive to declare a dependency to a UMD libra
 
 ## Footnotes
 
-## Preventing Name Conflicts
+### Preventing Name Conflicts
 
 Note that it's possible to define many types in the global scope when writing a global declaration file.
 We strongly discourage this as it leads to possible unresolvable name conflicts when many declaration files are in a project.
@@ -218,13 +218,13 @@ interface CatsKittySettings {}
 
 This guidance also ensures that the library can be transitioned to UMD without breaking declaration file users.
 
-## The Impact of ES6 on Module Plugins
+### The Impact of ES6 on Module Plugins
 
 Some plugins add or modify top-level exports on existing modules.
 While this is legal in CommonJS and other loaders, ES6 modules are considered immutable and this pattern will not be possible.
 Because TypeScript is loader-agnostic, there is no compile-time enforcement of this policy, but developers intending to transition to an ES6 module loader should be aware of this.
 
-## The Impact of ES6 on Module Call Signatures
+### The Impact of ES6 on Module Call Signatures
 
 Many popular libraries, such as Express, expose themselves as a callable function when imported.
 For example, the typical Express usage looks like this:
@@ -239,7 +239,7 @@ the top-level module object is _never_ callable.
 The most common solution here is to define a `default` export for a callable/constructable object;
 some module loader shims will automatically detect this situation and replace the top-level object with the `default` export.
 
-## Library file layout
+### Library file layout
 
 The layout of your declaration files should mirror the layout of the library.
 

--- a/packages/documentation/copy/en/get-started/TS for Functional Programmers.md
+++ b/packages/documentation/copy/en/get-started/TS for Functional Programmers.md
@@ -42,7 +42,7 @@ TypeScript uses postfix types, like so: `x: string` instead of `string x`.
 
 ## Concepts not in Haskell
 
-## Built-in types
+### Built-in types
 
 JavaScript defines 8 built-in types:
 
@@ -70,7 +70,7 @@ TypeScript has corresponding primitive types for the built-in types:
 - `undefined`
 - `object`
 
-### Other important TypeScript types
+#### Other important TypeScript types
 
 | Type           | Explanation                                                                     |
 | -------------- | ------------------------------------------------------------------------------- |
@@ -102,7 +102,7 @@ Notes:
 
 3. `[T, T]` is a subtype of `T[]`. This is different than Haskell, where tuples are not related to lists.
 
-### Boxed types
+#### Boxed types
 
 JavaScript has boxed equivalents of primitive types that contain the
 methods that programmers associate with those types. TypeScript
@@ -119,7 +119,7 @@ Number.prototype.toExponential.call(1);
 Note that calling a method on a numeric literal requires it to be in
 parentheses to aid the parser.
 
-## Gradual typing
+### Gradual typing
 
 TypeScript uses the type `any` whenever it can't tell what the type of
 an expression should be. Compared to `Dynamic`, calling `any` a type
@@ -151,7 +151,7 @@ let sepsis = anys[0] + anys[1]; // this could mean anything
 To get an error when TypeScript produces an `any`, use
 `"noImplicitAny": true`, or `"strict": true` in `tsconfig.json`.
 
-## Structural typing
+### Structural typing
 
 Structural typing is a familiar concept to most functional
 programmers, although Haskell and most MLs are not
@@ -191,7 +191,7 @@ let two: Two = x;
 two = new Three();
 ```
 
-## Unions
+### Unions
 
 In TypeScript, union types are untagged. In other words, they are not
 discriminated unions like `data` in Haskell. However, you can often
@@ -242,7 +242,7 @@ The following types have built-in predicates:
 Note that functions and arrays are objects at runtime, but have their
 own predicates.
 
-### Intersections
+#### Intersections
 
 In addition to unions, TypeScript also has intersections:
 
@@ -255,7 +255,7 @@ type Conflicting = { a: number } & { a: string };
 written as one object literal type. Intersection and union are
 recursive in case of conflicts, so `Conflicting.a: number & string`.
 
-## Unit types
+### Unit types
 
 Unit types are subtypes of primitive types that contain exactly one
 primitive value. For example, the string `"foo"` has the type
@@ -300,7 +300,7 @@ pad("hi", 10, s);
 
 ## Concepts similar to Haskell
 
-## Contextual typing
+### Contextual typing
 
 TypeScript has some obvious places where it can infer types, like
 variable declarations:
@@ -357,7 +357,7 @@ properties you'd have in a real program.
 Altogether, this feature can make TypeScript's inference look a bit
 like a unifying type inference engine, but it is not.
 
-## Type aliases
+### Type aliases
 
 Type aliases are mere aliases, just like `type` in Haskell. The
 compiler will attempt to use the alias name wherever it was used in
@@ -379,7 +379,7 @@ thinks it has a property named `__compileTimeOnly` that doesn't
 actually exist. This means that `FString` can still be assigned to
 `string`, but not the other way round.
 
-## Discriminated Unions
+### Discriminated Unions
 
 The closest equivalent to `data` is a union of types with discriminant
 properties, normally called discriminated unions in TypeScript:
@@ -437,7 +437,7 @@ function height(s: Shape) {
 }
 ```
 
-## Type Parameters
+### Type Parameters
 
 Like most C-descended languages, TypeScript requires declaration of
 type parameters:
@@ -477,7 +477,7 @@ In the first `length`, T is not necessary; notice that it's only
 referenced once, so it's not being used to constrain the type of the
 return value or other parameters.
 
-### Higher-kinded types
+#### Higher-kinded types
 
 TypeScript does not have higher kinded types, so the following is not legal:
 
@@ -485,7 +485,7 @@ TypeScript does not have higher kinded types, so the following is not legal:
 function length<T extends ArrayLike<unknown>, U>(m: T<U>) {}
 ```
 
-### Point-free programming
+#### Point-free programming
 
 Point-free programming &mdash; heavy use of currying and function
 composition &mdash; is possible in JavaScript, but can be verbose.
@@ -494,7 +494,7 @@ you'll end up specifying type parameters instead of value parameters. The
 result is so verbose that it's usually better to avoid point-free
 programming.
 
-## Module system
+### Module system
 
 JavaScript's modern module syntax is a bit like Haskell's, except that
 any file with `import` or `export` is implicitly a module:
@@ -533,7 +533,7 @@ function g() { }
 The latter style is more common but both are allowed, even in the same
 file.
 
-## `readonly` and `const`
+### `readonly` and `const`
 
 In JavaScript, mutability is the default, although it allows variable
 declarations with `const` to declare that the _reference_ is
@@ -589,7 +589,7 @@ a[0] = 101; // error
 However, none of these options are the default, so they are not
 consistently used in TypeScript code.
 
-## Next Steps
+### Next Steps
 
 This doc is a high level overview of the syntax and types you would use in everyday code. From here you should:
 

--- a/packages/documentation/copy/en/handbook-v1/Classes.md
+++ b/packages/documentation/copy/en/handbook-v1/Classes.md
@@ -132,7 +132,7 @@ Tommy the Palomino moved 34m.
 
 ## Public, private, and protected modifiers
 
-## Public by default
+### Public by default
 
 In our examples, we've been able to freely access the members that we declared throughout our programs.
 If you're familiar with classes in other languages, you may have noticed in the above examples we haven't had to use the word `public` to accomplish this; for instance, C# requires that each member be explicitly labeled `public` to be visible.
@@ -155,7 +155,7 @@ class Animal {
 }
 ```
 
-## ECMAScript Private Fields
+### ECMAScript Private Fields
 
 With TypeScript 3.8, TypeScript supports the new JavaScript syntax for private fields:
 
@@ -174,7 +174,7 @@ new Animal("Cat").#name;
 This syntax is built into the JavaScript runtime and can have better guarantees about the isolation of each private field.
 Right now, the best documentation for these private fields is in the TypeScript 3.8 [release notes](https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/#ecmascript-private-fields).
 
-## Understanding TypeScript's `private`
+### Understanding TypeScript's `private`
 
 TypeScript also has its own way to declare a member as being marked `private`, it cannot be accessed from outside of its containing class. For example:
 
@@ -237,7 +237,7 @@ Because `Animal` and `Rhino` share the `private` side of their shape from the sa
 When we try to assign from an `Employee` to `Animal` we get an error that these types are not compatible.
 Even though `Employee` also has a `private` member called `name`, it's not the one we declared in `Animal`.
 
-## Understanding `protected`
+### Understanding `protected`
 
 The `protected` modifier acts much like the `private` modifier with the exception that members declared `protected` can also be accessed within deriving classes. For example,
 

--- a/packages/documentation/copy/en/handbook-v1/Functions.md
+++ b/packages/documentation/copy/en/handbook-v1/Functions.md
@@ -47,7 +47,7 @@ function addToZ(x, y) {
 
 ## Function Types
 
-## Typing the function
+### Typing the function
 
 Let's add types to our simple examples from earlier:
 
@@ -64,7 +64,7 @@ let myAdd = function (x: number, y: number): number {
 We can add types to each of the parameters and then to the function itself to add a return type.
 TypeScript can figure the return type out by looking at the return statements, so we can also optionally leave this off in many cases.
 
-## Writing the function type
+### Writing the function type
 
 Now that we've typed the function, let's write the full type of the function out by looking at each piece of the function type.
 
@@ -102,7 +102,7 @@ Of note, only the parameters and the return type make up the function type.
 Captured variables are not reflected in the type.
 In effect, captured variables are part of the "hidden state" of any function and do not make up its API.
 
-## Inferring the types
+### Inferring the types
 
 In playing with the example, you may notice that the TypeScript compiler can figure out the type even if you only have types on one side of the equation:
 
@@ -211,7 +211,7 @@ let result3 = buildName("Bob", "Adams"); // okay and returns "Bob Adams"
 let result4 = buildName(undefined, "Adams"); // okay and returns "Will Adams"
 ```
 
-## Rest Parameters
+### Rest Parameters
 
 Required, optional, and default parameters all have one thing in common: they talk about one parameter at a time.
 Sometimes, you want to work with multiple parameters as a group, or you may not know how many parameters a function will ultimately take.
@@ -250,7 +250,7 @@ Fortunately, TypeScript lets you catch incorrect uses of `this` with a couple of
 If you need to learn how `this` works in JavaScript, though, first read Yehuda Katz's [Understanding JavaScript Function Invocation and "this"](http://yehudakatz.com/2011/08/11/understanding-javascript-function-invocation-and-this/).
 Yehuda's article explains the inner workings of `this` very well, so we'll just cover the basics here.
 
-## `this` and arrow functions
+### `this` and arrow functions
 
 In JavaScript, `this` is a variable that's set when a function is called.
 This makes it a very powerful and flexible feature, but it comes at the cost of always having to know about the context that a function is executing in.
@@ -316,7 +316,7 @@ alert("card: " + pickedCard.card + " of " + pickedCard.suit);
 Even better, TypeScript will warn you when you make this mistake if you pass the [`noImplicitThis`](/tsconfig#noImplicitThis) flag to the compiler.
 It will point out that `this` in `this.suits[pickedSuit]` is of type `any`.
 
-## `this` parameters
+### `this` parameters
 
 Unfortunately, the type of `this.suits[pickedSuit]` is still `any`.
 That's because `this` comes from the function expression inside the object literal.
@@ -366,7 +366,7 @@ alert("card: " + pickedCard.card + " of " + pickedCard.suit);
 Now TypeScript knows that `createCardPicker` expects to be called on a `Deck` object.
 That means that `this` is of type `Deck` now, not `any`, so [`noImplicitThis`](/tsconfig#noImplicitThis) will not cause any errors.
 
-### `this` parameters in callbacks
+#### `this` parameters in callbacks
 
 You can also run into errors with `this` in callbacks, when you pass functions to a library that will later call them.
 Because the library that calls your callback will call it like a normal function, `this` will be `undefined`.

--- a/packages/documentation/copy/en/handbook-v1/Generics.md
+++ b/packages/documentation/copy/en/handbook-v1/Generics.md
@@ -315,7 +315,7 @@ function loggingIdentity<T extends Lengthwise>(arg: T): T {
 loggingIdentity({ length: 10, value: 3 });
 ```
 
-## Using Type Parameters in Generic Constraints
+### Using Type Parameters in Generic Constraints
 
 You can declare a type parameter that is constrained by another type parameter.
 For example, here we'd like to get a property from an object given its name.
@@ -333,7 +333,7 @@ getProperty(x, "a");
 getProperty(x, "m");
 ```
 
-## Using Class Types in Generics
+### Using Class Types in Generics
 
 When creating factories in TypeScript using generics, it is necessary to refer to class types by their constructor functions. For example,
 

--- a/packages/documentation/copy/en/handbook-v1/Unions and Intersections.md
+++ b/packages/documentation/copy/en/handbook-v1/Unions and Intersections.md
@@ -75,7 +75,7 @@ let indentedString = padLeft("Hello world", true);
 A union type describes a value that can be one of several types.
 We use the vertical bar (`|`) to separate each type, so `number | string | boolean` is the type of a value that can be a `number`, a `string`, or a `boolean`.
 
-## Unions with Common Fields
+### Unions with Common Fields
 
 If we have a value that is a union type, we can only access members that are common to all types in the union.
 
@@ -107,7 +107,7 @@ In this example, `Bird` has a member named `fly`.
 We can't be sure whether a variable typed as `Bird | Fish` has a `fly` method.
 If the variable is really a `Fish` at runtime, then calling `pet.fly()` will fail.
 
-## Discriminating Unions
+### Discriminating Unions
 
 A common technique for working with unions is to have a single field which uses literal types which you can use to let TypeScript narrow down the possible current type. For example, we're going to create a union of three types which have a single shared field.
 
@@ -259,7 +259,7 @@ function logger(state: NetworkState): string {
 }
 ```
 
-## Union Exhaustiveness checking
+### Union Exhaustiveness checking
 
 We would like the compiler to tell us when we don't cover all variants of the discriminated union.
 For example, if we add `NetworkFromCachedState` to `NetworkState`, we need to update `logger` as well:

--- a/packages/documentation/copy/en/project-config/Project References.md
+++ b/packages/documentation/copy/en/project-config/Project References.md
@@ -146,7 +146,7 @@ Running `tsc --build` (`tsc -b` for short) will do the following:
 You can provide `tsc -b` with multiple config file paths (e.g. `tsc -b src test`).
 Just like `tsc -p`, specifying the config file name itself is unnecessary if it's named `tsconfig.json`.
 
-## `tsc -b` Commandline
+### `tsc -b` Commandline
 
 You can specify any number of config files:
 
@@ -191,7 +191,7 @@ If your solution is like this, you can continue to use `msbuild` with `tsc -p` a
 
 ## Guidance
 
-## Overall Structure
+### Overall Structure
 
 With more `tsconfig.json` files, you'll usually want to use [Configuration file inheritance](/docs/handbook/tsconfig-json.html) to centralize your common compiler options.
 This way you can change a setting in one file rather than having to edit multiple files.
@@ -202,20 +202,20 @@ This presents a simple entry point; e.g. in the TypeScript repo we simply run `t
 
 You can see these patterns in the TypeScript repo - see `src/tsconfig_base.json`, `src/tsconfig.json`, and `src/tsc/tsconfig.json` as key examples.
 
-## Structuring for relative modules
+### Structuring for relative modules
 
 In general, not much is needed to transition a repo using relative modules.
 Simply place a `tsconfig.json` file in each subdirectory of a given parent folder, and add `reference`s to these config files to match the intended layering of the program.
 You will need to either set the [`outDir`](/tsconfig#outDir) to an explicit subfolder of the output folder, or set the [`rootDir`](/tsconfig#rootDir) to the common root of all project folders.
 
-## Structuring for outFiles
+### Structuring for outFiles
 
 Layout for compilations using [`outFile`](/tsconfig#outFile) is more flexible because relative paths don't matter as much.
 One thing to keep in mind is that you'll generally want to not use `prepend` until the "last" project - this will improve build times and reduce the amount of I/O needed in any given build.
 The TypeScript repo itself is a good reference here - we have some "library" projects and some "endpoint" projects; "endpoint" projects are kept as small as possible and pull in only the libraries they need.
 
 <!--
-## Structuring for monorepos
+### Structuring for monorepos
 
 TODO: Experiment more and figure this out. Rush and Lerna seem to have different models that imply different things on our end
 -->

--- a/packages/documentation/copy/en/reference/Declaration Merging.md
+++ b/packages/documentation/copy/en/reference/Declaration Merging.md
@@ -189,7 +189,7 @@ Namespaces are flexible enough to also merge with other types of declarations.
 To do so, the namespace declaration must follow the declaration it will merge with. The resulting declaration has properties of both declaration types.
 TypeScript uses this capability to model some of the patterns in JavaScript as well as other programming languages.
 
-## Merging Namespaces with Classes
+### Merging Namespaces with Classes
 
 This gives the user a way of describing inner classes.
 
@@ -306,7 +306,7 @@ However, there are two limitations to keep in mind:
 1. You can't declare new top-level declarations in the augmentation -- just patches to existing declarations.
 2. Default exports also cannot be augmented, only named exports (since you need to augment an export by its exported name, and `default` is a reserved word - see [#14080](https://github.com/Microsoft/TypeScript/issues/14080) for details)
 
-## Global augmentation
+### Global augmentation
 
 You can also add declarations to the global scope from inside a module:
 

--- a/packages/documentation/copy/en/reference/JSX.md
+++ b/packages/documentation/copy/en/reference/JSX.md
@@ -70,7 +70,7 @@ This is important for two reasons:
 TypeScript uses the [same convention that React does](http://facebook.github.io/react/docs/jsx-in-depth.html#html-tags-vs.-react-components) for distinguishing between these.
 An intrinsic element always begins with a lowercase letter, and a value-based element always begins with an uppercase letter.
 
-## Intrinsic elements
+### Intrinsic elements
 
 Intrinsic elements are looked up on the special interface `JSX.IntrinsicElements`.
 By default, if this interface is not specified, then anything goes and intrinsic elements will not be type checked.
@@ -100,7 +100,7 @@ declare namespace JSX {
 }
 ```
 
-## Value-based elements
+### Value-based elements
 
 Value-based elements are simply looked up by identifiers that are in scope.
 
@@ -118,7 +118,7 @@ There are two ways to define a value-based element:
 
 Because these two types of value-based elements are indistinguishable from each other in a JSX expression, first TS tries to resolve the expression as a Function Component using overload resolution. If the process succeeds, then TS finishes resolving the expression to its declaration. If the value fails to resolve as a Function Component, TS will then try to resolve it as a class component. If that fails, TS will report an error.
 
-### Function Component
+#### Function Component
 
 As the name suggests, the component is defined as a JavaScript function where its first argument is a `props` object.
 TS enforces that its return type must be assignable to `JSX.Element`.
@@ -172,7 +172,7 @@ function MainButton(prop: ClickableProps): JSX.Element {
 
 > Note: Function Components were formerly known as Stateless Function Components (SFC). As Function Components can no longer be considered stateless in recent versions of react, the type `SFC` and its alias `StatelessComponent` were deprecated.
 
-### Class Component
+#### Class Component
 
 It is possible to define the type of a class component.
 However, to do so it is best to understand two new terms: the _element class type_ and the _element instance type_.
@@ -237,7 +237,7 @@ function NotAValidFactoryFunction() {
 <NotAValidFactoryFunction />; // error
 ```
 
-## Attribute type checking
+### Attribute type checking
 
 The first step to type checking attributes is to determine the _element attributes type_.
 This is slightly different between intrinsic and value-based elements.
@@ -312,7 +312,7 @@ const badProps = {};
 <foo {...badProps} />; // error
 ```
 
-## Children Type Checking
+### Children Type Checking
 
 In TypeScript 2.3, TS introduced type checking of _children_. _children_ is a special property in an _element attributes type_ where child *JSXExpression*s are taken to be inserted into the attributes.
 Similar to how TS uses `JSX.ElementAttributesProperty` to determine the name of _props_, TS uses `JSX.ElementChildrenAttribute` to determine the name of _children_ within those props.

--- a/packages/documentation/copy/en/reference/Modules.md
+++ b/packages/documentation/copy/en/reference/Modules.md
@@ -22,7 +22,7 @@ Conversely, a file without any top-level `import` or `export` declarations is tr
 
 ## Export
 
-## Exporting a declaration
+### Exporting a declaration
 
 Any declaration (such as a variable, function, class, type alias, or interface) can be exported by adding the `export` keyword.
 
@@ -48,7 +48,7 @@ export class ZipCodeValidator implements StringValidator {
 }
 ```
 
-## Export statements
+### Export statements
 
 Export statements are handy when exports need to be renamed for consumers, so the above example can be written as:
 
@@ -62,7 +62,7 @@ export { ZipCodeValidator };
 export { ZipCodeValidator as mainValidator };
 ```
 
-## Re-exports
+### Re-exports
 
 Often modules extend other modules, and partially expose some of their features.
 A re-export does not import it locally, or introduce a local variable.
@@ -98,7 +98,7 @@ export * from "./ParseIntBasedZipCodeValidator"; //  exports the 'ParseIntBasedZ
 Importing is just about as easy as exporting from a module.
 Importing an exported declaration is done through using one of the `import` forms below:
 
-## Import a single export from a module
+### Import a single export from a module
 
 ```ts
 import { ZipCodeValidator } from "./ZipCodeValidator";
@@ -113,14 +113,14 @@ import { ZipCodeValidator as ZCV } from "./ZipCodeValidator";
 let myValidator = new ZCV();
 ```
 
-## Import the entire module into a single variable, and use it to access the module exports
+### Import the entire module into a single variable, and use it to access the module exports
 
 ```ts
 import * as validator from "./ZipCodeValidator";
 let myValidator = new validator.ZipCodeValidator();
 ```
 
-## Import a module for side-effects only
+### Import a module for side-effects only
 
 Though not recommended practice, some modules set up some global state that can be used by other modules.
 These modules may not have any exports, or the consumer is not interested in any of their exports.
@@ -130,7 +130,7 @@ To import these modules, use:
 import "./my-module.js";
 ```
 
-## Importing Types
+### Importing Types
 
 Prior to TypeScript 3.8, you can import a type using `import`.
 With TypeScript 3.8, you can import a type using the `import` statement, or using `import type`.
@@ -527,7 +527,7 @@ Typically, these are defined in `.d.ts` files.
 If you're familiar with C/C++, you can think of these as `.h` files.
 Let's look at a few examples.
 
-## Ambient Modules
+### Ambient Modules
 
 In Node.js, most tasks are accomplished by loading one or more modules.
 We could define each module in its own `.d.ts` file with top-level export declarations, but it's more convenient to write them as one larger `.d.ts` file.
@@ -566,7 +566,7 @@ import * as URL from "url";
 let myUrl = URL.parse("https://www.typescriptlang.org");
 ```
 
-### Shorthand ambient modules
+#### Shorthand ambient modules
 
 If you don't want to take the time to write out declarations before using a new module, you can use a shorthand declaration to get started quickly.
 
@@ -583,7 +583,7 @@ import x, { y } from "hot-new-module";
 x(y);
 ```
 
-### Wildcard module declarations
+#### Wildcard module declarations
 
 Some module loaders such as [SystemJS](https://github.com/systemjs/systemjs/blob/master/docs/module-types.md)
 and [AMD](https://github.com/amdjs/amdjs-api/blob/master/LoaderPlugins.md) allow non-JavaScript content to be imported.
@@ -610,7 +610,7 @@ import data from "json!http://example.com/data.json";
 console.log(data, fileContent);
 ```
 
-### UMD modules
+#### UMD modules
 
 Some libraries are designed to be used in many module loaders, or with no module loading (global variables).
 These are known as [UMD](https://github.com/umdjs/umd) modules.
@@ -641,7 +641,7 @@ mathLib.isPrime(2);
 
 ## Guidance for structuring modules
 
-## Export as close to top-level as possible
+### Export as close to top-level as possible
 
 Consumers of your module should have as little friction as possible when using things that you export.
 Adding too many levels of nesting tends to be cumbersome, so think carefully about how you want to structure things.
@@ -653,14 +653,14 @@ This can quickly become a pain point for users, and is usually unnecessary.
 Static methods on an exported class have a similar problem - the class itself adds a layer of nesting.
 Unless it increases expressivity or intent in a clearly useful way, consider simply exporting a helper function.
 
-### If you're only exporting a single `class` or `function`, use `export default`
+#### If you're only exporting a single `class` or `function`, use `export default`
 
 Just as "exporting near the top-level" reduces friction on your module's consumers, so does introducing a default export.
 If a module's primary purpose is to house one specific export, then you should consider exporting it as a default export.
 This makes both importing and actually using the import a little easier.
 For example:
 
-#### MyClass.ts
+##### MyClass.ts
 
 ```ts
 export default class SomeType {
@@ -668,7 +668,7 @@ export default class SomeType {
 }
 ```
 
-#### MyFunc.ts
+##### MyFunc.ts
 
 ```ts
 export default function getThing() {
@@ -676,7 +676,7 @@ export default function getThing() {
 }
 ```
 
-#### Consumer.ts
+##### Consumer.ts
 
 ```ts
 import t from "./MyClass";
@@ -687,9 +687,9 @@ console.log(f());
 
 This is optimal for consumers. They can name your type whatever they want (`t` in this case) and don't have to do any excessive dotting to find your objects.
 
-### If you're exporting multiple objects, put them all at top-level
+#### If you're exporting multiple objects, put them all at top-level
 
-#### MyThings.ts
+##### MyThings.ts
 
 ```ts
 export class SomeType {
@@ -702,9 +702,9 @@ export function someFunc() {
 
 Conversely when importing:
 
-### Explicitly list imported names
+#### Explicitly list imported names
 
-#### Consumer.ts
+##### Consumer.ts
 
 ```ts
 import { SomeType, someFunc } from "./MyThings";
@@ -712,9 +712,9 @@ let x = new SomeType();
 let y = someFunc();
 ```
 
-### Use the namespace import pattern if you're importing a large number of things
+#### Use the namespace import pattern if you're importing a large number of things
 
-#### MyLargeModule.ts
+##### MyLargeModule.ts
 
 ```ts
 export class Dog { ... }
@@ -723,14 +723,14 @@ export class Tree { ... }
 export class Flower { ... }
 ```
 
-#### Consumer.ts
+##### Consumer.ts
 
 ```ts
 import * as myLargeModule from "./MyLargeModule.ts";
 let x = new myLargeModule.Dog();
 ```
 
-## Re-export to extend
+### Re-export to extend
 
 Often you will need to extend functionality on a module.
 A common JS pattern is to augment the original object with _extensions_, similar to how JQuery extensions work.
@@ -899,7 +899,7 @@ let c = new Calculator(2);
 test(c, "001+010="); // prints 3
 ```
 
-## Do not use namespaces in modules
+### Do not use namespaces in modules
 
 When first moving to a module-based organization, a common tendency is to wrap exports in an additional layer of namespaces.
 Modules have their own scope, and only exported declarations are visible from outside the module.
@@ -920,7 +920,7 @@ From the consumption side, the consumer of any given module gets to pick the nam
 
 > For more discussion about modules and namespaces see [Namespaces and Modules](/docs/handbook/namespaces-and-modules.html).
 
-## Red Flags
+### Red Flags
 
 All of the following are red flags for module structuring. Double-check that you're not trying to namespace your external modules if any of these apply to your files:
 

--- a/packages/documentation/copy/en/reference/Namespaces and Modules.md
+++ b/packages/documentation/copy/en/reference/Namespaces and Modules.md
@@ -40,7 +40,7 @@ Just like all global namespace pollution, it can be hard to identify component d
 
 In this section we'll describe various common pitfalls in using namespaces and modules, and how to avoid them.
 
-## `/// <reference>`-ing a module
+### `/// <reference>`-ing a module
 
 A common mistake is to try to use the `/// <reference ... />` syntax to refer to a module file, rather than using an `import` statement.
 To understand the distinction, we first need to understand how the compiler can locate the type information for a module based on the path of an `import` (e.g. the `...` in `import x from "...";`, `import x = require("...");`, etc.) path.
@@ -68,7 +68,7 @@ Recall that these need to be declared in a `.d.ts` file.
 The reference tag here allows us to locate the declaration file that contains the declaration for the ambient module.
 This is how the `node.d.ts` file that several of the TypeScript samples use is consumed.
 
-## Needless Namespacing
+### Needless Namespacing
 
 If you're converting a program from namespaces to modules, it can be easy to end up with a file that looks like this:
 
@@ -121,7 +121,7 @@ Here's a revised example:
   let t = new shapes.Triangle();
   ```
 
-## Trade-offs of Modules
+### Trade-offs of Modules
 
 Just as there is a one-to-one correspondence between JS files and modules, TypeScript has a one-to-one correspondence between module source files and their emitted JS files.
 One effect of this is that it's not possible to concatenate multiple module source files depending on the module system you target.

--- a/packages/documentation/copy/en/reference/Symbols.md
+++ b/packages/documentation/copy/en/reference/Symbols.md
@@ -91,53 +91,53 @@ Built-in symbols are used to represent internal language behaviors.
 
 Here is a list of well-known symbols:
 
-## `Symbol.asyncIterator`
+### `Symbol.asyncIterator`
 
 A method that returns async iterator for an object, compatible to be used with for await..of loop.
 
-## `Symbol.hasInstance`
+### `Symbol.hasInstance`
 
 A method that determines if a constructor object recognizes an object as one of the constructor’s instances. Called by the semantics of the instanceof operator.
 
-## `Symbol.isConcatSpreadable`
+### `Symbol.isConcatSpreadable`
 
 A Boolean value indicating that an object should be flattened to its array elements by Array.prototype.concat.
 
-## `Symbol.iterator`
+### `Symbol.iterator`
 
 A method that returns the default iterator for an object. Called by the semantics of the for-of statement.
 
-## `Symbol.match`
+### `Symbol.match`
 
 A regular expression method that matches the regular expression against a string. Called by the `String.prototype.match` method.
 
-## `Symbol.replace`
+### `Symbol.replace`
 
 A regular expression method that replaces matched substrings of a string. Called by the `String.prototype.replace` method.
 
-## `Symbol.search`
+### `Symbol.search`
 
 A regular expression method that returns the index within a string that matches the regular expression. Called by the `String.prototype.search` method.
 
-## `Symbol.species`
+### `Symbol.species`
 
 A function valued property that is the constructor function that is used to create derived objects.
 
-## `Symbol.split`
+### `Symbol.split`
 
 A regular expression method that splits a string at the indices that match the regular expression.
 Called by the `String.prototype.split` method.
 
-## `Symbol.toPrimitive`
+### `Symbol.toPrimitive`
 
 A method that converts an object to a corresponding primitive value.
 Called by the `ToPrimitive` abstract operation.
 
-## `Symbol.toStringTag`
+### `Symbol.toStringTag`
 
 A String value that is used in the creation of the default string description of an object.
 Called by the built-in method `Object.prototype.toString`.
 
-## `Symbol.unscopables`
+### `Symbol.unscopables`
 
 An Object whose own property names are property names that are excluded from the 'with' environment bindings of the associated objects.

--- a/packages/documentation/copy/en/reference/Type Compatibility.md
+++ b/packages/documentation/copy/en/reference/Type Compatibility.md
@@ -127,7 +127,7 @@ y = x; // Error, because x() lacks a location property
 
 The type system enforces that the source function's return type be a subtype of the target type's return type.
 
-## Function Parameter Bivariance
+### Function Parameter Bivariance
 
 When comparing the types of function parameters, assignment succeeds if either the source parameter is assignable to the target parameter, or vice versa.
 This is unsound because a caller might end up being given a function that takes a more specialized type, but invokes the function with a less specialized type.
@@ -170,7 +170,7 @@ listenEvent(EventType.Mouse, (e: number) => console.log(e));
 
 You can have TypeScript raise errors when this happens via the compiler flag [`strictFunctionTypes`](/tsconfig#strictFunctionTypes).
 
-## Optional Parameters and Rest Parameters
+### Optional Parameters and Rest Parameters
 
 When comparing functions for compatibility, optional and required parameters are interchangeable.
 Extra optional parameters of the source type are not an error, and optional parameters of the target type without corresponding parameters in the source type are not an error.
@@ -193,7 +193,7 @@ invokeLater([1, 2], (x, y) => console.log(x + ", " + y));
 invokeLater([1, 2], (x?, y?) => console.log(x + ", " + y));
 ```
 
-## Functions with overloads
+### Functions with overloads
 
 When a function has overloads, each overload in the target type must be matched by a compatible signature on the source type.
 This ensures that the source function can be called in all the same cases as the target function.
@@ -241,7 +241,7 @@ a = s; // OK
 s = a; // OK
 ```
 
-## Private and protected members in classes
+### Private and protected members in classes
 
 Private and protected members in a class affect their compatibility.
 When an instance of a class is checked for compatibility, if the target type contains a private member, then the source type must also contain a private member that originated from the same class.
@@ -294,7 +294,7 @@ identity = reverse; // OK, because (x: any) => any matches (y: any) => any
 
 ## Advanced Topics
 
-## Subtype vs Assignment
+### Subtype vs Assignment
 
 So far, we've used "compatible", which is not a term defined in the language spec.
 In TypeScript, there are two kinds of compatibility: subtype and assignment.

--- a/packages/documentation/copy/en/reference/Variable Declarations.md
+++ b/packages/documentation/copy/en/reference/Variable Declarations.md
@@ -74,7 +74,7 @@ function f() {
 f(); // returns '2'
 ```
 
-## Scoping rules
+### Scoping rules
 
 `var` declarations have some odd scoping rules for those used to other languages.
 Take the following example:
@@ -118,7 +118,7 @@ function sumMatrix(matrix: number[][]) {
 Maybe it was easy to spot out for some experienced JavaScript developers, but the inner `for`-loop will accidentally overwrite the variable `i` because `i` refers to the same function-scoped variable.
 As experienced developers know by now, similar sorts of bugs slip through code reviews and can be an endless source of frustration.
 
-## Variable capturing quirks
+### Variable capturing quirks
 
 Take a quick second to guess what the output of the following snippet is:
 
@@ -199,7 +199,7 @@ let hello = "Hello!";
 
 The key difference is not in the syntax, but in the semantics, which we'll now dive into.
 
-## Block-scoping
+### Block-scoping
 
 When a variable is declared using `let`, it uses what some call _lexical-scoping_ or _block-scoping_.
 Unlike variables declared with `var` whose scopes leak out to their containing function, block-scoped variables are not visible outside of their nearest containing block or `for`-loop.
@@ -263,7 +263,7 @@ let a;
 
 For more information on temporal dead zones, see relevant content on the [Mozilla Developer Network](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/let#Temporal_dead_zone_and_errors_with_let).
 
-## Re-declarations and Shadowing
+### Re-declarations and Shadowing
 
 With `var` declarations, we mentioned that it didn't matter how many times you declared your variables; you just got one.
 
@@ -340,7 +340,7 @@ This version of the loop will actually perform the summation correctly because t
 Shadowing should _usually_ be avoided in the interest of writing clearer code.
 While there are some scenarios where it may be fitting to take advantage of it, you should use your best judgement.
 
-## Block-scoped variable capturing
+### Block-scoped variable capturing
 
 When we first touched on the idea of variable capturing with `var` declaration, we briefly went into how variables act once captured.
 To give a better intuition of this, each time a scope is run, it creates an "environment" of variables.
@@ -450,7 +450,7 @@ Another ECMAScript 2015 feature that TypeScript has is destructuring.
 For a complete reference, see [the article on the Mozilla Developer Network](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment).
 In this section, we'll give a short overview.
 
-## Array destructuring
+### Array destructuring
 
 The simplest form of destructuring is array destructuring assignment:
 
@@ -509,7 +509,7 @@ console.log(second); // outputs 2
 console.log(fourth); // outputs 4
 ```
 
-## Tuple destructuring
+### Tuple destructuring
 
 Tuples may be destructured like arrays; the destructuring variables get the types of the corresponding tuple elements:
 
@@ -539,7 +539,7 @@ let [a] = tuple; // a: number
 let [, b] = tuple; // b: string
 ```
 
-## Object destructuring
+### Object destructuring
 
 You can also destructure objects:
 
@@ -571,7 +571,7 @@ let { a, ...passthrough } = o;
 let total = passthrough.b + passthrough.c.length;
 ```
 
-### Property renaming
+#### Property renaming
 
 You can also give different names to properties:
 
@@ -595,7 +595,7 @@ The type, if you specify it, still needs to be written after the entire destruct
 let { a: newName1, b: newName2 }: { a: string; b: number } = o;
 ```
 
-### Default values
+#### Default values
 
 Default values let you specify a default value in case a property is undefined:
 

--- a/packages/documentation/copy/en/tutorials/Gulp.md
+++ b/packages/documentation/copy/en/tutorials/Gulp.md
@@ -38,7 +38,7 @@ mkdir src
 mkdir dist
 ```
 
-## Initialize the project
+### Initialize the project
 
 Now we'll turn this folder into an npm package.
 
@@ -51,7 +51,7 @@ You can use the defaults except for your entry point.
 For your entry point, use `./dist/main.js`.
 You can always go back and change these in the `package.json` file that's been generated for you.
 
-## Install our dependencies
+### Install our dependencies
 
 Now we can use `npm install` to install packages.
 First install `gulp-cli` globally (if you use a Unix system, you may need to prefix the `npm install` commands in this guide with `sudo`).
@@ -67,7 +67,7 @@ Then install `typescript`, `gulp` and `gulp-typescript` in your project's dev de
 npm install --save-dev typescript gulp@4.0.0 gulp-typescript
 ```
 
-## Write a simple example
+### Write a simple example
 
 Let's write a Hello World program.
 In `src`, create the file `main.ts`:
@@ -91,7 +91,7 @@ In the project root, `proj`, create the file `tsconfig.json`:
 }
 ```
 
-## Create a `gulpfile.js`
+### Create a `gulpfile.js`
 
 In the project root, create the file `gulpfile.js`:
 
@@ -105,7 +105,7 @@ gulp.task("default", function () {
 });
 ```
 
-## Test the resulting app
+### Test the resulting app
 
 ```shell
 gulp
@@ -173,7 +173,7 @@ vinyl-source-stream lets us adapt the file output of Browserify back into a form
 npm install --save-dev browserify tsify vinyl-source-stream
 ```
 
-## Create a page
+### Create a page
 
 Create a file in `src` named `index.html`:
 
@@ -266,7 +266,7 @@ Now that we are bundling our code with Browserify and tsify, we can add various 
 
 - Terser compacts your code so that it takes less time to download.
 
-## Watchify
+### Watchify
 
 We'll start with Watchify to provide background compilation:
 
@@ -340,7 +340,7 @@ proj$ gulp
 [10:35:24] 2808 bytes written (0.05 seconds)
 ```
 
-## Terser
+### Terser
 
 First install Terser.
 Since the point of Terser is to mangle your code, we also need to install vinyl-buffer and gulp-sourcemaps to keep sourcemaps working.
@@ -398,7 +398,7 @@ gulp
 cat dist/bundle.js
 ```
 
-## Babel
+### Babel
 
 First install Babelify and the Babel preset for ES2015.
 Like Terser, Babelify mangles code, so we'll need vinyl-buffer and gulp-sourcemaps.

--- a/packages/documentation/copy/en/tutorials/Migrating from JavaScript.md
+++ b/packages/documentation/copy/en/tutorials/Migrating from JavaScript.md
@@ -82,12 +82,12 @@ You might have some more build steps in your pipeline.
 Perhaps you concatenate something to each of your files.
 Each build tool is different, but we'll do our best to cover the gist of things.
 
-## Gulp
+### Gulp
 
 If you're using Gulp in some fashion, we have a tutorial on [using Gulp](/docs/handbook/gulp.html) with TypeScript, and integrating with common build tools like Browserify, Babelify, and Uglify.
 You can read more there.
 
-## Webpack
+### Webpack
 
 Webpack integration is pretty simple.
 You can use `ts-loader`, a TypeScript loader, combined with `source-map-loader` for easier debugging.
@@ -155,13 +155,13 @@ If you plan on using the stricter settings that are available, it's best to turn
 For instance, if you never want TypeScript to silently infer `any` for a type without you explicitly saying so, you can use [`noImplicitAny`](/tsconfig#noImplicitAny) before you start modifying your files.
 While it might feel somewhat overwhelming, the long-term gains become apparent much more quickly.
 
-## Weeding out Errors
+### Weeding out Errors
 
 Like we mentioned, it's not unexpected to get error messages after conversion.
 The important thing is to actually go one by one through these and decide how to deal with the errors.
 Often these will be legitimate bugs, but sometimes you'll have to explain what you're trying to do a little better to TypeScript.
 
-### Importing from Modules
+#### Importing from Modules
 
 You might start out getting a bunch of errors like `Cannot find name 'require'.`, and `Cannot find name 'define'.`.
 In these cases, it's likely that you're using modules.
@@ -208,7 +208,7 @@ import foo = require("foo");
 foo.doStuff();
 ```
 
-### Getting Declaration Files
+#### Getting Declaration Files
 
 If you started converting over to TypeScript imports, you'll probably run into errors like `Cannot find module 'foo'.`.
 The issue here is that you likely don't have _declaration files_ to describe your library.
@@ -223,7 +223,7 @@ If you're using a module option other than `commonjs`, you'll need to set your [
 
 After that, you'll be able to import lodash with no issues, and get accurate completions.
 
-### Exporting from Modules
+#### Exporting from Modules
 
 Typically, exporting from a module involves adding properties to a value like `exports` or `module.exports`.
 TypeScript allows you to use top-level export statements.
@@ -269,7 +269,7 @@ function foo() {
 export = foo;
 ```
 
-### Too many/too few arguments
+#### Too many/too few arguments
 
 You'll sometimes find yourself calling a function with too many/few arguments.
 Typically, this is a bug, but in some cases, you might have declared a function that uses the `arguments` object instead of writing out any parameters:
@@ -320,7 +320,7 @@ We added two overload signatures to `myCoolFunction`.
 The first checks states that `myCoolFunction` takes a function (which takes a `number`), and then a list of `number`s.
 The second one says that it will take a function as well, and then uses a rest parameter (`...nums`) to state that any number of arguments after that need to be `number`s.
 
-### Sequentially Added Properties
+#### Sequentially Added Properties
 
 Some people find it more aesthetically pleasing to create an object and add properties immediately after like so:
 
@@ -355,7 +355,7 @@ options.volume = 11;
 
 Alternatively, you can just say `options` has the type `any` which is the easiest thing to do, but which will benefit you the least.
 
-### `any`, `Object`, and `{}`
+#### `any`, `Object`, and `{}`
 
 You might be tempted to use `Object` or `{}` to say that a value can have any property on it because `Object` is, for most purposes, the most general type.
 However **`any` is actually the type you want to use** in those situations, since it's the most _flexible_ type.
@@ -368,19 +368,19 @@ Keep in mind though, whenever you use `any`, you lose out on most of the error c
 If a decision ever comes down to `Object` and `{}`, you should prefer `{}`.
 While they are mostly the same, technically `{}` is a more general type than `Object` in certain esoteric cases.
 
-## Getting Stricter Checks
+### Getting Stricter Checks
 
 TypeScript comes with certain checks to give you more safety and analysis of your program.
 Once you've converted your codebase to TypeScript, you can start enabling these checks for greater safety.
 
-### No Implicit `any`
+#### No Implicit `any`
 
 There are certain cases where TypeScript can't figure out what certain types should be.
 To be as lenient as possible, it will decide to use the type `any` in its place.
 While this is great for migration, using `any` means that you're not getting any type safety, and you won't get the same tooling support you'd get elsewhere.
 You can tell TypeScript to flag these locations down and give an error with the [`noImplicitAny`](/tsconfig#noImplicitAny) option.
 
-### Strict `null` & `undefined` Checks
+#### Strict `null` & `undefined` Checks
 
 By default, TypeScript assumes that `null` and `undefined` are in the domain of every type.
 That means anything declared with the type `number` could be `null` or `undefined`.
@@ -402,7 +402,7 @@ foo!.length; // okay - 'foo!' just has type 'string[]'
 
 As a heads up, when using [`strictNullChecks`](/tsconfig#strictNullChecks), your dependencies may need to be updated to use [`strictNullChecks`](/tsconfig#strictNullChecks) as well.
 
-### No Implicit `any` for `this`
+#### No Implicit `any` for `this`
 
 When you use the `this` keyword outside of classes, it has the type `any` by default.
 For instance, imagine a `Point` class, and imagine a function that we wish to add as a method:


### PR DESCRIPTION
2e7a786701dd069fb959c6902fd1c87562e29953 changed all h1 tags to h2 tags. While that change does make sense, the commit forgot to update 162 subheadings accordingly. The hierarchy between headings is important for accessibility.