### PR TITLE
Updated Mapped Types Handbook Reference in Playground Example

### DIFF
--- a/packages/playground-examples/copy/en/TypeScript/Meta-Types/Mapped Types.ts
+++ b/packages/playground-examples/copy/en/TypeScript/Meta-Types/Mapped Types.ts
@@ -54,4 +54,4 @@ type CorrectMappedArtistForEdit = MyPartialTypeForEdit<Artist>;
 // work, but covers most of the basics. If you'd like to
 // dive in with more depth, check out the handbook:
 //
-// https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types
+// https://www.typescriptlang.org/docs/handbook/2/mapped-types.html


### PR DESCRIPTION
The playground example demonstrating Mapped Types includes a reference link at the bottom of the page to the Handbook section on Mapped Types. However, the existing link sends users to the depreciated Mapped Types page, this updates the link to the updated page in the handbook.