### PR TITLE
Make `elementToAppend` take priority over `domID` for sandbox configs

### DIFF
--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -144,7 +144,7 @@ export const createTypeScriptSandbox = (
 
   const language = languageType(config)
   const filePath = createFileUri(config, compilerOptions, monaco)
-  const element = "domID" in config ? document.getElementById(config.domID) : (config as any).elementToAppend
+  const element = (config as any).elementToAppend ? (config as any).elementToAppend : document.getElementById(config.domID)
 
   const model = monaco.editor.createModel(defaultText, language, filePath)
   monaco.editor.defineTheme("sandbox", sandboxTheme)


### PR DESCRIPTION
Closes https://github.com/microsoft/TypeScript-Website/issues/2885.