### PR TITLE
docs: fix broken link in `TypeScript 2.6.md`

### DIFF
--- a/packages/documentation/copy/en/release-notes/TypeScript 2.6.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 2.6.md
@@ -12,7 +12,7 @@ The [`strictFunctionTypes`](/tsconfig#strictFunctionTypes) switch is part of the
 You can opt-out by setting `--strictFunctionTypes false` on your command line or in your tsconfig.json.
 
 Under [`strictFunctionTypes`](/tsconfig#strictFunctionTypes) function type parameter positions are checked _contravariantly_ instead of _bivariantly_.
-For some background on what variance means for function types check out [What are covariance and contravariance?](http://web.archive.org/web/20220823104433/https://www.stephanboyer.com/post/132/what-are-covariance-and-contravariance).
+For some background on what variance means for function types check out [What are covariance and contravariance?](https://web.archive.org/web/20220823104433/https://www.stephanboyer.com/post/132/what-are-covariance-and-contravariance).
 
 The stricter checking applies to all function types, _except_ those originating in method or constructor declarations.
 Methods are excluded specifically to ensure generic classes and interfaces (such as `Array<T>`) continue to mostly relate covariantly.

--- a/packages/documentation/copy/en/release-notes/TypeScript 2.6.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 2.6.md
@@ -12,7 +12,7 @@ The [`strictFunctionTypes`](/tsconfig#strictFunctionTypes) switch is part of the
 You can opt-out by setting `--strictFunctionTypes false` on your command line or in your tsconfig.json.
 
 Under [`strictFunctionTypes`](/tsconfig#strictFunctionTypes) function type parameter positions are checked _contravariantly_ instead of _bivariantly_.
-For some background on what variance means for function types check out [What are covariance and contravariance?](https://archive.md/B1xWu).
+For some background on what variance means for function types check out [What are covariance and contravariance?](http://web.archive.org/web/20220823104433/https://www.stephanboyer.com/post/132/what-are-covariance-and-contravariance).
 
 The stricter checking applies to all function types, _except_ those originating in method or constructor declarations.
 Methods are excluded specifically to ensure generic classes and interfaces (such as `Array<T>`) continue to mostly relate covariantly.


### PR DESCRIPTION
Hello, this is the follow-up PR for #2808.

The previous PR changed to using archive.md on April but now it's already inaccessible. This is because this archive site historically changed its domain many times due to the crawls ignoring robots.txt. (ref. https://en.wikipedia.org/wiki/Archive.today)

This changes to use the reliable Internet Archive link so that we won't need to change URLs in the future. (Additional information: https://github.com/microsoft/TypeScript-Website/issues/2776#issuecomment-1500269003)