### PR TITLE
fix: typo in link in `customConditions`

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/customConditions.md
+++ b/packages/tsconfig-reference/copy/en/options/customConditions.md
@@ -3,7 +3,7 @@ display: "Custom Conditions"
 oneline: "Conditions to set in addition to the resolver-specific defaults when resolving imports."
 ---
 
-`--customConditions` takes a list of additional [conditions](https://nodejs.org/api/packages.html#nested-conditions) that should succeed when TypeScript resolves from an [`exports`] or (https://nodejs.org/api/packages.html#exports) or [`imports`](https://nodejs.org/api/packages.html#imports) field of a `package.json`.
+`--customConditions` takes a list of additional [conditions](https://nodejs.org/api/packages.html#nested-conditions) that should succeed when TypeScript resolves from an [`exports`](https://nodejs.org/api/packages.html#exports) or [`imports`](https://nodejs.org/api/packages.html#imports) field of a `package.json`.
 These conditions are added to whatever existing conditions a resolver will use by default.
 
 For example, when this field is set in a `tsconfig.json` as so:


### PR DESCRIPTION
## Summary

Fix typo in between a markdown link

## Details

- extra "or" was added and so the markdown link did not correctly render
  - instead it was shown as verbatim text in the docs
  
### Screenshot

![Screenshot 2023-07-18 at 1 07 16 PM](https://github.com/microsoft/TypeScript-Website/assets/4970083/3103e5c5-26e8-4115-b4d1-32e483ba54ff)

## Misc

I stopped making PRs for a while as they didn't get responses 😕 Glad to see that this repo is being more actively maintained again! Critical resource for the language and community!
