### PR TITLE
feat: link to `moduleResolution` from `exports` configs

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/customConditions.md
+++ b/packages/tsconfig-reference/copy/en/options/customConditions.md
@@ -38,4 +38,4 @@ So when importing from a package with the following `package.json`
 
 TypeScript will try to look for files corresponding to `foo.mjs`.
 
-This field is only valid under the `node16`, `nodenext`, and `bundler` options for `--moduleResolution`.
+This field is only valid under the `node16`, `nodenext`, and `bundler` options for [`--moduleResolution`](#moduleResolution).

--- a/packages/tsconfig-reference/copy/en/options/resolvePackageJsonExports.md
+++ b/packages/tsconfig-reference/copy/en/options/resolvePackageJsonExports.md
@@ -5,4 +5,4 @@ oneline: "Use the package.json 'exports' field when resolving package imports."
 
 `--resolvePackageJsonExports` forces TypeScript to consult [the `exports` field of `package.json` files](https://nodejs.org/api/packages.html#exports) if it ever reads from a package in `node_modules`.
 
-This option defaults to `true` under the `node16`, `nodenext`, and `bundler` options for `--moduleResolution`.
+This option defaults to `true` under the `node16`, `nodenext`, and `bundler` options for [`--moduleResolution`](#moduleResolution).

--- a/packages/tsconfig-reference/copy/en/options/resolvePackageJsonImports.md
+++ b/packages/tsconfig-reference/copy/en/options/resolvePackageJsonImports.md
@@ -5,4 +5,4 @@ oneline: "Use the package.json 'imports' field when resolving imports."
 
 `--resolvePackageJsonImports` forces TypeScript to consult [the `imports` field of `package.json` files](https://nodejs.org/api/packages.html#imports) when performing a lookup that starts with `#` from a file whose ancestor directory contains a `package.json`.
 
-This option defaults to `true` under the `node16`, `nodenext`, and `bundler` options for `--moduleResolution`.
+This option defaults to `true` under the `node16`, `nodenext`, and `bundler` options for [`--moduleResolution`](#moduleResolution).


### PR DESCRIPTION
## Summary

Add links in new `tsconfig` options that mention/impact `moduleResolution`

## Details

- all the new Node `package.json#exports` / `imports` configurations mention `moduleResolution`, but did not link to it
  - consistent with the rest of the docs, always link when another `tsconfig` option is mentioned