### PR TITLE
fix: remove redundant `ES2020` section in `module`

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/module.md
+++ b/packages/tsconfig-reference/copy/en/options/module.md
@@ -74,17 +74,6 @@ import { valueOfPi } from "./constants";
 export const twoPi = valueOfPi * 2;
 ```
 
-#### `ES2020`
-
-```ts twoslash
-// @showEmit
-// @module: es2020
-// @noErrors
-import { valueOfPi } from "./constants";
-
-export const twoPi = valueOfPi * 2;
-```
-
 #### `ES2015`/`ES6`/`ES2020`/`ES2022`
 
 ```ts twoslash


### PR DESCRIPTION
## Summary

`ES2020` is referenced twice under `module`

## Details

- `ES2020` is already covered in the section with `ES2015` - `ES2022`
  - same exact output and already mentioned there
  - easier to read and more consistent

- did not touch `ESNext` as that isn't mentioned in the below section
  - and theoretically could change in the future
  
### Screenshot

![Screenshot 2023-07-18 at 1 21 42 PM](https://github.com/microsoft/TypeScript-Website/assets/4970083/10e4a7e8-efd8-4f0a-8a3c-f800c4bd2208)
