### PR TITLE
feat: format and link `package.json` Defaults

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -240,6 +240,14 @@ export const defaultsForOptions = {
   noImplicitThis: trueIf("strict"),
   preserveConstEnums: trueIf("isolatedModules"),
   reactNamespace: "React",
+  resolvePackageJsonExports: [
+    "`true` when [`moduleResolution`](#moduleResolution) is `node16`, `nodenext`, or `bundler`;",
+    "otherwise `false`",
+  ],
+  resolvePackageJsonImports: [
+    "`true` when [`moduleResolution`](#moduleResolution) is `node16`, `nodenext`, or `bundler`;",
+    "otherwise `false`",
+  ],
   rootDir: "Computed from the list of input files.",
   rootDirs: "Computed from the list of input files.",
   strictBindCallApply: trueIf("strict"),


### PR DESCRIPTION
## Summary

Add consistent formatting and linking to `resolvePackageJsonExports` / `Imports`' "Defaults" section

## Details

- previously the defaults did not consistently use backticks
  - unlike the rest of the docs

- also add a link to `moduleResolution` when it is referenced in the defaults
  - consistent with existing docs
  
- no actual content changes, just formatting/linking

### Screenshot

The right side "Default" did not have consistent formatting previously:

![Screenshot 2023-07-18 at 1 30 55 PM](https://github.com/microsoft/TypeScript-Website/assets/4970083/8728632a-0091-42fb-acb8-8cea105c0a5f)
