### PR TITLE
docs: consistently use semicolons for Defaults

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -189,7 +189,7 @@ export const relatedTo: [AnOption, AnOption[]][] = [
 
 function trueIf(name: string) {
   return [
-    `\`true\` if [\`${name}\`](#${name}),`,
+    `\`true\` if [\`${name}\`](#${name});`,
     "`false` otherwise.",
   ];
 }
@@ -207,13 +207,13 @@ export const defaultsForOptions = {
     ])
   ),
   allowSyntheticDefaultImports: [
-    "`true` if [`esModuleInterop`](#esModuleInterop) is enabled, [`module`](#module) is `system`, or [`moduleResolution`](#module-resolution) is `bundler`,",
+    "`true` if [`esModuleInterop`](#esModuleInterop) is enabled, [`module`](#module) is `system`, or [`moduleResolution`](#module-resolution) is `bundler`;",
     "`false` otherwise.",
   ],
   alwaysStrict: trueIf("strict"),
   declaration: trueIf("composite"),
   esModuleInterop: [
-    "`true` if [`module`](#module) is `node16` or `nodenext`,",
+    "`true` if [`module`](#module) is `node16` or `nodenext`;",
     "`false` otherwise.",
   ],
   exclude: [
@@ -222,17 +222,17 @@ export const defaultsForOptions = {
     "jspm_packages",
     "[`outDir`](#outDir)",
   ],
-  include: ["`[]` if [`files`](#files) is specified,", "`**/*` otherwise."],
+  include: ["`[]` if [`files`](#files) is specified;", "`**/*` otherwise."],
   incremental: trueIf("composite"),
   jsxFactory: "React.createElement",
   locale: "Platform specific.",
   module: [
-    "`CommonJS` if [`target`](#target) is `ES3` or `ES5`,",
+    "`CommonJS` if [`target`](#target) is `ES3` or `ES5`;",
     "`ES6`/`ES2015` otherwise.",
   ],
   moduleResolution: [
-    "`Classic` if [`module`](#module) is `AMD`, `UMD`, `System` or `ES6`/`ES2015`,",
-    "Matches if [`module`](#module) is `node16` or `nodenext`,",
+    "`Classic` if [`module`](#module) is `AMD`, `UMD`, `System`, or `ES6`/`ES2015`;",
+    "Matches if [`module`](#module) is `node16` or `nodenext`;",
     "`Node` otherwise.",
   ],
   newLine: "Platform specific.",
@@ -249,7 +249,7 @@ export const defaultsForOptions = {
   strictNullChecks: trueIf("strict"),
   target: "ES3",
   useDefineForClassFields: [
-    "`true` if [`target`](#target) is `ES2022` or higher, including `ESNext`,",
+    "`true` if [`target`](#target) is `ES2022` or higher, including `ESNext`;",
     "`false` otherwise.",
   ],
 };


### PR DESCRIPTION
## Summary

Attempt to clarify long lists of Defaults with lots of commas by using some semicolons instead

## Details

- when multiple options are listed out, there A TON of commas, so separating out pieces can be tough
  - use a semicolon instead of a comma between different options to clarify the separations
    - could also use a period, but a semicolon is consistent with the `resolvePackageJsonExports` / `Imports` docs (see also #2894)
    
- also add a missing Oxford comma in `moduleResolution`

- this should hopefully make it _a bit_ easier on the eyes 😅

### Screenshot

`moduleResolution` is a particularly good example of how hard this is to read currently:

![Screenshot 2023-07-18 at 1 56 08 PM](https://github.com/microsoft/TypeScript-Website/assets/4970083/5d86998a-07d2-4c28-ac8a-de5e51d5a2bc)
