### PR TITLE
feat: add `verbatimModuleSyntax` to Related

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -178,8 +178,9 @@ export const relatedTo: [AnOption, AnOption[]][] = [
   ["suppressImplicitAnyIndexErrors", ["noImplicitAny"]],
 
   ["listFiles", ["explainFiles"]],
-  ["preserveValueImports", ["isolatedModules", "importsNotUsedAsValues"]],
-  ["importsNotUsedAsValues", ["preserveValueImports"]],
+
+  ["preserveValueImports", ["isolatedModules", "importsNotUsedAsValues", "verbatimModuleSyntax"]],
+  ["importsNotUsedAsValues", ["preserveValueImports", "verbatimModuleSyntax"]],
 ];
 
 /**


### PR DESCRIPTION
## Summary

`preserveValueImports` and `importsNotUsedAsValues` should be Related to `verbatimModuleSyntax`

## Details

- `preserveValueImports` and `importsNotUsedAsValues` are now deprecated, and produce warnings as well
  - they are deprecated in favor of `verbatimModuleSyntax` and mention that in their descriptions, but not in their Related

- do not link back from `verbatimModuleSyntax` as the old config options are deprecated

- also add a new line between this group and `listFiles` as these are not related to each other
  - consistently have a new line between different related groups