### PR TITLE
Adds some infra to warn on files which changed in the PR but aren't accounted for

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,29 +40,14 @@ jobs:
         env:
           CI: true
 
-      # Deploy preview environment for non-forks
-      - uses: Azure/static-web-apps-deploy@v1
-        if: github.event.pull_request.base.repo.id == github.event.pull_request.head.repo.id
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PROD }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          action: upload
-          app_location: site
-          skip_app_build: true
-
-      # Upload site artifact for forks so it can be deployed by a maintainer on-demand
-      - uses: actions/upload-artifact@v3
-        if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
-        with:
-          name: site-${{ github.event.number }}
-          path: site/
-
       # danger for PR builds
-      - if: github.event_name == 'pull_request' && github.event.pull_request.base.repo.id == github.event.pull_request.head.repo.id
-        run: "yarn danger ci"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_DEPLOY_URL_ROOT: ${{ steps.deploy.outputs.static_web_app_url }}
+      - name: "Run Danger"
+        run: |
+          # Exposing this token is safe because the user of it has no other public repositories
+          # and has no permission to modify this repository. See DefinitelyTyped #62638 for the discussion.
+          TOKEN='ghp_i5wtj1l2AbpFv3OU96w6R'
+          TOKEN+='On3bHOkcV2AmVY6'
+          DANGER_GITHUB_API_TOKEN=$TOKEN yarn danger ci
 
   windows:
     if: github.event.action != 'closed'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,6 +40,23 @@ jobs:
         env:
           CI: true
 
+      # Deploy preview environment for non-forks
+      - uses: Azure/static-web-apps-deploy@v1
+        if: github.event.pull_request.base.repo.id == github.event.pull_request.head.repo.id
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PROD }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: upload
+          app_location: site
+          skip_app_build: true
+
+      # Upload site artifact for forks so it can be deployed by a maintainer on-demand
+      - uses: actions/upload-artifact@v3
+        if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
+        with:
+          name: site-${{ github.event.number }}
+          path: site/
+
       # danger for PR builds
       - name: "Run Danger"
         run: |

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -2,9 +2,16 @@
 // yarn danger pr https://github.com/microsoft/TypeScript-Website/pull/115
 
 import spellcheck from "danger-plugin-spellcheck"
-
-// Blocked on PR deploys, see CI.yml
-// import lighthouse from "danger-plugin-lighthouse"
+import { warn, danger }from "danger"
+import { execSync } from "child_process"
 
 // Spell check all the things
 spellcheck({ settings: "microsoft/TypeScript-Website@spellcheck.json" })
+
+const gitStatus = execSync("git status --porcelain").toString()
+if (gitStatus.includes("M")) {
+    const files = gitStatus.split("\n").filter(f => f.startsWith(" M ")).map(f => f.substr(3))
+    const linksToChangedFiles = danger.github.utils.fileLinks(files)
+    
+    warn(`There are un-staged changes to generated files: \n ${linksToChangedFiles}`)
+}

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -2,7 +2,7 @@
 // yarn danger pr https://github.com/microsoft/TypeScript-Website/pull/115
 
 import spellcheck from "danger-plugin-spellcheck"
-import { warn, danger }from "danger"
+import { warn, danger } from "danger"
 import { execSync } from "child_process"
 
 // Spell check all the things

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -8,7 +8,7 @@
     "test": "echo 'NOOP'",
     "lint": "node scripts/lintTwoslashErrors.js",
     "create-handbook-nav": "node ./scripts/generateTypesForFilesInDocs && node ./scripts/generateDocsNavigationPerLanguage.js",
-    "bootstrap": "node ./scripts/generateAttribution.js"
+    "bootstrap": "yarn create-handbook-nav && node ./scripts/generateAttribution.js"
   },
   "prettier": {
     "semi": true

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -4,11 +4,11 @@
   "license": "MIT",
   "version": "1.0.0",
   "scripts": {
-    "build": "echo 'NOOP'",
+    "build": "yarn create-handbook-nav",
     "test": "echo 'NOOP'",
     "lint": "node scripts/lintTwoslashErrors.js",
     "create-handbook-nav": "node ./scripts/generateTypesForFilesInDocs && node ./scripts/generateDocsNavigationPerLanguage.js",
-    "bootstrap": "yarn create-handbook-nav && node ./scripts/generateAttribution.js"
+    "bootstrap": "node ./scripts/generateAttribution.js"
   },
   "prettier": {
     "semi": true


### PR DESCRIPTION
Re: https://github.com/microsoft/TypeScript-Website/pull/2900

I'm not entirely sure about the fully cleaned bootstrap issues (it was only really meant to be ran once to download sets of files, and not really be needed to run again except for new ts versions) - so I've moved the one thing which definitely was only triggering in bootstrap only from the most recent PR into the build flow, its a tiny codegen and seems reasonable. I think most of the changes from the recent PR came from OSS folks not running the build but just making direct changes.

This PR switches Danger to run on all PRs and removes my old infra for doing static web app deploys ( https://github.com/Azure/static-web-apps/issues/1#issuecomment-675757849 ) using the same code as we use in DT. It won't fail the build, but it will list what files have changed locally at the end of the run and that could be a good indicator of what's going on.