### PR TITLE
Updated Korean footer requirement for Privacy link

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/SiteFooter.tsx
+++ b/packages/typescriptlang-org/src/components/layout/SiteFooter.tsx
@@ -281,7 +281,7 @@ export const SiteFooter = (props: Props) => {
               href="https://go.microsoft.com/fwlink/?LinkId=521839"
               title="Microsoft Privacy Policy"
             >
-              Privacy
+            { lang === "ko" ? "개인정보처리방침 및 위치정보이용약관" : "Privacy"}
             </a>
             {lang === "fr" ?
               <a


### PR DESCRIPTION
Updating the anchor text of the Privacy link to match the new requirement for the website's South Korean localized version.