### PR TITLE
Update Enums.md: Fix wrong description

### DIFF
--- a/packages/documentation/copy/en/reference/Enums.md
+++ b/packages/documentation/copy/en/reference/Enums.md
@@ -220,7 +220,7 @@ function f(x: E) {
 
 In that example, we first checked whether `x` was _not_ `E.Foo`.
 If that check succeeds, then our `||` will short-circuit, and the body of the 'if' will run.
-However, if the check didn't succeed, then `x` can _only_ be `E.Bar`, so it doesn't make sense to see whether it's equal to `E.Bar`.
+However, if the check didn't succeed, then `x` can _only_ be `E.Foo`, so it doesn't make sense to see whether it's _not_ equal to `E.Bar`.
 
 ## Enums at runtime
 


### PR DESCRIPTION

in this section
[Union enums and enum member types](https://www.typescriptlang.org/docs/handbook/enums.html#union-enums-and-enum-member-types)

```ts
enum E {
  Foo,
  Bar,
}

function f(x: E) {
  if (x !== E.Foo || x !== E.Bar) {
```

In that example, we first checked whether x was not E.Foo. If that check succeeds, then our || will short-circuit, and the body of the ‘if’ will run. However, if the check didn’t succeed, `then x can only be E.Bar`, so it doesn’t make sense to see whether it’s equal to E.Bar.

when the first check didn’t succeed, then x is `E.Foo`, so it doesn’t make sense to see `x !== E.Bar`

