### PR TITLE
Adds satisfies to the jsdoc reference

### DIFF
--- a/packages/documentation/copy/en/javascript/JSDoc Reference.md
+++ b/packages/documentation/copy/en/javascript/JSDoc Reference.md
@@ -401,7 +401,7 @@ let c = new Cache()
 
 ### `@satisfies`
 
-`@satisfies` provides access to the postfix [operator `satisfies`](/docs/handbook/release-notes/typescript-4-9.html) in TypeScript. Satisfies is used to declare that a value implements type but does not affect the type of the value. 
+`@satisfies` provides access to the postfix [operator `satisfies`](/docs/handbook/release-notes/typescript-4-9.html) in TypeScript. Satisfies is used to declare that a value implements a type but does not affect the type of the value. 
 
 ```js twoslash
 // @errors: 1360

--- a/packages/documentation/copy/en/javascript/JSDoc Reference.md
+++ b/packages/documentation/copy/en/javascript/JSDoc Reference.md
@@ -19,6 +19,8 @@ Note any tags which are not explicitly listed below (such as `@async`) are not y
 - [`@typedef`](#typedef-callback-and-param)
 - [`@callback`](#typedef-callback-and-param)
 - [`@template`](#template)
+- [`@satisfies`](#satisfies)
+
 
 #### Classes
 
@@ -396,6 +398,29 @@ class Cache {
 }
 let c = new Cache()
 ```
+
+### `@satisfies`
+
+`@satisfies` provides access to the postfix [operator `satisfies`](/docs/handbook/release-notes/typescript-4-9.html) in TypeScript. Satisfies is used to declare that a value implements type but does not affect the type of the value. 
+
+```js twoslash
+// @errors: 1360
+/**
+ * @typedef {"hello world" | "Hello, world"} WelcomeMessage
+ */
+
+/** @satisfies {WelcomeMessage} */
+const message = "hello world"
+//     ^?
+
+/** @satisfies {WelcomeMessage} */
+const failingMessage = "Hello world!"
+
+/** @type {WelcomeMessage} */
+const messageUsingType = "hello world"
+//     ^?
+```
+
 
 ## Classes
 


### PR DESCRIPTION
This was added with 5.1 https://github.com/microsoft/TypeScript/pull/51753 but not mentioned in the JSDoc reference 

Code sample: https://www.typescriptlang.org/dev/bug-workbench/?checkJs=true&allowJs=true&all=true&noEmit=true#code/PTAEAEDMEsBsFMB2BDAtvAXKaiAOBXAFwDoArAZwCgQJlZYB7AdwCkqbwBjAC3k4Gs21MOEQMAoqmiFK1AFRzKoOREIBPXPAAm8SKADeAIl70GoJgwBOsLYdAAfUIYAS8UwBpzVm4YC+oAHU3TgZ0AFl4cnJkAHN4JTlgWWAFCGjCaHIYSIMg2BDwyOi4-0TKEMRyQlB0KNj4UABeJxNGL2tbYVBu7oA9AH5k1PB0zOzyXODQ+Ai6kuUkiqrQSGQ4HBjZ4obmlzdYaHabAEJDIZVwdU1J-Omt+tLFhkrq2u2AJiaW-bMLDrOaD1QANZEA