### PR TITLE
Update module.md: replace CommonJS with nodenext

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/module.md
+++ b/packages/tsconfig-reference/copy/en/options/module.md
@@ -3,7 +3,7 @@ display: "Module"
 oneline: "Specify what module code is generated."
 ---
 
-Sets the module system for the program. See the <a href='/docs/handbook/modules.html'>Modules</a> reference page for more information. You very likely want `"CommonJS"` for node projects.
+Sets the module system for the program. See the <a href='/docs/handbook/modules.html'>Modules</a> reference page for more information. You very likely want `"nodenext"` for modern node projects.
 
 Changing `module` affects [`moduleResolution`](#moduleResolution) which [also has a reference page](/docs/handbook/module-resolution.html).
 


### PR DESCRIPTION
The documentation on [module tsconfig option](https://www.typescriptlang.org/tsconfig#module) says

> You very likely want "CommonJS" for node projects.

This seems wrong now that Node can support ESM and interop with CommonJS at the same time. The `module` option [decides what syntax to use when importing](https://www.typescriptlang.org/tsconfig#module). To be able to import both ESM and CommonJS modules one must use the `import` syntax from ESM. [Using require to load an ES module is not supported](https://nodejs.org/api/esm.html#require).

The docs about [moduleResolution](https://www.typescriptlang.org/tsconfig#moduleResolution) already says `nodenext` is the preferred way.