### PR TITLE
Fix spacing issue in Declaration Files/Publishing

### DIFF
--- a/packages/typescriptlang-org/src/templates/markdown.scss
+++ b/packages/typescriptlang-org/src/templates/markdown.scss
@@ -11,6 +11,7 @@
     flex-wrap: wrap;
     font-weight: 400;
     line-height: 1.3;
+    white-space-collapse: preserve;
 
     a {
       padding-right: 10px !important;


### PR DESCRIPTION
By default the flex header collapses the trailing whitespace of the text elements inside:
<img src="https://github.com/microsoft/TypeScript-Website/assets/118424338/76493244-cc44-4f4a-9ea1-5f79a82b6f01" height="150px" />


After adding this line: 
<img src="https://github.com/microsoft/TypeScript-Website/assets/118424338/79fd2916-67ab-4644-805a-0724e4e54e81" height="150px" />
