### PR TITLE
Add a ts-check to the jsdoc satisifes

### DIFF
--- a/packages/documentation/copy/en/javascript/JSDoc Reference.md
+++ b/packages/documentation/copy/en/javascript/JSDoc Reference.md
@@ -405,6 +405,7 @@ let c = new Cache()
 
 ```js twoslash
 // @errors: 1360
+// @ts-check
 /**
  * @typedef {"hello world" | "Hello, world"} WelcomeMessage
  */


### PR DESCRIPTION
I missed the ts-check which is required to raise an errors in a .js file for this reference code sample

<img width="848" alt="Screenshot 2023-08-19 at 18 52 27" src="https://github.com/microsoft/TypeScript-Website/assets/49038/cec63f8c-faa5-4726-8a2e-3e07c7fd7aff">
