### PR TITLE
Update Everyday Types.md

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -621,16 +621,16 @@ There are two ways to work around this.
    Change 1 means "I intend for `req.method` to always have the _literal type_ `"GET"`", preventing the possible assignment of `"GUESS"` to that field after.
    Change 2 means "I know for other reasons that `req.method` has the value `"GET"`".
 
-2. You can use `as const` to convert the entire object to be type literals:
+2. You can use `as const` to let TypeScript know that `req.method` will not be modified in the interval:
 
    ```ts twoslash
    declare function handleRequest(url: string, method: "GET" | "POST"): void;
    // ---cut---
-   const req = { url: "https://example.com", method: "GET" } as const;
+   const req = { url: "https://example.com", method: "GET" as const};
    handleRequest(req.url, req.method);
    ```
 
-The `as const` suffix acts like `const` but for the type system, ensuring that all properties are assigned the literal type instead of a more general version like `string` or `number`.
+The `as const` suffix acts like `const` but for the type system, ensuring that properties are assigned the literal type instead of a more general version like `string` or `number`.
 
 ## `null` and `undefined`
 


### PR DESCRIPTION
I think the solution of making "as const" apply to .req only instead of the object makes more sense given we are focusing on .req in the context. We also avoid enforcing literal type on "https://example.com" which is unintended (potentially).