### PR TITLE
remove deprecated link

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -872,6 +872,5 @@ const f3 = function (): void {
 
 For more on `void` please refer to these other documentation entries:
 
-- [v1 handbook](https://www.typescriptlang.org/docs/handbook/basic-types.html#void)
 - [v2 handbook](https://www.typescriptlang.org/docs/handbook/2/functions.html#void)
 - [FAQ - "Why are functions returning non-void assignable to function returning void?"](https://github.com/Microsoft/TypeScript/wiki/FAQ#why-are-functions-returning-non-void-assignable-to-function-returning-void)


### PR DESCRIPTION
when going to v1 page a get a message telling that v1 is deprecated and i should return back to v2 handbook page