### PR TITLE
Fix v5.0 release notes typo

### DIFF
--- a/packages/documentation/copy/en/release-notes/TypeScript 5.0.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 5.0.md
@@ -936,7 +936,7 @@ let myConfigSettings = {
 } satisfies ConfigSettings;
 ```
 
-Here, TypeScript knows that `myCompilerOptions.extends` was declared with an array - because while `satisfies` validated the type of our object, it didn't bluntly change it to `CompilerOptions` and lose information.
+Here, TypeScript knows that `myConfigSettings.extends` was declared with an array - because while `satisfies` validated the type of our object, it didn't bluntly change it to `CompilerOptions` and lose information.
 So if we want to map over `extends`, that's fine.
 
 ```ts


### PR DESCRIPTION
This fixes a small typo in the v5.0 release notes in which a prose paragraph refers to the wrong variable name to match the example code.