### PR TITLE
Swap call/construct to match the interface name

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -87,8 +87,8 @@ You can combine call and construct signatures in the same type arbitrarily:
 
 ```ts twoslash
 interface CallOrConstruct {
-  new (s: string): Date;
   (n?: number): string;
+  new (s: string): Date;
 }
 ```
 


### PR DESCRIPTION
Interface name is called CallAndConstruct, but the properties were construct and call.
Figured it'd make more sense to match the order with the name