### PR TITLE
Change `Base` to `Derived1` for consistency in explanation

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -682,7 +682,7 @@ class Derived2 extends Base {
   f1(other: Derived2) {
     other.x = 10;
   }
-  f2(other: Base) {
+  f2(other: Derived1) {
     other.x = 10;
   }
 }


### PR DESCRIPTION
The explaination uses Derived1 but the code example uses `f2(other:Base)`. Explaination seems correct but looks confusing as we read. 

![image](https://github.com/microsoft/TypeScript-Website/assets/11216794/0acb24e2-753a-4d20-88bd-529b43e339fa)

