### PR TITLE
Rephrase thing to identifier

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -71,7 +71,7 @@ let myName: string = "Alice";
 ```
 
 > TypeScript doesn't use "types on the left"-style declarations like `int x = 0;`
-> Type annotations will always go _after_ the thing being typed.
+> Type annotations will always go _after_ the identifier being typed.
 
 In most cases, though, this isn't needed.
 Wherever possible, TypeScript tries to automatically _infer_ the types in your code.


### PR DESCRIPTION
While defining type annotations to entities like variables, functions, etc., I feel it makes much more sense to use the terminology **identifier** instead of simply calling it a *thing*.