### PR TITLE
Add keepalive workflow

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          if [[ $(git log --oneline --since "50 days" | head -c1 | wc -c) == 0 ]]; then
+          if [[ $(git log --format="%H" --since "50 days" | head -c1 | wc -c) == 0 ]]; then
             git config user.email "typescriptbot@microsoft.com"
             git config user.name "TypeScript Bot"
             git commit --allow-empty -m "Automated commit to keep GitHub Actions active"

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,21 @@
+name: Keep alive
+on:
+  schedule:
+    - cron: "0 0 * * *"
+    
+jobs:
+  keepalive:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          if [[ $(git log --oneline --since "50 days" | head -c1 | wc -c) == 0 ]]; then
+            git config user.email "typescriptbot@microsoft.com"
+            git config user.name "TypeScript Bot"
+            git commit --allow-empty -m "Automated commit to keep GitHub Actions active"
+            git push
+          fi


### PR DESCRIPTION
If a repo hasn't been committed to in 60 days, GitHub disables Actions. Since this repo doesn't get touched often, but its workflows are integral, we work around that problem via a workflow in the TypeScript repo itself (https://github.com/microsoft/TypeScript/blob/main/.github/workflows/ensure-related-repos-run-crons.yml) as that repo is active.

Rather than using GHA in another repo to manage this repo, this PR instead adds a workflow that makes the empty commit so long as no commit has happened in the past 50 days. This is more manageable, keeping the workflows in their respective repos.

There is an action someone wrote for this (https://github.com/gautamkrishnar/keepalive-workflow) but it seems like overkill to pull in.