### PR TITLE
Updated README to indicate the range of node versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### Getting Started
 
-This repo uses [yarn workspaces][y-wrk] with node 13+, and [watchman](https://facebook.github.io/watchman/docs/install.html). (Windows users can install [watchman via chocolatey](https://chocolatey.org/packages/watchman))
+This repo uses [yarn workspaces][y-wrk] with node between 13.14.0 and 16.20.2, and [watchman](https://facebook.github.io/watchman/docs/install.html). (Windows users can install [watchman via chocolatey](https://chocolatey.org/packages/watchman))
 
 With those set up, clone this repo and run `yarn install`.
 


### PR DESCRIPTION
The README indicates that the project uses node versions 13+. However, I ran the the project with 18.13.0 and got this error when running `yarn start`: 
```
TypeScript-Website v2 >> yarn start
[BUILD] success connected to Watchman
[SITE] success open and validate gatsby-configs, load plugins - 6.576s
success onPreInit - 0.036s
success initialize cache - 0.029s
success copy gatsby files - 0.122s
[SITE]
[SITE] /Users/nbarrett/projects/os/TypeScript-Website/node_modules/yoga-layout-prebuilt/yoga-layout/build/Release/nbind.js:53
[SITE]         throw ex;
[SITE]         ^
[SITE]
[SITE] Error: error:0308010C:digital envelope routines::unsupported
[SITE]     at new Hash (node:internal/crypto/hash:67:19)
[SITE]     at Object.createHash (node:crypto:135:10)
[SITE]     at BulkUpdateDecorator.hashFactory (/Users/nbarrett/projects/os/TypeScript-Website/node_modules/webpack/lib/util/createHash.js:145:18)
[SITE]     at BulkUpdateDecorator.digest (/Users/nbarrett/projects/os/TypeScript-Website/node_modules/webpack/lib/util/createHash.js:80:21)
[SITE]     at Compilation.createHash (/Users/nbarrett/projects/os/TypeScript-Website/node_modules/webpack/lib/Compilation.js:3456:47)
[SITE]     at /Users/nbarrett/projects/os/TypeScript-Website/node_modules/webpack/lib/Compilation.js:2483:39
[SITE]     at /Users/nbarrett/projects/os/TypeScript-Website/node_modules/webpack/lib/Compilation.js:2680:5
[SITE]     at Object.eachLimit (/Users/nbarrett/projects/os/TypeScript-Website/node_modules/neo-async/async.js:3461:14)
[SITE]     at Compilation._runCodeGenerationJobs (/Users/nbarrett/projects/os/TypeScript-Website/node_modules/webpack/lib/Compilation.js:2642:12)
[SITE]     at Compilation.codeGeneration (/Users/nbarrett/projects/os/TypeScript-Website/node_modules/webpack/lib/Compilation.js:2632:8)
[SITE]     at /Users/nbarrett/projects/os/TypeScript-Website/node_modules/webpack/lib/Compilation.js:2468:11
[SITE]     at Hook.eval [as callAsync] (eval at create (/Users/nbarrett/projects/os/TypeScript-Website/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
[SITE]     at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/Users/nbarrett/projects/os/TypeScript-Website/node_modules/tapable/lib/Hook.js:18:14)
[SITE]     at /Users/nbarrett/projects/os/TypeScript-Website/node_modules/webpack/lib/Compilation.js:2422:36
[SITE]     at Hook.eval [as callAsync] (eval at create (/Users/nbarrett/projects/os/TypeScript-Website/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
[SITE]     at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/Users/nbarrett/projects/os/TypeScript-Website/node_modules/tapable/lib/Hook.js:18:14) {
[SITE]   opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
[SITE]   library: 'digital envelope routines',
[SITE]   reason: 'unsupported',
[SITE]   code: 'ERR_OSSL_EVP_UNSUPPORTED'
[SITE] }
```

I downgraded to the stable 17 version and got the same error, and then I downgraded to 16 and that allowed me to run the project.