### PR TITLE
Put nightly on top of playground list

### DIFF
--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -295,7 +295,7 @@ export const setupPlayground = (
 
   const notWorkingInPlayground = ["3.1.6", "3.0.1", "2.8.1", "2.7.2", "2.4.1"]
 
-  const allVersions = [...sandbox.supportedVersions.filter(f => !notWorkingInPlayground.includes(f)), "Nightly"]
+  const allVersions = ["Nightly", ...sandbox.supportedVersions.filter(f => !notWorkingInPlayground.includes(f))]
 
   allVersions.forEach((v: string) => {
     const li = document.createElement("li")


### PR DESCRIPTION
There's so many TS versions that everyone keeps scrolling to find nightly. I think it should just be on top.