### PR TITLE
Remove color customizations from .vscode/settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,24 +6,4 @@
   },
   "typescript.tsdk": "node_modules/typescript/lib",
   "deno.enable": false,
-  "workbench.colorCustomizations": {
-    "activityBar.activeBackground": "#5592d5",
-    "activityBar.activeBorder": "#f2ccde",
-    "activityBar.background": "#5592d5",
-    "activityBar.foreground": "#15202b",
-    "activityBar.inactiveForeground": "#15202b99",
-    "activityBarBadge.background": "#f2ccde",
-    "activityBarBadge.foreground": "#15202b",
-    "sash.hoverBorder": "#5592d5",
-    "statusBar.background": "#3178c6",
-    "statusBar.foreground": "#e7e7e7",
-    "statusBarItem.hoverBackground": "#5592d5",
-    "statusBarItem.remoteBackground": "#3178c6",
-    "statusBarItem.remoteForeground": "#e7e7e7",
-    "titleBar.activeBackground": "#3178c6",
-    "titleBar.activeForeground": "#e7e7e7",
-    "titleBar.inactiveBackground": "#3178c699",
-    "titleBar.inactiveForeground": "#e7e7e799"
-  },
-  "peacock.color": "#3178C6"
 }


### PR DESCRIPTION
These customizations only apply to the VSCode editor when you open the repo in the editor and can conflict with your chosen color theme in VSCode, reducing visibility and making things harder to use.