### PR TITLE
Choose correct name for  type `(string | number)[]`

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Conditional Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Conditional Types.md
@@ -265,7 +265,7 @@ To avoid that behavior, you can surround each side of the `extends` keyword with
 ```ts twoslash
 type ToArrayNonDist<Type> = [Type] extends [any] ? Type[] : never;
 
-// 'StrArrOrNumArr' is no longer a union.
-type StrArrOrNumArr = ToArrayNonDist<string | number>;
+// 'ArrOfStrOrNum' is no longer a union.
+type ArrOfStrOrNum = ToArrayNonDist<string | number>;
 //   ^?
 ```


### PR DESCRIPTION
While I get the point of keeping the typenames the same for the sake of the consistency of the example, I think the updated name highlights the difference between the types `string[] | number[]` and `(string | number)[]` since `StrArrOrNumArr` is not correct anymore at this point.