### PR TITLE
Fix generic parameter defaults section in Generics.md

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Generics.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Generics.md
@@ -405,7 +405,7 @@ type Container<T, U> = {
 };
 
 // ---cut---
-declare function create<T extends HTMLElement = HTMLDivElement, U = T[]>(
+declare function create<T extends HTMLElement = HTMLDivElement, U extends HTMLElement[] = T[]>(
   element?: T,
   children?: U
 ): Container<T, U>;


### PR DESCRIPTION
Let's suppose that
```ts
class Animal {
  name: string = "TS";
}
```

then the first `create` declaration
```ts
declare function create(): Container<HTMLDivElement, HTMLDivElement[]>;
declare function create<T extends HTMLElement>(element: T): Container<T, T[]>;
declare function create<T extends HTMLElement, U extends HTMLElement>(
  element: T,
  children: U[]
): Container<T, U[]>;
```

correctly catches `create(new HTMLElement(), [new Animal()])` as type error, whereas the shortened version, that is 
```ts
declare function create<T extends HTMLElement = HTMLDivElement, U = T[]>(
  element?: T,
  children?: U
): Container<T, U>;
```
does allow `create(new HTMLElement(), [new Animal()])`.