### PR TITLE
Make an example more illustrative in Generics.md

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Generics.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Generics.md
@@ -152,7 +152,7 @@ let myIdentity: <Type>(arg: Type) => Type = identity;
 We could also have used a different name for the generic type parameter in the type, so long as the number of type variables and how the type variables are used line up.
 
 ```ts twoslash
-function identity<Input>(arg: Input): Input {
+function identity<Type>(arg: Type): Type {
   return arg;
 }
 


### PR DESCRIPTION
When reading this, I thought the authors' idea must have been to use _different_ names in the generic type parameter and the type. Doesn't the suggested version illustrate the concept better? 🤔 

> We could also have used a different name for the generic type parameter in the type, so long as the number of type variables and how the type variables are used line up.

**Before**
The name is `Input` in both declarations:
```ts twoslash
function identity<Input>(arg: Input): Input {
  return arg;
}

let myIdentity: <Input>(arg: Input) => Input = identity;
```

**After**
The name is `Type` in the first declaration but `Input` in the second:
```ts twoslash
function identity<Type>(arg: Type): Type {
  return arg;
}

let myIdentity: <Input>(arg: Input) => Input = identity;
```

I don't think this PR suggests anything new — I rather believe the suggested version was the original intention.