### PR TITLE
Update `compilerOptions.jsx` to reflect latest preferences

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/jsx.md
+++ b/packages/tsconfig-reference/copy/en/options/jsx.md
@@ -6,11 +6,11 @@ oneline: "Specify what JSX code is generated."
 Controls how JSX constructs are emitted in JavaScript files.
 This only affects output of JS files that started in `.tsx` files.
 
-- `react`: Emit `.js` files with JSX changed to the equivalent `React.createElement` calls
-- `react-jsx`: Emit `.js` files with the JSX changed to `_jsx` calls
-- `react-jsxdev`: Emit `.js` files with the JSX changed to `_jsx` calls
+- `react-jsx`: Emit `.js` files with the JSX changed to `_jsx` calls for production
+- `react-jsxdev`: Emit `.js` files with the JSX changed to `_jsx` calls for development
 - `preserve`: Emit `.jsx` files with the JSX unchanged
 - `react-native`: Emit `.js` files with the JSX unchanged
+- `react`: Emit `.js` files with JSX changed to the equivalent `React.createElement` calls
 
 ### For example
 
@@ -20,7 +20,7 @@ This sample code:
 export const HelloWorld = () => <h1>Hello world</h1>;
 ```
 
-Default: `"react"`
+default: `"react-jsx"`<sup>[[1]](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)</sup>
 
 ```tsx twoslash
 declare module JSX {
@@ -31,6 +31,22 @@ declare module JSX {
 }
 // @showEmit
 // @noErrors
+// @jsx: react-jsx
+export const HelloWorld = () => <h1>Hello world</h1>;
+```
+
+React dev transform: `"react-jsxdev"`<sup>[[1]](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)</sup>
+
+```tsx twoslash
+declare module JSX {
+  interface Element {}
+  interface IntrinsicElements {
+    [s: string]: any;
+  }
+}
+// @showEmit
+// @noErrors
+// @jsx: react-jsxdev
 export const HelloWorld = () => <h1>Hello world</h1>;
 ```
 
@@ -64,7 +80,8 @@ declare module JSX {
 export const HelloWorld = () => <h1>Hello world</h1>;
 ```
 
-React 17 transform: `"react-jsx"`<sup>[[1]](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)</sup>
+
+Legacy runtime: `"react"`
 
 ```tsx twoslash
 declare module JSX {
@@ -75,21 +92,5 @@ declare module JSX {
 }
 // @showEmit
 // @noErrors
-// @jsx: react-jsx
-export const HelloWorld = () => <h1>Hello world</h1>;
-```
-
-React 17 dev transform: `"react-jsxdev"`<sup>[[1]](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)</sup>
-
-```tsx twoslash
-declare module JSX {
-  interface Element {}
-  interface IntrinsicElements {
-    [s: string]: any;
-  }
-}
-// @showEmit
-// @noErrors
-// @jsx: react-jsxdev
 export const HelloWorld = () => <h1>Hello world</h1>;
 ```

--- a/packages/tsconfig-reference/copy/en/options/jsx.md
+++ b/packages/tsconfig-reference/copy/en/options/jsx.md
@@ -6,8 +6,8 @@ oneline: "Specify what JSX code is generated."
 Controls how JSX constructs are emitted in JavaScript files.
 This only affects output of JS files that started in `.tsx` files.
 
-- `react-jsx`: Emit `.js` files with the JSX changed to `_jsx` calls for production
-- `react-jsxdev`: Emit `.js` files with the JSX changed to `_jsx` calls for development
+- `react-jsx`: Emit `.js` files with the JSX changed to `_jsx` calls optimized for production
+- `react-jsxdev`: Emit `.js` files with the JSX changed to `_jsx` calls for development only
 - `preserve`: Emit `.jsx` files with the JSX unchanged
 - `react-native`: Emit `.js` files with the JSX unchanged
 - `react`: Emit `.js` files with JSX changed to the equivalent `React.createElement` calls

--- a/packages/tsconfig-reference/copy/en/options/jsx.md
+++ b/packages/tsconfig-reference/copy/en/options/jsx.md
@@ -20,7 +20,7 @@ This sample code:
 export const HelloWorld = () => <h1>Hello world</h1>;
 ```
 
-default: `"react-jsx"`<sup>[[1]](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)</sup>
+React: `"react-jsx"`<sup>[[1]](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)</sup>
 
 ```tsx twoslash
 declare module JSX {
@@ -81,7 +81,7 @@ export const HelloWorld = () => <h1>Hello world</h1>;
 ```
 
 
-Legacy runtime: `"react"`
+Legacy React runtime: `"react"`
 
 ```tsx twoslash
 declare module JSX {


### PR DESCRIPTION
`react-jsx` makes the most sense as a default.

[Preview](https://github.com/eps1lon/TypeScript-Website/blob/jsx-default/packages/tsconfig-reference/copy/en/options/jsx.md)