### PR TITLE
Update Object Types.md

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Object Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Object Types.md
@@ -275,7 +275,7 @@ Only some types are allowed for index signature properties: `string`, `number`, 
 
 <details>
     <summary>It is possible to support multiple types of indexers...</summary>
-    <p>It is possible to support multiple types of indexers.  Note that when using both `number` and `string` indexers, the type returned from a numeric indexer must be a subtype of the type returned from the string indexer. This is because when indexing with a <code>number</code>, JavaScript will actually convert that to a <code>string</code> before indexing into an object. That means that indexing with <code>100</code> (a <code>number</code>) is the same thing as indexing with <code>"100"</code> (a <code>string</code>), so the two need to be consistent.</p>
+    <p>It is possible to support multiple types of indexers. Note that when using both `number` and `string` indexers, the type returned from a numeric indexer must be a subtype of the type returned from the string indexer. This is because when indexing with a <code>number</code>, JavaScript will actually convert that to a <code>string</code> before indexing into an object. That means that indexing with <code>100</code> (a <code>number</code>) is the same thing as indexing with <code>"100"</code> (a <code>string</code>), so the two need to be consistent.</p>
 
 ```ts twoslash
 // @errors: 2413

--- a/packages/documentation/copy/en/handbook-v2/Object Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Object Types.md
@@ -274,8 +274,8 @@ This index signature states that when a `StringArray` is indexed with a `number`
 Only some types are allowed for index signature properties: `string`, `number`, `symbol`, template string patterns, and union types consisting only of these.
 
 <details>
-    <summary>It is possible to support both types of indexers...</summary>
-    <p>It is possible to support both types of indexers, but the type returned from a numeric indexer must be a subtype of the type returned from the string indexer. This is because when indexing with a <code>number</code>, JavaScript will actually convert that to a <code>string</code> before indexing into an object. That means that indexing with <code>100</code> (a <code>number</code>) is the same thing as indexing with <code>"100"</code> (a <code>string</code>), so the two need to be consistent.</p>
+    <summary>It is possible to support multiple types of indexers...</summary>
+    <p>It is possible to support multiple types of indexers.  Note that when using both `number` and `string` indexers, the type returned from a numeric indexer must be a subtype of the type returned from the string indexer. This is because when indexing with a <code>number</code>, JavaScript will actually convert that to a <code>string</code> before indexing into an object. That means that indexing with <code>100</code> (a <code>number</code>) is the same thing as indexing with <code>"100"</code> (a <code>string</code>), so the two need to be consistent.</p>
 
 ```ts twoslash
 // @errors: 2413


### PR DESCRIPTION
[Index Signatures of Object Types](https://www.typescriptlang.org/docs/handbook/2/objects.html#index-signatures) 

> It is possible to support both types of indexers, but the type returned from a numeric indexer must be a subtype of the type returned from the string indexer. 

Due to [the change supporting more types](https://github.com/microsoft/TypeScript-Website/issues/2525), `both types of indexers` is no more valid now.

The updated statement reflects the support for multiple types and clarifies the caveat when using both number and string indexers.


