### PR TITLE
A type argument should be passed

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -1211,7 +1211,7 @@ class Box<T> {
   }
 }
 
-const box = new Box();
+const box = new Box<string>();
 box.value = "Gameboy";
 
 box.value;


### PR DESCRIPTION
A type argument should be passed for proper demonstration of the example.