### PR TITLE
Swap CatName and CatInfo definitions in Record example

### DIFF
--- a/packages/documentation/copy/en/reference/Utility Types.md
+++ b/packages/documentation/copy/en/reference/Utility Types.md
@@ -140,12 +140,12 @@ Constructs an object type whose property keys are `Keys` and whose property valu
 ##### Example
 
 ```ts twoslash
+type CatName = "miffy" | "boris" | "mordred";
+
 interface CatInfo {
   age: number;
   breed: string;
 }
-
-type CatName = "miffy" | "boris" | "mordred";
 
 const cats: Record<CatName, CatInfo> = {
   miffy: { age: 10, breed: "Persian" },


### PR DESCRIPTION
- CatName and CatInfo were defined in one order but used in another. This made it difficult to read the example from top to bottom in a single pass.