### PR TITLE
Reorder Pick, Omit, Extract, and Exclude sections

### DIFF
--- a/packages/documentation/copy/en/reference/Utility Types.md
+++ b/packages/documentation/copy/en/reference/Utility Types.md
@@ -188,6 +188,34 @@ todo;
 // ^?
 ```
 
+## `Extract<Type, Union>`
+
+<blockquote class=bg-reading>
+
+Released:  
+[2.8](/docs/handbook/release-notes/typescript-2-8.html#predefined-conditional-types)
+
+</blockquote>
+
+Constructs a type by extracting from `Type` all union members that are assignable to `Union`.
+
+##### Example
+
+```ts twoslash
+type T0 = Extract<"a" | "b" | "c", "a" | "f">;
+//    ^?
+type T1 = Extract<string | number | (() => void), Function>;
+//    ^?
+
+type Shape =
+  | { kind: "circle"; radius: number }
+  | { kind: "square"; x: number }
+  | { kind: "triangle"; x: number; y: number };
+
+type T2 = Extract<Shape, { kind: "circle" }>
+//    ^?
+```
+
 ## `Omit<Type, Keys>`
 
 <blockquote class=bg-reading>
@@ -229,34 +257,6 @@ const todoInfo: TodoInfo = {
 
 todoInfo;
 // ^?
-```
-
-## `Extract<Type, Union>`
-
-<blockquote class=bg-reading>
-
-Released:  
-[2.8](/docs/handbook/release-notes/typescript-2-8.html#predefined-conditional-types)
-
-</blockquote>
-
-Constructs a type by extracting from `Type` all union members that are assignable to `Union`.
-
-##### Example
-
-```ts twoslash
-type T0 = Extract<"a" | "b" | "c", "a" | "f">;
-//    ^?
-type T1 = Extract<string | number | (() => void), Function>;
-//    ^?
-
-type Shape =
-  | { kind: "circle"; radius: number }
-  | { kind: "square"; x: number }
-  | { kind: "triangle"; x: number; y: number };
-
-type T2 = Extract<Shape, { kind: "circle" }>
-//    ^?
 ```
 
 ## `Exclude<UnionType, ExcludedMembers>`

--- a/packages/documentation/copy/en/reference/Utility Types.md
+++ b/packages/documentation/copy/en/reference/Utility Types.md
@@ -231,6 +231,34 @@ todoInfo;
 // ^?
 ```
 
+## `Extract<Type, Union>`
+
+<blockquote class=bg-reading>
+
+Released:  
+[2.8](/docs/handbook/release-notes/typescript-2-8.html#predefined-conditional-types)
+
+</blockquote>
+
+Constructs a type by extracting from `Type` all union members that are assignable to `Union`.
+
+##### Example
+
+```ts twoslash
+type T0 = Extract<"a" | "b" | "c", "a" | "f">;
+//    ^?
+type T1 = Extract<string | number | (() => void), Function>;
+//    ^?
+
+type Shape =
+  | { kind: "circle"; radius: number }
+  | { kind: "square"; x: number }
+  | { kind: "triangle"; x: number; y: number };
+
+type T2 = Extract<Shape, { kind: "circle" }>
+//    ^?
+```
+
 ## `Exclude<UnionType, ExcludedMembers>`
 
 <blockquote class=bg-reading>
@@ -258,34 +286,6 @@ type Shape =
   | { kind: "triangle"; x: number; y: number };
 
 type T3 = Exclude<Shape, { kind: "circle" }>
-//    ^?
-```
-
-## `Extract<Type, Union>`
-
-<blockquote class=bg-reading>
-
-Released:  
-[2.8](/docs/handbook/release-notes/typescript-2-8.html#predefined-conditional-types)
-
-</blockquote>
-
-Constructs a type by extracting from `Type` all union members that are assignable to `Union`.
-
-##### Example
-
-```ts twoslash
-type T0 = Extract<"a" | "b" | "c", "a" | "f">;
-//    ^?
-type T1 = Extract<string | number | (() => void), Function>;
-//    ^?
-
-type Shape =
-  | { kind: "circle"; radius: number }
-  | { kind: "square"; x: number }
-  | { kind: "triangle"; x: number; y: number };
-
-type T2 = Extract<Shape, { kind: "circle" }>
 //    ^?
 ```
 


### PR DESCRIPTION
- The original order of these four sections was: 

   `Pick, Omit, Exclude, Extract, `

   Or, in terms of Keeping and Deleting key/union members, the original order was:

   `Keep, Delete, Delete, Keep`

   I rearranged it to be this:

   `Pick, Omit, Extract, Exclude, `

   Or, in terms of Keeping and Deleting key/union members:

   `Keep, Delete, Keep, Delete`
- I plan to add another commit to change the order to: 

    `Pick, Extract, Omit, Exclude, `

   Or, in terms of Keeping and Deleting key/union members:

   `Keep, Keep, Delete, Delete`

   I think this order is even more useful, because I am often looking at this page trying to figure out which "Keep" utility type I'm looking for, or which "Delete" utility type, and now they will be side-by-side. The reason I'm not putting this in a single commit is because I think this next "improvement" is more subjective than the current, and I want to make it easier to `git reset` a portion 