### PR TITLE
Include dates and links to release blog posts in release-notes

### DIFF
--- a/packages/documentation/copy/en/release-notes/TypeScript 2.0.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 2.0.md
@@ -5,6 +5,8 @@ permalink: /docs/handbook/release-notes/typescript-2-0.html
 oneline: TypeScript 2.0 Release Notes
 ---
 
+Release date: [September 22, 2016](https://devblogs.microsoft.com/typescript/announcing-typescript-2-0/)
+
 ## Null- and undefined-aware types
 
 TypeScript has two special types, Null and Undefined, that have the values `null` and `undefined` respectively.

--- a/packages/documentation/copy/en/release-notes/TypeScript 2.1.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 2.1.md
@@ -5,6 +5,8 @@ permalink: /docs/handbook/release-notes/typescript-2-1.html
 oneline: TypeScript 2.1 Release Notes
 ---
 
+Release date: [December 7th, 2016](https://devblogs.microsoft.com/typescript/announcing-typescript-2-1-2/)
+
 ## `keyof` and Lookup Types
 
 In JavaScript it is fairly common to have APIs that expect property names as parameters, but so far it hasn't been possible to express the type relationships that occur in those APIs.

--- a/packages/documentation/copy/en/release-notes/TypeScript 2.2.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 2.2.md
@@ -5,6 +5,8 @@ permalink: /docs/handbook/release-notes/typescript-2-2.html
 oneline: TypeScript 2.2 Release Notes
 ---
 
+Release date: [February 22, 2017](https://devblogs.microsoft.com/typescript/announcing-typescript-2-2/)
+
 ## Support for Mix-in classes
 
 TypeScript 2.2 adds support for the ECMAScript 2015 mixin class pattern (see [MDN Mixin description](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes#Mix-ins) and ["Real" Mixins with JavaScript Classes](http://justinfagnani.com/2015/12/21/real-mixins-with-javascript-classes/) for more details) as well as rules for combining mixin construct signatures with regular construct signatures in intersection types.

--- a/packages/documentation/copy/en/release-notes/TypeScript 2.3.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 2.3.md
@@ -5,6 +5,8 @@ permalink: /docs/handbook/release-notes/typescript-2-3.html
 oneline: TypeScript 2.3 Release Notes
 ---
 
+Release date: [April 27, 2017](https://devblogs.microsoft.com/typescript/announcing-typescript-2-3/)
+
 ## Generators and Iteration for ES5/ES3
 
 _First some ES2016 terminology:_

--- a/packages/documentation/copy/en/release-notes/TypeScript 2.4.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 2.4.md
@@ -5,6 +5,8 @@ permalink: /docs/handbook/release-notes/typescript-2-4.html
 oneline: TypeScript 2.4 Release Notes
 ---
 
+Release date: [June 27, 2017](https://devblogs.microsoft.com/typescript/announcing-typescript-2-4/)
+
 ## Dynamic Import Expressions
 
 Dynamic `import` expressions are a new feature and part of ECMAScript that allows users to asynchronously request a module at any arbitrary point in your program.


### PR DESCRIPTION
So far as I can tell, the only difference between the [release blog post](https://devblogs.microsoft.com/typescript/announcing-typescript-2-3/) and the [release notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html) is that the former includes a release date.

If you're looking at the release notes for an old release, that's useful information! So this adds it to the docs pages.

I only added dates and blog post links to five releases in this PR. If the maintainers like the idea I'm happy to add them to the remaining releases.