### PR TITLE
fix(sandbox): switch alwaysStrict default to false

### DIFF
--- a/packages/playground-examples/copy/en/Playground/Config/New Compiler Defaults.ts
+++ b/packages/playground-examples/copy/en/Playground/Config/New Compiler Defaults.ts
@@ -28,7 +28,7 @@ const defaultCompilerOptions = {
   noImplicitThis: true,
   noImplicitReturns: true,
 
-  alwaysStrict: true,
+  alwaysStrict: false,
   allowUnreachableCode: false,
   allowUnusedLabels: false,
 

--- a/packages/sandbox/src/compilerOptions.ts
+++ b/packages/sandbox/src/compilerOptions.ts
@@ -24,7 +24,7 @@ export function getDefaultSandboxCompilerOptions(config: SandboxConfig, monaco: 
     // 3.7 off, 3.8 on I think
     useDefineForClassFields: false,
 
-    alwaysStrict: true,
+    alwaysStrict: false,
     allowUnreachableCode: false,
     allowUnusedLabels: false,
 


### PR DESCRIPTION
Per my interpretation of [a brief discussion on `alwaysStrict` in Discord]( https://discord.com/channels/508357248330760243/640177465490407425/1196309864260046858), changes the default value for that setting to off.

Note that this doesn't imply anything about TypeScript's recommendations around strict mode. It just changes the playground to not emit a `"use strict";` on top of emitted JS. That string has been a thorn in my side trying to teach TypeScript in workshops for years.