### PR TITLE
Fix sidebar header tree creation

### DIFF
--- a/packages/typescriptlang-org/src/templates/documentation.tsx
+++ b/packages/typescriptlang-org/src/templates/documentation.tsx
@@ -195,18 +195,33 @@ type MarkdownHeadingTreeNode = {
 
 function headerListToTree(sidebarHeaders: GatsbyTypes.Maybe<Pick<GatsbyTypes.MarkdownHeading, "value" | "depth">>[]) {
   const tree: MarkdownHeadingTreeNode[] = []
-  let currentParent: MarkdownHeadingTreeNode | undefined
-  sidebarHeaders.forEach(heading => {
-    if (!currentParent || heading!.depth === 2) {
-      currentParent = { value: heading!.value!, depth: heading!.depth!, children: [] }
-      tree.push(currentParent)
-    } else {
-      currentParent.children?.push({
-        value: heading!.value!,
-        depth: heading!.depth!,
-      })
+  const stack: { node: MarkdownHeadingTreeNode; depth: number }[] = []
+
+  sidebarHeaders.forEach(header => {
+    const value = header?.value!;
+    const depth = header?.depth!;
+    const newNode: MarkdownHeadingTreeNode = {
+      value,
+      depth
     }
+
+    while (stack.length > 0 && stack[stack.length - 1].depth >= depth) {
+      stack.pop()
+    }
+
+    if (stack.length === 0) {
+      tree.push(newNode)
+    } else {
+      const topNode = stack[stack.length - 1].node;
+      if (!topNode.children) {
+        topNode.children = [];
+      }
+      topNode.children.push(newNode);
+    }
+
+    stack.push({ node: newNode, depth })
   })
+
   return tree
 }
 


### PR DESCRIPTION
I don't think the depth structure of the document's sidebar represents the depth of the headers in the document very well.

This makes it a little difficult to understand the content.

For example, for "Narrowing" in the handbook, the header in the document looks like this

```md
## `typeof` type guards
# Truthiness narrowing
## Equality narrowing
## The `in` operator narrowing
## `instanceof` narrowing
## Assignments
## Control flow analysis
## Using type predicates
## Assertion functions
# Discriminated unions
# The `never` type
# Exhaustiveness checking
```

In the sidebar on the current page, it looks like this

<img width="213" alt="image" src="https://github.com/laranhee/TypeScript-Website/assets/8968165/f3223140-0cdf-498f-b4ad-00d087abe0f3">

I think this makes more sense. because I think all the h1s should be 1-depth, and the first h2 should be 1-depth.

<img width="202" alt="image" src="https://github.com/laranhee/TypeScript-Website/assets/8968165/ff116e41-265e-4e3f-a384-782620a3a505">

I've also found cases like this with "template-literal-types", "conditional-types", etc.


