### PR TITLE
Fix `@typescript/vfs` Critical dependency: the request of a dependency is an expression

### DIFF
--- a/packages/typescript-vfs/src/index.ts
+++ b/packages/typescript-vfs/src/index.ts
@@ -641,9 +641,9 @@ export function createVirtualLanguageServiceHost(
 }
 
 const requirePath = () => {
-  return require(String.fromCharCode(112, 97, 116, 104)) as typeof import("path")
+  return require('path') as typeof import("path")
 }
 
 const requireFS = () => {
-  return require(String.fromCharCode(102, 115)) as typeof import("fs")
+  return require('fs') as typeof import("fs")
 }


### PR DESCRIPTION
I am getting warnings and after errors due these `require` statements

```
../node_modules/.pnpm/@typescript+vfs@1.5.0/node_modules/@typescript/vfs/dist/vfs.esm.js
Critical dependency: the request of a dependency is an expression

Import trace for requested module:
../node_modules/.pnpm/@typescript+vfs@1.5.0/node_modules/@typescript/vfs/dist/vfs.esm.js
../node_modules/.pnpm/twoslash@0.1.0_typescript@5.3.3/node_modules/twoslash/dist/index.mjs
../node_modules/.pnpm/shikiji-twoslash@0.10.2_typescript@5.3.3/node_modules/shikiji-twoslash/dist/index.mjs
../packages/nextra/dist/server/compile.js
./app/docs/guide/ssg/page.mdx
./.next/static/chunks/nextra-page-map-.mjs
./app/layout.tsx
```