### PR TITLE
Fix the expanded main content header's style for better UX

### DIFF
--- a/packages/typescriptlang-org/src/templates/tsconfig.scss
+++ b/packages/typescriptlang-org/src/templates/tsconfig.scss
@@ -33,12 +33,12 @@
       }
     }
   }
-  &.button.open {
+  &.button.closed {
     svg {
       transform: rotate(270deg);
     }
   }
-  &.button.closed {
+  &.button.open {
     a {
       text-decoration: none;
       color: var(--text-color);


### PR DESCRIPTION
I think the arrow icon behavior is reversed in this section. Not sure about the link styling ( I mean what's your preferred style in this case ) 

### Before: 

#### collapsed
![image](https://github.com/microsoft/TypeScript-Website/assets/65634467/2b5f8930-b263-46dc-b384-5c86612b0feb)

#### expanded
![image](https://github.com/microsoft/TypeScript-Website/assets/65634467/a41b7dba-65c3-42de-8feb-36a6ba39ef19)


### After : 

#### collapsed
![image](https://github.com/microsoft/TypeScript-Website/assets/65634467/f426dfc8-f611-497c-ad7d-f1caab6abb52)

#### expanded
![image](https://github.com/microsoft/TypeScript-Website/assets/65634467/cd07e1dc-c8d8-47e6-8717-9699490a595a)

