### PR TITLE
Fix `@typescript/vfs` type declaration error

### DIFF
--- a/packages/typescript-vfs/package.json
+++ b/packages/typescript-vfs/package.json
@@ -41,6 +41,7 @@
     "typescript": false
   },
   "dependencies": {
+    "@types/lz-string": "^1.3.33",
     "debug": "^4.1.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6126,6 +6126,7 @@ __metadata:
   resolution: "@typescript/vfs@workspace:packages/typescript-vfs"
   dependencies:
     "@types/jest": ^25.1.3
+    "@types/lz-string": ^1.3.33
     babel-jest: ^26.0.6
     cpy-cli: ^3.1.1
     debug: ^4.1.1


### PR DESCRIPTION
Add the missing `lz-string` type dependency.
fix #2953 