### PR TITLE
Quick styling change for consistency on "More on Functions.md"

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -368,7 +368,7 @@ Note that when a parameter is optional, callers can always pass `undefined`, as 
 
 ```ts twoslash
 declare function f(x?: number): void;
-// cut
+// ---cut---
 // All OK
 f();
 f(10);


### PR DESCRIPTION
Simple update for consistency in comment styles for cutting prior code snippet in sample.
This single snippet uses "// cut", all other samples on this page use a clear style  "// ---cut---"