### PR TITLE
Improve first Example of "The satisfies Operator" in TS 4.9 r notes

### DIFF
--- a/packages/documentation/copy/en/release-notes/TypeScript 4.9.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 4.9.md
@@ -20,10 +20,7 @@ const palette = {
 //  ^^^^ sacrebleu - we've made a typo!
 };
 
-// We want to be able to use array methods on 'red'...
-const redComponent = palette.red.at(0);
-
-// or string methods on 'green'...
+// We want to be able to use string methods on 'green'...
 const greenNormalized = palette.green.toUpperCase();
 ```
 
@@ -42,8 +39,9 @@ const palette: Record<Colors, string | RGB> = {
 //  ~~~~ The typo is now correctly detected
 };
 
-// But we now have an undesirable error here - 'palette.red' "could" be a string.
-const redComponent = palette.red.at(0);
+// But we now have an undesirable error here - 'palette.green' "could" be of type RGB and
+// property 'toUpperCase' does not exist on type 'string | RGB'.
+const greenNormalized = palette.green.toUpperCase();
 ```
 
 The new `satisfies` operator lets us validate that the type of an expression matches some type, without changing the resulting type of that expression.
@@ -61,8 +59,7 @@ const palette = {
 //  ~~~~ The typo is now caught!
 } satisfies Record<Colors, string | RGB>;
 
-// Both of these methods are still accessible!
-const redComponent = palette.red.at(0);
+// toUpperCase() methode is still accessible!
 const greenNormalized = palette.green.toUpperCase();
 ```
 


### PR DESCRIPTION
See for details: https://github.com/microsoft/TypeScript/issues/57005

tl;dr: Documentation is incorrect or misleading. Since values are unions of string and array, palette.red.at(0) will not throw an error, because `at()` method is a method that exists for both types.