### PR TITLE
fix/ Update listFiles to listEmittedFiles in listEmittedFiles.md

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/listEmittedFiles.md
+++ b/packages/tsconfig-reference/copy/en/options/listEmittedFiles.md
@@ -25,7 +25,7 @@ With:
 {
   "compilerOptions": {
     "declaration": true,
-    "listFiles": true
+    "listEmittedFiles": true
   }
 }
 ```


### PR DESCRIPTION
There is a small mistake in the name of the property in the file called `listEmittedFiles.md`. This error likely occurred when copying from the `listFiles.md` file.