### PR TITLE
Use explicit file types for module examples

### DIFF
--- a/packages/documentation/copy/en/modules-reference/Reference.md
+++ b/packages/documentation/copy/en/modules-reference/Reference.md
@@ -231,10 +231,12 @@ The detected module format of input `.ts`/`.tsx`/`.mts`/`.cts` files determines 
 The emit format of each file is determined by the [detected module format](#module-format-detection) of each file. ESM emit is similar to [`--module esnext`](#es2015-es2020-es2022-esnext), but has a special transformation for `import x = require("...")`, which is not allowed in `--module esnext`:
 
 ```ts
+// @Filename: main.ts
 import x = require("mod");
 ```
 
 ```js
+// @Filename: main.js
 import { createRequire as _createRequire } from "module";
 const __require = _createRequire(import.meta.url);
 const x = __require("mod");
@@ -243,11 +245,13 @@ const x = __require("mod");
 CommonJS emit is similar to [`--module commonjs`](#commonjs), but dynamic `import()` calls are not transformed. Emit here is shown with `esModuleInterop` enabled:
 
 ```ts
+// @Filename: main.ts
 import fs from "fs"; // transformed
 const dynamic = import("mod"); // not transformed
 ```
 
 ```js
+// @Filename: main.js
 "use strict";
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
@@ -287,6 +291,7 @@ const dynamic = import("mod"); // not transformed
 #### Examples
 
 ```ts
+// @Filename: main.ts
 import x, { y, z } from "mod";
 import * as mod from "mod";
 const dynamic = import("mod");
@@ -297,6 +302,7 @@ export default "default export";
 ```
 
 ```js
+// @Filename: main.js
 import x, { y, z } from "mod";
 import * as mod from "mod";
 const dynamic = import("mod");
@@ -320,6 +326,7 @@ export default "default export";
 > Output is shown with `esModuleInterop: false`.
 
 ```ts
+// @Filename: main.ts
 import x, { y, z } from "mod";
 import * as mod from "mod";
 const dynamic = import("mod");
@@ -330,6 +337,7 @@ export default "default export";
 ```
 
 ```js
+// @Filename: main.js
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.e1 = void 0;
@@ -343,6 +351,7 @@ exports.default = "default export";
 ```
 
 ```ts
+// @Filename: main.ts
 import mod = require("mod");
 console.log(mod);
 
@@ -353,6 +362,7 @@ export = {
 ```
 
 ```js
+// @Filename: main.js
 "use strict";
 const mod = require("mod");
 console.log(mod);
@@ -372,6 +382,7 @@ module.exports = {
 #### Examples
 
 ```ts
+// @Filename: main.ts
 import x, { y, z } from "mod";
 import * as mod from "mod";
 const dynamic = import("mod");
@@ -382,6 +393,7 @@ export default "default export";
 ```
 
 ```js
+// @Filename: main.js
 System.register(["mod"], function (exports_1, context_1) {
     "use strict";
     var mod_1, mod, dynamic, e1;
@@ -415,6 +427,7 @@ System.register(["mod"], function (exports_1, context_1) {
 #### Examples
 
 ```ts
+// @Filename: main.ts
 import x, { y, z } from "mod";
 import * as mod from "mod";
 const dynamic = import("mod");
@@ -425,6 +438,7 @@ export default "default export";
 ```
 
 ```js
+// @Filename: main.js
 define(["require", "exports", "mod", "mod"], function (require, exports, mod_1, mod) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
@@ -449,6 +463,7 @@ define(["require", "exports", "mod", "mod"], function (require, exports, mod_1, 
 #### Examples
 
 ```ts
+// @Filename: main.ts
 import x, { y, z } from "mod";
 import * as mod from "mod";
 const dynamic = import("mod");
@@ -459,6 +474,7 @@ export default "default export";
 ```
 
 ```js
+// @Filename: main.js
 (function (factory) {
     if (typeof module === "object" && typeof module.exports === "object") {
         var v = factory(require, exports);


### PR DESCRIPTION
In "The `module` compiler option" section of the TS docs, it is difficult to understand that each pair of codeblocks represents a source file and built file. It is obvious in the markdown code due to the fact that the language is specified in the code block, but that is not transparent to the reader of the site. For example, the `ES...` example section has an identical input and output which is confusing for most even given the context of the section it is in or even the page they are on. 

This PR attempts to fix that by adding filename comments above each pair of code blocks that specify that it is an input file (`.ts`) or a built file (`.js`). The syntax chosen matches the syntax from the "Type-only imports and exports" section on the same page.

As an example, here is the existing `ES...` section.

```ts
import x, { y, z } from "mod";
import * as mod from "mod";
const dynamic = import("mod");
console.log(x, y, z, mod, dynamic);

export const e1 = 0;
export default "default export";
```

```js
import x, { y, z } from "mod";
import * as mod from "mod";
const dynamic = import("mod");
console.log(x, y, z, mod, dynamic);

export const e1 = 0;
export default "default export";
```
