### PR TITLE
Document NoInfer

### DIFF
--- a/packages/documentation/copy/en/reference/Utility Types.md
+++ b/packages/documentation/copy/en/reference/Utility Types.md
@@ -452,6 +452,32 @@ type T4 = InstanceType<Function>;
 //    ^?
 ```
 
+## `NoInfer<Type>`
+
+<blockquote class=bg-reading>
+
+Released:  
+[5.4](https://devblogs.microsoft.com/typescript/announcing-typescript-5-4/#the-noinfer-utility-type)
+
+</blockquote>
+
+Blocks inferences to the contained type. Other than blocking inferences, `NoInfer<Type>` is
+identical to `Type`.
+
+##### Example
+
+```ts
+function createStreetLight<C extends string>(
+  colors: C[],
+  defaultColor?: NoInfer<C>,
+) {
+  // ...
+}
+
+createStreetLight(["red", "yellow", "green"], "red");  // OK
+createStreetLight(["red", "yellow", "green"], "blue");  // Error
+```
+
 ## `ThisParameterType<Type>`
 
 <blockquote class=bg-reading>


### PR DESCRIPTION
Not using twoslash for the example here because the document is built with TS 5.0, which would complain that `NoInfer` is an unknown symbol.

Fix microsoft/TypeScript#58121