### PR TITLE
Fixes a typo in esm-csj-interop.md

### DIFF
--- a/packages/documentation/copy/en/modules-reference/appendices/ESM-CJS-Interop.md
+++ b/packages/documentation/copy/en/modules-reference/appendices/ESM-CJS-Interop.md
@@ -141,7 +141,7 @@ Meanwhile, other transpilers were coming up with a way to solve the same problem
    ```
    that we can check for when we transpile a default import:
    ```ts
-   // import hello from "./modue";
+   // import hello from "./module";
    const _mod = require("./module");
    const hello = _mod.__esModule ? _mod.default : _mod;
    ```


### PR DESCRIPTION
This pull request fixes a typo in the word 'module' in the file ESM-CJS-Interop.md