### PR TITLE
Rewrite preview environment to use new artifact system

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,14 +1,12 @@
 name: CI
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
     branches:
       - v2
 
 jobs:
   tests:
     runs-on: ubuntu-latest
-    if: github.event.action != 'closed'
     steps:
       # Check out, and set up the node/ruby infra
       - uses: actions/checkout@v2
@@ -40,32 +38,20 @@ jobs:
         env:
           CI: true
 
-      # Deploy preview environment for non-forks
-      - uses: Azure/static-web-apps-deploy@v1
-        if: github.event.pull_request.base.repo.id == github.event.pull_request.head.repo.id
+      - uses: actions/upload-artifact@v4
+        if: github.event_name == 'pull_request'
         with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PROD }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          action: upload
-          app_location: site
-          skip_app_build: true
-
-      # Upload site artifact for forks so it can be deployed by a maintainer on-demand
-      - uses: actions/upload-artifact@v3
-        if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
-        with:
-          name: site-${{ github.event.number }}
-          path: site/
+          name: site
+          path: site
+          retention-days: 7
 
       # danger for PR builds
       - if: github.event_name == 'pull_request' && github.event.pull_request.base.repo.id == github.event.pull_request.head.repo.id
         run: "yarn danger ci"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_DEPLOY_URL_ROOT: ${{ steps.deploy.outputs.static_web_app_url }}
 
   windows:
-    if: github.event.action != 'closed'
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,7 +43,6 @@ jobs:
         with:
           name: site
           path: site
-          retention-days: 7
 
       # danger for PR builds
       - if: github.event_name == 'pull_request' && github.event.pull_request.base.repo.id == github.event.pull_request.head.repo.id

--- a/.github/workflows/close-preview.yml
+++ b/.github/workflows/close-preview.yml
@@ -1,5 +1,11 @@
 name: Close preview environment
 on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        required: true
+        type: string
+        description: PR number
   pull_request_target:
     types: [closed]
 
@@ -11,3 +17,4 @@ jobs:
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PROD }}
           action: close
+          app_location: /dev/null

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -17,129 +17,102 @@ jobs:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - name: Download site build
-        if: github.event_name == 'workflow_run'
-        uses: actions/github-script@v6
-        id: download-from-workflow-run
+      - name: Get PR/workflow run info
+        id: get-info
+        uses: actions/github-script@v7
         with:
-          result-encoding: string
           script: |
-            const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
-            });
-            const artifact = allArtifacts.data.artifacts.find(artifact => {
-              return artifact.name.startsWith('site-');
-            });
-            if (!artifact) {
-              console.log('No site artifact found');
-              return;
-            }
-
-            const prNumber = artifact.name.split('-')[1];
-            console.log('Detected PR number from artifact: ', prNumber);
-
-            // Check if the PR has the "deploy-preview" label
-            const pr = (await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-            })).data;
-            if (!pr.labels.some(label => label.name === 'deploy-preview')) {
-              console.log('PR does not have the "deploy-preview" label');
-              return;
-            }
-
-            const download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: artifact.id,
-               archive_format: 'zip',
-            });
-
-            const fs = require('fs');
-            fs.writeFileSync('site.zip', Buffer.from(download.data));
-            return prNumber;
-
-      - name: Download site build
-        if: github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch'
-        uses: actions/github-script@v6
-        id: download-from-pr
-        with:
-          result-encoding: string
-          script: |
-            const prNumber = context.eventName === 'pull_request_target'
-              ? context.payload.pull_request.number
-              : context.payload.inputs.pr;
-
-            if (context.eventName === 'pull_request_target' && context.payload.label.name !== 'deploy-preview') {
-              console.log('Label is not "deploy-preview"');
-              return;
-            }
-
             let pr;
-            if (context.eventName === 'workflow_dispatch') {
-              pr = (await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber,
-              })).data;
-            } else {
-              pr = context.payload.pull_request;
+            let workflowRun;
+            let isLabel = false;
+            switch (context.eventName) {
+              case "workflow_dispatch":
+                pr = (await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: +context.payload.inputs.pr,
+                })).data;
+                break;
+              case "pull_request_target":
+                pr = context.payload.pull_request;
+                break;
+              case "workflow_run":
+                workflowRun = context.payload.workflow_run;
+                pr = workflowRun.pull_requests[0];
+                if (pr) {
+                  // Reload the PR to get the labels.
+                  pr = (await github.rest.pulls.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: pr.number,
+                  })).data;
+                } else {
+                  // PRs sent from forks do not get the pull_requests field set.
+                  // https://github.com/orgs/community/discussions/25220
+                  pr = (await github.rest.pulls.list({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    head: workflowRun.head_sha,
+                    per_page: 1,
+                  })).data[0];
+                }
             }
 
-            // https://github.com/orgs/community/discussions/24709
-            const workflowRun = (await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'CI.yml',
-              branch: pr.head.ref,
-              event: 'pull_request',
-              status: 'success',
-              per_page: 1,
-            })).data.workflow_runs[0];
+            if (!pr) {
+              throw new Error("Could not find PR");
+            }
+
+            if (!pr.labels.some((label) => label.name === "deploy-preview")) {
+              console.log(`PR ${pr.number} does not have the deploy-preview label`);
+              return null;
+            }
 
             if (!workflowRun) {
-              console.log('No matching workflow run found from branch ', pr.head.ref);
-              return;
+              try {
+                workflowRun = (await github.rest.actions.listWorkflowRuns({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: "ci.yml",
+                  head_sha: pr.head.sha,
+                  per_page: 1,
+                })).data.workflow_runs[0];
+              } catch (e) {
+                console.log(e);
+              }
             }
 
-            const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: workflowRun.id,
-            });
-            const artifact = allArtifacts.data.artifacts.find(artifact => {
-              return artifact.name.startsWith('site-');
-            });
-            if (!artifact) {
-              console.log('No site artifact found');
-              return;
+            if (!workflowRun) {
+              console.log(`Could not find workflow run for PR ${pr.number}`);
+              return null;
             }
 
-            const download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: artifact.id,
-               archive_format: 'zip',
-            });
+            console.log(`Found workflow run ${workflowRun.html_url}`)
 
-            const fs = require('fs');
-            fs.writeFileSync('site.zip', Buffer.from(download.data));
-            return prNumber;
+            if (workflowRun.conclusion !== "success") {
+              console.log(`Workflow run did not succeed`);
+              return null;
+            }
 
-      - name: Unzip site build
-        if: steps.download-from-workflow-run.outputs.result || steps.download-from-pr.outputs.result
-        run: unzip site.zip -d site
+            const result = { pr: pr.number, runId: workflowRun.id };
+            console.log(result);
+            return result;
+
+      - name: Download site build from PR
+        if: ${{ steps.get-info.outputs.result != 'null' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: site
+          path: site
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ fromJson(steps.get-info.outputs.result).runId }}
 
       - run: ls -R
-        if: steps.download-from-workflow-run.outputs.result || steps.download-from-pr.outputs.result
+        if: ${{ steps.get-info.outputs.result != 'null' }}
         working-directory: site
 
       - name: Deploy
         id: deploy
-        if: steps.download-from-workflow-run.outputs.result || steps.download-from-pr.outputs.result
+        if: ${{ steps.get-info.outputs.result != 'null' }}
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PROD }}
@@ -148,14 +121,14 @@ jobs:
           app_location: "site"
           skip_app_build: true
           production_branch: v2
-          deployment_environment: ${{ steps.download-from-workflow-run.outputs.result || steps.download-from-pr.outputs.result }}
+          deployment_environment: ${{ fromJson(steps.get-info.outputs.result).pr }}
 
       - name: Comment on PR
         # azure/static-web-apps-deploy seems to comment itself when the event is pull_request_target
-        if: github.event_name != 'pull_request_target' && (steps.download-from-workflow-run.outputs.result || steps.download-from-pr.outputs.result)
-        uses: actions/github-script@v6
+        if: ${{ steps.get-info.outputs.result != 'null' && github.event_name != 'pull_request_target' }}
+        uses: actions/github-script@v7
         env:
-          PR_NUMBER: ${{ steps.download-from-workflow-run.outputs.result || steps.download-from-pr.outputs.result }}
+          PR_NUMBER: ${{ fromJson(steps.get-info.outputs.result).pr }}
           SITE_URL: ${{ steps.deploy.outputs.static_web_app_url }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GitHub Actions artifacts are a lot more robust now; rewrite the preview system to more directly pull artifacts, avoid zipping, etc. This new rewrite should also now be more robust when it comes to PR states, races, etc.