### PR TITLE
Make String, Number and Boolean types more clear.

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -24,7 +24,7 @@ As you might expect, these are the same names you'd see if you used the JavaScri
 - `number` is for numbers like `42`. JavaScript does not have a special runtime value for integers, so there's no equivalent to `int` or `float` - everything is simply `number`
 - `boolean` is for the two values `true` and `false`
 
-> The type names [`String`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String), [`Number`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number), and [`Boolean`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean) (starting with capital letters) are legal and refer to the object wrapper for their respective data types. You should rarely find yourself using them except when you need to work with methods or properties specific to these data types. However, _Always_ use `string`, `number`, or `boolean` for types.
+> The type names [`String`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String), [`Number`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number), and [`Boolean`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean) (starting with capital letters) are legal and refer to the object wrapper for their respective data types. You should rarely find yourself using them except when you need to work with methods or properties specific to these data types. However, _always_ use `string`, `number`, or `boolean` for types.
 
 ## Arrays
 

--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -24,7 +24,7 @@ As you might expect, these are the same names you'd see if you used the JavaScri
 - `number` is for numbers like `42`. JavaScript does not have a special runtime value for integers, so there's no equivalent to `int` or `float` - everything is simply `number`
 - `boolean` is for the two values `true` and `false`
 
-> The type names `String`, `Number`, and `Boolean` (starting with capital letters) are legal, but refer to some special built-in types that will very rarely appear in your code. _Always_ use `string`, `number`, or `boolean` for types.
+> The type names [`String`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String), [`Number`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number), and [`Boolean`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean) (starting with capital letters) are legal and refer to the object wrapper for their respective data types. You should rarely find yourself using them except when you need to work with methods or properties specific to these data types. However, _Always_ use `string`, `number`, or `boolean` for types.
 
 ## Arrays
 


### PR DESCRIPTION
The current documentation lacks clarity in its explanation of `String`, `Number`, and `Boolean`. Rather than providing a clear definition, the document simply states that these are special built-in types that are rarely used in code.

It would be more helpful to explain what these types are when they are typically used, and why they are not commonly seen in code. Additionally, it adds links to the sources where users can learn more about these types.