### PR TITLE
docs(jsdoc): remove `const` and `inheritDoc` from unsupported tags

### DIFF
--- a/packages/documentation/copy/en/javascript/JSDoc Reference.md
+++ b/packages/documentation/copy/en/javascript/JSDoc Reference.md
@@ -823,7 +823,5 @@ TypeScript ignores any unsupported JSDoc tags.
 
 The following tags have open issues to support them:
 
-- `@const` ([issue #19672](https://github.com/Microsoft/TypeScript/issues/19672))
-- `@inheritdoc` ([issue #23215](https://github.com/Microsoft/TypeScript/issues/23215))
 - `@memberof` ([issue #7237](https://github.com/Microsoft/TypeScript/issues/7237))
 - `@yields` ([issue #23857](https://github.com/Microsoft/TypeScript/issues/23857))


### PR DESCRIPTION
Both microsoft/TypeScript#19672 and microsoft/TypeScript#23215 are resolved in recent release, so those may be removed from unsupported tags.