### PR TITLE
Clarify TypeScript's structurally typed vs. nominally typed distinction

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -388,7 +388,7 @@ printCoord({ x: 100, y: 100 });
 
 Just like when we used a type alias above, the example works just as if we had used an anonymous object type.
 TypeScript is only concerned with the _structure_ of the value we passed to `printCoord` - it only cares that it has the expected properties.
-Being concerned only with the structure and capabilities of types is why we call TypeScript a _structurally typed_ type system.
+Being concerned only with the structure and capabilities of types is why we call TypeScript a _structurally typed_ type system; the opposite is a _nominally typed_ type system, where type compatibility is based on the names of the types rather than their structure.
 
 ### Differences Between Type Aliases and Interfaces
 


### PR DESCRIPTION
Many readers who refer to the documentation may not be familiar with type systems. Therefore, when they come across the following statement:
 
> Being concerned only with the structure and capabilities of types is why we call TypeScript a *structurally typed* type system.

It may not make complete sense to them. To make it clearer, we should mention the opposite of what is meant by the term "structurally typed" to help readers understand more clearly and look it up if needed.