### PR TITLE
Add example to make statement clearer.

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -95,12 +95,12 @@ function fn(ctor: CallOrConstruct) {
   // Passing an argument of type `number` to `ctor` matches it against
   // the first definition in the `CallOrConstruct` interface.
   console.log(ctor(10));
-              // ^
+              // ^?
 
   // Similarly, passing an argument of type `string` to `ctor` matches it
   // against the second definition in the `CallOrConstruct` interface.
   console.log(new ctor("10"));
-                  // ^
+                  // ^?
 }
 
 fn(Date);

--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -90,6 +90,20 @@ interface CallOrConstruct {
   (n?: number): string;
   new (s: string): Date;
 }
+
+function fn(ctor: CallOrConstruct) {
+  // Passing an argument of type `number` to `ctor` matches it against
+  // the first definition in the `CallOrConstruct` interface.
+  console.log(ctor(10));
+              // ^
+
+  // Similarly, passing an argument of type `string` to `ctor` matches it
+  // against the second definition in the `CallOrConstruct` interface.
+  console.log(new ctor("10"));
+                  // ^
+}
+
+fn(Date);
 ```
 
 ## Generic Functions


### PR DESCRIPTION
The documentation states that:

> Some objects, like JavaScript’s Date object, can be called with or without new. You can combine call and construct signatures in the same type arbitrarily:

To make the statement more comprehensible, it would be helpful to include a code snippet showing an example using the said `Date` object. This would enable readers to easily follow along with the statement instead of having to reproduce it in their minds.