### PR TITLE
Don't crash when dts output not present in playground

### DIFF
--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -319,7 +319,7 @@ export const createTypeScriptSandbox = (
   /** Gets the DTS for the JS/TS  of compiling your editor's code */
   const getDTSForCode = async () => {
     const result = await getEmitResult()
-    return result.outputFiles.find((o: any) => o.name.endsWith(".d.ts"))!.text
+    return result.outputFiles.find((o: any) => o.name.endsWith(".d.ts"))?.text || ""
   }
 
   const getWorkerProcess = async (): Promise<TypeScriptWorker> => {


### PR DESCRIPTION
this technically would require a package bump for external users, but my main focus now is to get the playground not erroring