### PR TITLE
Update Conditional Types.md: clarify return type inference for overloaded functions

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Conditional Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Conditional Types.md
@@ -205,7 +205,7 @@ type Bools = GetReturnType<(a: boolean, b: boolean) => boolean[]>;
 //   ^?
 ```
 
-When inferring the return type from a type with multiple call signatures, such as an overloaded function, it's essential to note that inferences are made from the _last overload signature_, not from the [implementation signature](https://www.typescriptlang.org/docs/handbook/2/functions.html#overload-signatures-and-the-implementation-signature).
+When inferring the return type from a type with multiple call signatures, such as an overloaded function, inferences are made from the _last overload signature_, not from the [implementation signature](https://www.typescriptlang.org/docs/handbook/2/functions.html#overload-signatures-and-the-implementation-signature).
 
 ```ts twoslash
 // @errors: 2322

--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Conditional Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Conditional Types.md
@@ -205,15 +205,20 @@ type Bools = GetReturnType<(a: boolean, b: boolean) => boolean[]>;
 //   ^?
 ```
 
-When inferring from a type with multiple call signatures (such as the type of an overloaded function), inferences are made from the _last_ signature (which, presumably, is the most permissive catch-all case). It is not possible to perform overload resolution based on a list of argument types.
+When inferring the return type from a type with multiple call signatures, such as an overloaded function, it's essential to note that inferences are made from the _last overload signature_, not from the [implementation signature](https://www.typescriptlang.org/docs/handbook/2/functions.html#overload-signatures-and-the-implementation-signature).
 
 ```ts twoslash
-declare function stringOrNum(x: string): number;
-declare function stringOrNum(x: number): string;
-declare function stringOrNum(x: string | number): string | number;
+// @errors: 2322
+function myFunction(x: string): null; // Overload signature
+function myFunction(x: number): boolean; // Overload signature
+function myFunction(x: string | number): null | boolean { // Implementation signature
+    return typeof x === "string" ? null : true;
+}
 
-type T1 = ReturnType<typeof stringOrNum>;
+type ReturnTypeOfMyFunction = ReturnType<typeof myFunction>; // boolean
 //   ^?
+
+const result: ReturnTypeOfMyFunction = myFunction("hi");  // Error
 ```
 
 ## Distributive Conditional Types


### PR DESCRIPTION
### Description:

This pull request aims to enhance the clarity and accuracy of the TypeScript documentation regarding return type inference for overloaded functions. The current documentation states that inferences are made from the last signature, which may lead to misconceptions. Through this contribution, I have clarified that inferences are made from the last _overload_ signature, not from the _implementation_ signature, which is crucial for understanding how TypeScript handles type inference in such cases.

### Changes Made:

- Updated the documentation in Conditional Types.md to reflect the correct behavior of return type inference for overloaded functions.
- Modified the example code to clearly distinguish between overload signatures and the implementation signature.
- Removed misleading information and provided more accurate explanation of the inference process.

This contribution aims to improve the educational value of the documentation and ensure that users have a clear understanding of how TypeScript handles type inference in the context of overloaded functions.

[View Playground Example](https://www.typescriptlang.org/play/?#code/PTAEAEFMCdoe2gZwFygEwGY1oFADMBXAOwGMAXASziNAFsBPAMWPKqIAoAPVRM6CogHMAlKiIEANhIDcoEKADyANxgS4AQwAmoRBUFF1ZAtEj4WlanSbm2XMQVoAjGKNCO4cCZHVFZ85aoa2rr6hsamhKQWNAzMUbbcOnwCgqAAPqDiTi72UuluHl4+oADecmAAkrQADl60kERkhmw6egZGJjig3aAmHTRk9NWQcHignKAAvNOgAES8-EKzoAD8mZISoKh8BJDSOAC+ODiDw6AASpD9ACpDkAp4ALLW8ZaTF1fGRLfDADynIzGsRs1AAfH4wO5PN4iDh5N0AHorY4kai8XqQRCSMioS43O4PZ5xVhvKzE6LsWYACwos2EsnKoAAorAEOgsLh4YjkUA)

### Additional Information:

Additionally, there is an existing [issue](https://github.com/microsoft/TypeScript/issues/24275) in the TypeScript [repository](https://github.com/microsoft/TypeScript) that discusses a behavior related to return type inference for overloaded functions. It has been labelled as a "design limitation"  ([Link to Message](https://github.com/microsoft/TypeScript/issues/24275#issuecomment-390701982)). 
