### PR TITLE
De-any: Refactor example to eliminate usage of 'any'

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -157,17 +157,7 @@ class Point {
   constructor(x: number, y: number);
   constructor(xy: string);
   constructor(x: string | number, y: number = 0) {
-    // Check if x is a string (assuming it contains comma-separated coordinates)
-    if (typeof x === 'string') {
-      const coordinates = x.split(','); 
-      this.x = parseFloat(coordinates[0]);
-      this.y = parseFloat(coordinates[1]);
-    } else {
-      // If x is not a string, assume it's a number and assign it to x
-      this.x = x;
-      // Assign y to the provided value or default to 0 if not provided
-      this.y = y;
-    }
+    // Code logic here
   }
 }
 ```

--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -150,11 +150,24 @@ class Point {
 
 ```ts twoslash
 class Point {
-  // Overloads
-  constructor(x: number, y: string);
-  constructor(s: string);
-  constructor(xs: any, y?: any) {
-    // TBD
+  x: number;
+  y: number;
+
+  // Constructor overloads
+  constructor(x: number, y: number);
+  constructor(xy: string);
+  constructor(x: string | number, y: number = 0) {
+    // Check if x is a string (assuming it contains comma-separated coordinates)
+    if (typeof x === 'string') {
+      const coordinates = x.split(','); 
+      this.x = parseFloat(coordinates[0]);
+      this.y = parseFloat(coordinates[1]);
+    } else {
+      // If x is not a string, assume it's a number and assign it to x
+      this.x = x;
+      // Assign y to the provided value or default to 0 if not provided
+      this.y = y;
+    }
   }
 }
 ```


### PR DESCRIPTION
Replace 'any' type in the constructor parameters with more specific types to improve code readability.

Think, it's beneficial to discourage the use of 'any' in documentation.

[Don't use _any_](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#any)

[Open in Playground](https://www.typescriptlang.org/play/?#code/MYGwhgzhAEAKD2BLAdgF2gbwLAChrQA8AuaZAVwFsAjAUwCcBuXfATxPOvqZ2egHo+0AMLxkEVHTLBU8OtHgA3eiHhgAJhF7BR4ydNkAKYqUq06AGmhsTnOgEpu+bWIlSZdI9d0oA5g606rvoext7IPtAAPjZmltYcZtAAvNAADHaYvPgCwgAWNMAA1tCIAGaEJTBg0GERBpAQlL4l6M6oYCgw2hQUYAC0EDQADmB0YKg0atDasmoo4zQQdlkl5QaoLEM08OUEyUkpAOS1hxnYePiXzuLT8LPzEzApBAB0EEMgiKgGh+anDNAVvhULlEBAXnsUiM6IMAGIqcYGGZ0ObIBYQADaqQAuv4LpdoCCwS8WMloNC4QjvsjUeiMQBGXGOS4AX2gNBAg0y+MuOQAkrtKqR4OhqrVLA1KDQWsdoNUEvQ5cgpg1ED5kC1CfBCEDCaDwZDCMyCTkAIJQNUa0kyPXSoZ0RSINSTaAKMAgMjS2TQZ2lMBkEDoG2pVbC9D2x3OtS6ong0kpFjG6As3gpnAsoA)