### PR TITLE
Classes.md: Update description for getter and setter member visibility

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -250,7 +250,7 @@ TypeScript has some special inference rules for accessors:
 
 - If `get` exists but no `set`, the property is automatically `readonly`
 - If the type of the setter parameter is not specified, it is inferred from the return type of the getter
-- Getters and setters must have the same [Member Visibility](#member-visibility)
+- `set` accessors may be less visible than their corresponding `get` accessor
 
 Since [TypeScript 4.3](https://devblogs.microsoft.com/typescript/announcing-typescript-4-3/), it is possible to have accessors with different types for getting and setting.
 

--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -250,7 +250,6 @@ TypeScript has some special inference rules for accessors:
 
 - If `get` exists but no `set`, the property is automatically `readonly`
 - If the type of the setter parameter is not specified, it is inferred from the return type of the getter
-- `set` accessors may be less visible than their corresponding `get` accessor
 
 Since [TypeScript 4.3](https://devblogs.microsoft.com/typescript/announcing-typescript-4-3/), it is possible to have accessors with different types for getting and setting.
 


### PR DESCRIPTION
Got some updates for the TypeScript documentation, specifically regarding member visibility for getters and setters:

- Tightened up the documentation to clarify that `set` accessors might have lower visibility compared to their `get` counterparts.

[Related merged pull request (Differing Visibility)](https://github.com/microsoft/TypeScript/pull/42425)

