### PR TITLE
Updated twoslasher custom tag matcher to allow whitespace

### DIFF
--- a/packages/ts-twoslasher/src/index.ts
+++ b/packages/ts-twoslasher/src/index.ts
@@ -208,7 +208,7 @@ function setOption(name: string, value: string, opts: CompilerOptions, ts: TS) {
 const booleanConfigRegexp = /^\/\/\s?@(\w+)$/
 
 // https://regex101.com/r/8B2Wwh/1
-const valuedConfigRegexp = /^\/\/\s?@(\w+):\s?(.+)$/
+const valuedConfigRegexp = /^\s?\/\/\s?@(\w+):\s?(.+)$/
 
 function filterCompilerOptions(codeLines: string[], defaultCompilerOptions: CompilerOptions, ts: TS) {
   const options = { ...defaultCompilerOptions }


### PR DESCRIPTION
Currently, there is a bug in the custom tag matcher which doesn't show up in the commented regex example due to a subtle difference between the example regex and the production code regex. The linked regex sample ( for convenience: https://regex101.com/r/8B2Wwh/1 ) differs from the production code in a subtle way: it omitted the starting `^` used in the production regex. This subtle difference means that in the linked example, comments indented with spaces or tabs are still matched. However, the production regex begins with `/^\/\/`, which will not match comments that have been indented as it requires `//` be the first characters of the line. Here's an example regex showing that an indented commented fails to match: https://regex101.com/r/fkqmfp/1

This is an issue however because it is valid *and common* for a comment to be intended to line up with the code being commented. In fact, this is a standard behavior of most automated formatting tools.

With this change, custom tag comments that are indented will be matched by the `valuedConfigRegexp`: see https://regex101.com/r/0pHWps/1

I believe the regex comment above this change should also be updated, but I assume there is an official regex101 account which should be used to create it to ensure a 3rd party (ie: me) can't delete it. If there isn't an official microsoft/typescript regex101 account please let me know and I'd be happy to create one and add the link in this pr.