### PR TITLE
Remove old preview site comments on new comment

### DIFF
--- a/.github/workflows/close-preview.yml
+++ b/.github/workflows/close-preview.yml
@@ -9,6 +9,9 @@ on:
   pull_request_target:
     types: [closed]
 
+concurrency:
+  group: preview-site
+
 jobs:
   close:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -128,7 +128,8 @@ jobs:
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PREVIEW }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          # Unsetting the repo token so we can control commenting ourselves.
+          # repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
           app_location: "site"
           skip_app_build: true
@@ -136,8 +137,7 @@ jobs:
           deployment_environment: ${{ fromJson(steps.get-info.outputs.result).pr }}
 
       - name: Comment on PR
-        # azure/static-web-apps-deploy seems to comment itself when the event is pull_request_target
-        if: ${{ steps.get-info.outputs.result != 'null' && github.event_name != 'pull_request_target' }}
+        if: ${{ steps.get-info.outputs.result != 'null' }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           PR_NUMBER: ${{ fromJson(steps.get-info.outputs.result).pr }}
@@ -145,9 +145,28 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const prefix = "Azure Static Web Apps: Your stage site is ready!";
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: +process.env.PR_NUMBER,
+              per_page: 100,
+            });
+
+            for (const comment of comments) {
+              if (comment.user?.login === "github-actions[bot]" && comment.body?.startsWith(prefix)) {
+                console.log(`Deleting comment ${comment.id}`);
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: comment.id,
+                });
+              }
+            }
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: process.env.PR_NUMBER,
-              body: `Azure Static Web Apps: Your stage site is ready! Visit it here: ${process.env.SITE_URL}`
+              issue_number: +process.env.PR_NUMBER,
+              body: `${prefix} Visit it here: ${process.env.SITE_URL}`
             });

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -17,6 +17,9 @@ permissions:
   pull-requests: write
   actions: read
 
+concurrency:
+  group: preview-site
+
 jobs:
   deploy:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'


### PR DESCRIPTION
Right now, the action comments every time a build succeeds. If we keep pushing to a PR, that's basically one comment per push.

We can either only ever have one comment, or just remove old comments and leave the final one. I think the latter is better as it'll clearly show for which commits a preview site applies.

While here, ensure preview site jobs don't race.