### PR TITLE
Use single job to track CI status

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -86,3 +86,17 @@ jobs:
 
       - run: yarn bootstrap
       - run: yarn build
+
+  required:
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs:
+      - tests
+      - windows
+    
+    steps:
+      - name: Check required jobs
+        env:
+          NEEDS: ${{ toJson(needs) }}
+        run: |
+          ! echo $NEEDS | jq -e 'to_entries[] | { job: .key, result: .value.result } | select(.result != "success")'


### PR DESCRIPTION
In prep for #3079 which makes tests a matrix.