### PR TITLE
Describe legacy JSDoc type synonyms

### DIFF
--- a/packages/documentation/copy/en/javascript/JSDoc Reference.md
+++ b/packages/documentation/copy/en/javascript/JSDoc Reference.md
@@ -825,3 +825,27 @@ The following tags have open issues to support them:
 
 - `@memberof` ([issue #7237](https://github.com/Microsoft/TypeScript/issues/7237))
 - `@yields` ([issue #23857](https://github.com/Microsoft/TypeScript/issues/23857))
+
+### Legacy type synonyms
+
+A number of common types are given aliases for compatibility with old JavaScript code.
+Some of the aliases are the same as existing types, although most of those are rarely used.
+For example, `String` is treated as an alias for `string`.
+Even though `String` is a type in TypeScript, it's rarely used, and old JSDoc often uses it to mean `string`.
+
+- `String -> string`
+- `Number -> number`
+- `Boolean -> boolean`
+- `Void -> void`
+- `Undefined -> undefined`
+- `Null -> null`
+- `function -> Function`
+- `array -> Array<any>`
+- `promise -> Promise<any>`
+- `Object -> any`
+
+The last three aliases are turned off when `noImplicitAny: true`:
+
+- `Object` stays `Object`, which is rarely used built-in type.
+- `array` stays `array`, which is not a built-in type.
+- `promise` stays `promise`, which is not a built-in type.

--- a/packages/documentation/copy/en/javascript/JSDoc Reference.md
+++ b/packages/documentation/copy/en/javascript/JSDoc Reference.md
@@ -9,7 +9,9 @@ translatable: true
 The list below outlines which constructs are currently supported
 when using JSDoc annotations to provide type information in JavaScript files.
 
-Note any tags which are not explicitly listed below (such as `@async`) are not yet supported.
+Note:
+- Any tags which are not explicitly listed below (such as `@async`) are not yet supported.
+- Only documentation tags are supported in TypeScript files. The rest of the tags are only supported in JavaScript files.
 
 #### Types
 
@@ -831,7 +833,9 @@ The following tags have open issues to support them:
 A number of common types are given aliases for compatibility with old JavaScript code.
 Some of the aliases are the same as existing types, although most of those are rarely used.
 For example, `String` is treated as an alias for `string`.
-Even though `String` is a type in TypeScript, it's rarely used, and old JSDoc often uses it to mean `string`.
+Even though `String` is a type in TypeScript, old JSDoc often uses it to mean `string`.
+Besides, in TypeScript, the capitalized versions of primitive types are wrapper types -- almost always a mistake to use.
+So the compiler treats these types as synonyms based on usage in old JSDoc:
 
 - `String -> string`
 - `Number -> number`
@@ -847,7 +851,5 @@ Even though `String` is a type in TypeScript, it's rarely used, and old JSDoc of
 
 The last four aliases are turned off when `noImplicitAny: true`:
 
-- `object` stays `object`, which is a common built-in type.
-- `Object` stays `Object`, which is a rarely used built-in type.
-- `array` stays `array`, which is not a built-in type.
-- `promise` stays `promise`, which is not a built-in type.
+- `object` and `Object` are built-in types, although `Object` is rarely used.
+- `array` and `promise` are not built-in, but might be declared somewhere in your program.

--- a/packages/documentation/copy/en/javascript/JSDoc Reference.md
+++ b/packages/documentation/copy/en/javascript/JSDoc Reference.md
@@ -843,9 +843,11 @@ Even though `String` is a type in TypeScript, it's rarely used, and old JSDoc of
 - `array -> Array<any>`
 - `promise -> Promise<any>`
 - `Object -> any`
+- `object -> any`
 
-The last three aliases are turned off when `noImplicitAny: true`:
+The last four aliases are turned off when `noImplicitAny: true`:
 
-- `Object` stays `Object`, which is rarely used built-in type.
+- `object` stays `object`, which is a common built-in type.
+- `Object` stays `Object`, which is a rarely used built-in type.
 - `array` stays `array`, which is not a built-in type.
 - `promise` stays `promise`, which is not a built-in type.


### PR DESCRIPTION
like String for string, etc.