### PR TITLE
Don't throw in deploy-preview on not found PR

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -73,7 +73,8 @@ jobs:
             }
 
             if (!pr) {
-              throw new Error("Could not find PR");
+              console.log("Could not find PR");
+              return null;
             }
 
             console.log(`Found PR ${pr.html_url}`);


### PR DESCRIPTION
The search can fail if a force push removed the head commit.