### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -29,15 +29,8 @@ jobs:
       - name: Prepare website v2
         run: |
           pnpm install
-          pnpm docs-sync pull microsoft/TypeScript-Website-localizations#main 1
           pnpm bootstrap
-          pnpm run --filter=typescriptlang-org setup-playground-cache-bust
           pnpm build
-
-      - name: Build website v2
-        run: |
-          pnpm build-site
-          cp -r packages/typescriptlang-org/public site
 
       - uses: changesets/action@aba318e9165b45b7948c60273e0b72fce0a64eb9 # v1.4.7
         with:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -36,5 +36,5 @@ jobs:
         with:
           publish: pnpm ci:publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_BOT_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }} 


### PR DESCRIPTION
- I forgot that we don't have perms anymore to let GHA make PRs, so we have to use a different token.
- There's no need to do a full site build; I did a diff before/after this PR and the produced packages are identical.