### PR TITLE
Temporarily ignore private packages in changeset config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,17 @@
   "access": "public",
   "baseBranch": "v2",
   "updateInternalDependencies": "patch",
-  "ignore": [],
+  "ignore": [
+    "@typescript/playground",
+    "@typescript/playground-handbook",
+    "@typescript/playground-worker",
+    "community-meta",
+    "documentation",
+    "glossary",
+    "playground-examples",
+    "tsconfig-reference",
+    "typescriptlang-org"
+  ],
   "privatePackages": {
     "tag": false,
     "version": false


### PR DESCRIPTION
Until changesets is fixed to also ignore private packages for tagging, releasing, etc, manually list out all private packages we currently have so they are never looked at.