### PR TITLE
Fix preview site getting cancelled, deploying on closed PRs

### DIFF
--- a/.github/workflows/close-preview.yml
+++ b/.github/workflows/close-preview.yml
@@ -9,9 +9,6 @@ on:
   pull_request_target:
     types: [closed]
 
-concurrency:
-  group: preview-site
-
 jobs:
   close:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -17,9 +17,6 @@ permissions:
   pull-requests: write
   actions: read
 
-concurrency:
-  group: preview-site
-
 jobs:
   deploy:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
@@ -78,6 +75,11 @@ jobs:
 
             console.log(`Found PR ${pr.html_url}`);
             console.log(pr);
+
+            if (pr.state !== "open") {
+              console.log(`PR ${pr.number} is not open`);
+              return null;
+            }
 
             if (!pr.labels.some((label) => label.name === "deploy-preview")) {
               console.log(`PR ${pr.number} does not have the deploy-preview label`);


### PR DESCRIPTION
There's some sort of GHA bug where the concurrency group is getting cancelled even though it was not configured that way. The main reason for the grouping was to prevent races on open/close, but since the initial step is fast, just checking the status should be sufficient to prevent that.