### PR TITLE
Fix bot token for changeset PR sending

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           fetch-depth: 0
           filter: blob:none
+          token: ${{ secrets.GITHUB_BOT_TOKEN }}
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: "18.x"


### PR DESCRIPTION
This can't be the GHA token because that won't trigger builds. Blah.