### PR TITLE
Disable playground plugin script in bootstrap

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -9,7 +9,7 @@
     "dist"
   ],
   "scripts": {
-    "bootstrap": "node scripts/getListOfPluginsFromNPM.js",
+    "//bootstrap": "node scripts/getListOfPluginsFromNPM.js",
     "build-fast-test": "esbuild src/index.ts --outdir=../typescriptlang-org/static/js/playground/2  --format=esm --target=es2020 --bundle",
     "build": "tsc",
     "test": "jest"


### PR DESCRIPTION
This script changes the list of plugins on bootstrap into a committed file, which causes differences when building. This is annoying for local dev, but also fails CI because I made it error on file diffs like that.

The fixes could be:

- gitignore the file; builds are less deterministic
- Stop updating it

I'm going to opt for the latter for now. There do not seem to be new plugins being created these days. We can manually rerun the script later or figure something better out.