### PR TITLE
More publishing fixes

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -38,4 +38,4 @@ jobs:
           publish: pnpm ci:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_BOT_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }} 
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }} 

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 shell-emulator=true
+publish-branch=v2

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     ]
   },
   "scripts": {
-    "ci:publish": "pnpm changeset tag && pnpm publish -r --publish-branch v2",
+    "ci:publish": "pnpm changeset tag && pnpm publish -r",
     "bootstrap": "pnpm -r run bootstrap && BOOTSTRAPPING=true pnpm -r run build",
     "start": "concurrently -p \"[{name}]\" -n \"BUILD,SITE\" -c \"bgBlue.bold,bgMagenta.bold\" \"node watcher.js\" \"pnpm run --filter=typescriptlang-org start\"",
     "build": "pnpm run --filter=!typescriptlang-org build",


### PR DESCRIPTION
- Set the branch in npmrc
- Ensure we use `NODE_AUTH_TOKEN` which is what setup-node actually configures npmrc to pull from.