### PR TITLE
Clarify left-side-only behavior of distributive conditional types

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Conditional Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Conditional Types.md
@@ -218,7 +218,8 @@ type T1 = ReturnType<typeof stringOrNum>;
 
 ## Distributive Conditional Types
 
-When conditional types act on a generic type, they become _distributive_ when given a union type.
+When the type on the left of the `extends` is a generic type parameter,
+the conditional type becomes _distributive_ over unions.
 For example, take the following:
 
 ```ts twoslash


### PR DESCRIPTION
The documentation for distributive conditional types is currently inaccurate. This line:
> When conditional types act on a generic type, they become distributive when given a union type

One minor inaccuracy is that it uses the term "generic type" to refer to a type parameter; whereas the rest of the documentation on generic types uses "generic type" to mean a type that itself accepts a type argument.

Setting that phrasing aside, this sentence inaccurately describes when distributive behavior happens. It says that conditional types are distributive in **all cases** where they "act on a generic type [parameter]"; but from experimentation it appears that they are actually only distributive when the generic type parameter is on the **left side** of the `extends`. For example:

```typescript
type A<T> = T extends any ? [T] : never;
type B<T> = any extends T ? [T] : never;
type U = "x" | "y";
type AU = A<U>; // AU = ["x"] | ["y"]
type BU = B<U>; // BU = ["x" | "y"]
```

I don't know whether this difference between the documented and actual semantics is a bug in the documentation or a bug in TypeScript itself, but this PR assumes it's the former.