### PR TITLE
Fix link to cheat sheet zip

### DIFF
--- a/packages/typescriptlang-org/src/templates/pages/docs/index.tsx
+++ b/packages/typescriptlang-org/src/templates/pages/docs/index.tsx
@@ -73,7 +73,7 @@ const Index: React.FC<Props> = (props) => {
       } else {
 
       return <li key={item.id}>
-        { path.endsWith("png") ?
+        { path.endsWith(".png") || path.endsWith(".zip") ?
           <a href={path}>{item.title}</a> :
           <Link to={path}>{item.title}</Link>
         }


### PR DESCRIPTION
Fixes #3126

This code special cased pngs, but not the zip file which is also in the list.