### PR TITLE
Don't depend on DOM types in createDefaultMapFromCDN

### DIFF
--- a/.changeset/silver-kangaroos-exist.md
+++ b/.changeset/silver-kangaroos-exist.md
@@ -1,0 +1,5 @@
+---
+"@typescript/vfs": patch
+---
+
+Don't depend on DOM types in createDefaultMapFromCDN

--- a/packages/typescript-vfs/package.json
+++ b/packages/typescript-vfs/package.json
@@ -51,7 +51,6 @@
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "jest-watch-typeahead": "^2.2.2",
-    "lz-string": "^1.5.0",
     "ts-jest": "^29.0.5",
     "tslib": "^2.6.2",
     "typescript": "*"

--- a/packages/typescript-vfs/src/index.ts
+++ b/packages/typescript-vfs/src/index.ts
@@ -6,13 +6,24 @@ type CompilerHost = import("typescript").CompilerHost
 type SourceFile = import("typescript").SourceFile
 type TS = typeof import("typescript")
 
+type FetchLike = (url: string) => Promise<{ json(): Promise<any>; text(): Promise<string> }>
+
+interface LocalStorageLike {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+}
+
+declare var localStorage: LocalStorageLike | undefined;
+declare var fetch: FetchLike | undefined;
+
 let hasLocalStorage = false
 try {
   hasLocalStorage = typeof localStorage !== `undefined`
 } catch (error) { }
 
 const hasProcess = typeof process !== `undefined`
-const shouldDebug = (hasLocalStorage && localStorage.getItem("DEBUG")) || (hasProcess && process.env.DEBUG)
+const shouldDebug = (hasLocalStorage && localStorage!.getItem("DEBUG")) || (hasProcess && process.env.DEBUG)
 const debugLog = shouldDebug ? console.log : (_message?: any, ..._optionalParams: any[]) => ""
 
 export interface VirtualTypeScriptEnvironment {
@@ -297,14 +308,6 @@ export interface LZString {
   decompressFromUTF16(compressed: string): string
 }
 
-export type FetchLike = (url: string) => Promise<{ json(): Promise<any>; text(): Promise<string> }>
-
-export interface LocalStorageLike {
-  getItem(key: string): string | null
-  setItem(key: string, value: string): void
-  removeItem(key: string): void
-}
-
 /**
  * Create a virtual FS Map with the lib files from a particular TypeScript
  * version based on the target, Always includes dom ATM.
@@ -326,7 +329,7 @@ export const createDefaultMapFromCDN = (
   fetcher?: FetchLike,
   storer?: LocalStorageLike
 ) => {
-  const fetchlike = fetcher || fetch
+  const fetchlike = fetcher || fetch!
   const fsMap = new Map<string, string>()
   const files = knownLibFilesForCompilerOptions(options, ts)
   const prefix = `https://playgroundcdn.typescriptlang.org/cdn/${version}/typescript/lib/`
@@ -353,7 +356,7 @@ export const createDefaultMapFromCDN = (
 
   // A localstorage and lzzip aware version of the lib files
   function cached() {
-    const storelike = storer || localStorage
+    const storelike = storer || localStorage!
 
     const keys = Object.keys(storelike)
     keys.forEach(key => {

--- a/packages/typescript-vfs/src/index.ts
+++ b/packages/typescript-vfs/src/index.ts
@@ -292,6 +292,19 @@ export const addAllFilesFromFolder = (map: Map<string, string>, workingDir: stri
 export const addFilesForTypesIntoFolder = (map: Map<string, string>) =>
   addAllFilesFromFolder(map, "node_modules/@types")
 
+export interface LZString {
+  compressToUTF16(input: string): string
+  decompressFromUTF16(compressed: string): string
+}
+
+export type FetchLike = (url: string) => Promise<{ json(): Promise<any>; text(): Promise<string> }>
+
+export interface LocalStorageLike {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+}
+
 /**
  * Create a virtual FS Map with the lib files from a particular TypeScript
  * version based on the target, Always includes dom ATM.
@@ -309,9 +322,9 @@ export const createDefaultMapFromCDN = (
   version: string,
   cache: boolean,
   ts: TS,
-  lzstring?: typeof import("lz-string"),
-  fetcher?: typeof fetch,
-  storer?: typeof localStorage
+  lzstring?: LZString,
+  fetcher?: FetchLike,
+  storer?: LocalStorageLike
 ) => {
   const fetchlike = fetcher || fetch
   const fsMap = new Map<string, string>()

--- a/packages/typescript-vfs/tsconfig.json
+++ b/packages/typescript-vfs/tsconfig.json
@@ -5,7 +5,7 @@
   "compilerOptions": {
     "target": "ES2015",
     "module": "esnext",
-    "lib": ["dom", "esnext"],
+    "lib": ["esnext"],
     "importHelpers": true,
     "declaration": true,
     "sourceMap": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,9 +324,6 @@ importers:
       jest-watch-typeahead:
         specifier: ^2.2.2
         version: 2.2.2(jest@29.7.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.33)(typescript@5.4.5)))
-      lz-string:
-        specifier: ^1.5.0
-        version: 1.5.0
       ts-jest:
         specifier: ^29.0.5
         version: 29.1.3(@babel/core@7.24.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.5))(jest@29.7.0(@types/node@18.19.33)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.33)(typescript@5.4.5)))(typescript@5.4.5)


### PR DESCRIPTION
Fixes #2953
Closes #3035

This package can be loaded in both Node and the browser; try to make the types work for both.