### PR TITLE
fix: small design issue for "get started" card and "headline diagram"

### DIFF
--- a/packages/typescriptlang-org/src/templates/pages/css/index.scss
+++ b/packages/typescriptlang-org/src/templates/pages/css/index.scss
@@ -484,6 +484,7 @@ $headline-foreground-bg: white;
           overflow-x: auto;
           position: relative;
           background-color: #235a97;
+          border-radius: 0px 0px calc(8px - 2px) calc(8px - 2px);
 
           pre {
             margin: 0;
@@ -557,7 +558,7 @@ $headline-foreground-bg: white;
       background: $ts-main-blue-color;
       background-position-y: bottom -180px;
       height: 260px;
-      border: 1px solid white;
+      outline: 1px solid white;
       color: white;
       &.handbook {
         background-image: url(/images/index/get-started-handbook-blue.svg);
@@ -578,26 +579,28 @@ $headline-foreground-bg: white;
         background-color: #156fb4;
       }
       &:hover {
-        border-width: 2px;
+        outline-width: 2px;
         box-shadow: 0px 4px 20px -2px rgba(0, 0, 0, 0.25);
-        max-width: 246px;
       }
     }
 
     &.tall {
       background: #ffffff;
-      border: 1px solid #000000;
+      outline: 1px solid #000000;
       color: black;
       height: 342px;
       margin-bottom: 2px;
 
       &:hover {
-        border-color: $ts-main-blue-color;
-        border-width: 2px;
+        outline-color: $ts-main-blue-color;
+        outline-width: 2px;
+        color: $ts-main-blue-color;
         box-shadow: 0px 4px 20px -2px rgba(0, 0, 0, 0.25);
-        max-width: 246px;
-        height: 344px;
         margin-bottom: 0px;
+
+        svg path {
+          stroke: $ts-main-blue-color;
+        }
       }
       &:active {
         background-color: #eeeeee;
@@ -617,7 +620,6 @@ $headline-foreground-bg: white;
     }
 
     &:active {
-      margin-top: 1px;
       box-shadow: 0px 4px 10px 0px rgba(0, 0, 0, 0.25);
     }
 


### PR DESCRIPTION
Hello,

I fixed a few minor issues I noticed on the homepage. Under the `headline diagram`, the `.text` class was missing the bottom parameter for the `border-radius`, which caused a bad appearance.

In the `get started` card design, changing the `border` value on hover caused alignment issues. Using `outline` instead of `border` solved the problem.

### Headline Diagram Issue
| Before | After |
|--------|--------|
| ![Screenshot 2024-06-05 at 3 20 06 PM](https://github.com/microsoft/TypeScript-Website/assets/40598819/c5363f84-7407-4267-83f2-4ae431df2022) | ![Screenshot 2024-06-05 at 3 20 21 PM](https://github.com/microsoft/TypeScript-Website/assets/40598819/e3fbea3c-b25b-4af0-a863-f19fbc573936) | 


### Get Started Card Issue
| Before | After |
|--------|--------|
| ![Kapture 2024-06-05 at 15 26 45](https://github.com/microsoft/TypeScript-Website/assets/40598819/d4cbb8e1-3344-4a0f-b7c7-0c445fdde214) | ![Kapture 2024-06-05 at 15 30 26](https://github.com/microsoft/TypeScript-Website/assets/40598819/bab6b624-eeee-4aa2-b523-cd89b31e8fd2) | 




