### PR TITLE
Fix: Remove irrelevant errors from example

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -150,8 +150,8 @@ class Point {
 
 ```ts twoslash
 class Point {
-  x: number;
-  y: number;
+  x: number = 0;
+  y: number = 0;
 
   // Constructor overloads
   constructor(x: number, y: number);


### PR DESCRIPTION
I think errors like these aren't appropriate for this example since it's about different matters.
![Screenshot from 2024-06-05 22-11-28](https://github.com/microsoft/TypeScript-Website/assets/79020992/bf2292cc-749c-470c-bcf4-b53c0e2365e7)
