### PR TITLE
fix: ui overlap between dropdown and sticky-widget

### DIFF
--- a/packages/typescriptlang-org/src/templates/play.scss
+++ b/packages/typescriptlang-org/src/templates/play.scss
@@ -59,16 +59,16 @@
     }
 
     &.dropdown {
-
       ul,
       .dropdown-dialog {
+        $sticky-widget-z-index: 4;
 
         display: none;
 
         position: absolute;
         top: 100%;
         left: 0;
-        z-index: 1;
+        z-index: $sticky-widget-z-index + 1;
         float: left;
       }
     }


### PR DESCRIPTION
I was using Playground and found Ui overlapping between dropdown contents and sticky-widget

The z-index of the sticky-scroll is higher, so I set it to be one larger than that z-index.

**prev**

https://github.com/microsoft/TypeScript-Website/assets/87258182/ab3fa5f7-8785-4aec-a21b-910287cb549b

**after**

https://github.com/microsoft/TypeScript-Website/assets/87258182/2c5c0384-1c00-48ee-9e3f-57a0b0f97f03

