### PR TITLE
Fix typo in TypeScript 4.9.md

### DIFF
--- a/packages/documentation/copy/en/release-notes/TypeScript 4.9.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 4.9.md
@@ -59,7 +59,7 @@ const palette = {
 //  ~~~~ The typo is now caught!
 } satisfies Record<Colors, string | RGB>;
 
-// toUpperCase() methode is still accessible!
+// toUpperCase() method is still accessible!
 const greenNormalized = palette.green.toUpperCase();
 ```
 


### PR DESCRIPTION
Replaces "methode" with "method".