### PR TITLE
compiler options: explaining typeRoots CLI interface a bit

### DIFF
--- a/packages/documentation/copy/en/project-config/Compiler Options.md
+++ b/packages/documentation/copy/en/project-config/Compiler Options.md
@@ -1409,7 +1409,7 @@ tsc app.ts util.ts --target esnext --outfile index.js
 </td>
 </tr>
 <tr class="option-description even"><td colspan="3">
-<p>Specify multiple folders that act like <code>./node_modules/@types</code>.</p>
+<p>Specify multiple folders that act like <code>./node_modules/@types</code>. Note that the commandline accepts null (as <code>--typeRoots 'null'</code>) or a comma seperated list of paths.</p>
 </td></tr>
 
 <tr class='odd' name='types'>


### PR DESCRIPTION
Having `typeRoots` via CLI is not trivial and right now not documented.

Note: my initial concern was the `--paths` options which I can not got to fly with the same CLI Argument `--paths 'null'` in the same form which was successful with `typeRoots`.