### PR TITLE
Simply create a new file when calling `updateFile`

### DIFF
--- a/packages/typescript-vfs/src/index.ts
+++ b/packages/typescript-vfs/src/index.ts
@@ -1,10 +1,12 @@
-type System = import("typescript").System
-type CompilerOptions = import("typescript").CompilerOptions
-type CustomTransformers = import("typescript").CustomTransformers
-type LanguageServiceHost = import("typescript").LanguageServiceHost
-type CompilerHost = import("typescript").CompilerHost
-type SourceFile = import("typescript").SourceFile
-type TS = typeof import("typescript")
+import type {
+  System,
+  CompilerOptions,
+  CustomTransformers,
+  SourceFile,
+  CompilerHost,
+  LanguageServiceHost,
+} from "typescript"
+import type TS from "typescript"
 
 type FetchLike = (url: string) => Promise<{ json(): Promise<any>; text(): Promise<string> }>
 
@@ -14,13 +16,13 @@ interface LocalStorageLike {
   removeItem(key: string): void
 }
 
-declare var localStorage: LocalStorageLike | undefined;
-declare var fetch: FetchLike | undefined;
+declare var localStorage: LocalStorageLike | undefined
+declare var fetch: FetchLike | undefined
 
 let hasLocalStorage = false
 try {
   hasLocalStorage = typeof localStorage !== `undefined`
-} catch (error) { }
+} catch (error) {}
 
 const hasProcess = typeof process !== `undefined`
 const shouldDebug = (hasLocalStorage && localStorage!.getItem("DEBUG")) || (hasProcess && process.env.DEBUG)
@@ -48,7 +50,7 @@ export interface VirtualTypeScriptEnvironment {
 export function createVirtualTypeScriptEnvironment(
   sys: System,
   rootFiles: string[],
-  ts: TS,
+  ts: typeof TS,
   compilerOptions: CompilerOptions = {},
   customTransformers?: CustomTransformers
 ): VirtualTypeScriptEnvironment {
@@ -103,7 +105,7 @@ export function createVirtualTypeScriptEnvironment(
  * @param target The compiler settings target baseline
  * @param ts A copy of the TypeScript module
  */
-export const knownLibFilesForCompilerOptions = (compilerOptions: CompilerOptions, ts: TS) => {
+export const knownLibFilesForCompilerOptions = (compilerOptions: CompilerOptions, ts: typeof TS) => {
   const target = compilerOptions.target || ts.ScriptTarget.ES5
   const lib = compilerOptions.lib || []
 
@@ -197,7 +199,7 @@ export const knownLibFilesForCompilerOptions = (compilerOptions: CompilerOptions
     "lib.esnext.promise.d.ts",
     "lib.esnext.string.d.ts",
     "lib.esnext.symbol.d.ts",
-    "lib.esnext.weakref.d.ts"
+    "lib.esnext.weakref.d.ts",
   ]
 
   const targetToCut = ts.ScriptTarget[target]
@@ -316,7 +318,7 @@ export const createDefaultMapFromCDN = (
   options: CompilerOptions,
   version: string,
   cache: boolean,
-  ts: TS,
+  ts: typeof TS,
   lzstring?: LZString,
   fetcher?: FetchLike,
   storer?: LocalStorageLike
@@ -342,7 +344,7 @@ export const createDefaultMapFromCDN = (
           contents.forEach((text, index) => fsMap.set("/" + files[index], text))
         })
         // Return a NOOP for .d.ts files which aren't in the current build of TypeScript
-        .catch(() => { })
+        .catch(() => {})
     )
   }
 
@@ -373,7 +375,7 @@ export const createDefaultMapFromCDN = (
                 return t
               })
               // Return a NOOP for .d.ts files which aren't in the current build of TypeScript
-              .catch(() => { })
+              .catch(() => {})
           )
         } else {
           return Promise.resolve(unzip(content))
@@ -467,7 +469,7 @@ export function createSystem(files: Map<string, string>): System {
 export function createFSBackedSystem(
   files: Map<string, string>,
   _projectRoot: string,
-  ts: TS,
+  ts: typeof TS,
   tsLibDirectory?: string
 ): System {
   // We need to make an isolated folder for the tsconfig, but also need to be able to resolve the
@@ -544,7 +546,7 @@ export function createFSBackedSystem(
  * which works with TypeScript objects - returns both a compiler host, and a way to add new SourceFile
  * instances to the in-memory file system.
  */
-export function createVirtualCompilerHost(sys: System, compilerOptions: CompilerOptions, ts: TS) {
+export function createVirtualCompilerHost(sys: System, compilerOptions: CompilerOptions, ts: typeof TS) {
   const sourceFiles = new Map<string, SourceFile>()
   const save = (sourceFile: SourceFile) => {
     sourceFiles.set(sourceFile.fileName, sourceFile)
@@ -596,7 +598,7 @@ export function createVirtualLanguageServiceHost(
   sys: System,
   rootFiles: string[],
   compilerOptions: CompilerOptions,
-  ts: TS,
+  ts: typeof TS,
   customTransformers?: CustomTransformers
 ) {
   const fileNames = [...rootFiles]


### PR DESCRIPTION
Previously the code used TypeScript's `updateFile`, which performs an incremental parse; however, if we don't expect the contents to be similar enough, this wastes a lot of work. Reuse should still be done for untouched files from old versions of the program.

If I measured correctly (big if!), the **before** is something like this:

```
Duration: 358.75s, Total samples = 330527.55ms (92.13%)
Showing nodes accounting for 234432.24ms, 70.93% of 330527.55ms total
Dropped 12123 nodes (cum <= 1652.64ms)
      flat  flat%   sum%        cum   cum%
43480.84ms 13.15% 13.15% 43480.84ms 13.15%  (garbage collector)
22431.38ms  6.79% 19.94% 29808.65ms  9.02%  scan
14276.95ms  4.32% 24.26% 16485.47ms  4.99%  explainThemeScope
8470.93ms  2.56% 26.82% 17812.28ms  5.39%  doJSDocScan
7503.03ms  2.27% 29.09% 50711.16ms 15.34%  bind
6731.53ms  2.04% 31.13% 14063.59ms  4.25%  declareSymbol
```

And the **after** (with this PR) looks like this:

```
Duration: 136.13s, Total samples = 104413.98ms (76.70%)
Showing nodes accounting for 66596.18ms, 63.78% of 104413.98ms total
Dropped 10304 nodes (cum <= 522.07ms)
      flat  flat%   sum%        cum   cum%
12840.82ms 12.30% 12.30% 14840.34ms 14.21%  explainThemeScope
10529.17ms 10.08% 22.38% 10529.17ms 10.08%  (garbage collector)
3089.92ms  2.96% 25.34% 24318.65ms 23.29%  tokenizeWithTheme
2659.21ms  2.55% 27.89%  2659.21ms  2.55%  readFileUtf8
2524.28ms  2.42% 30.31% 39548.81ms 37.88%  visit
2190.34ms  2.10% 32.40%  2713.73ms  2.60%  stat
```

I did run a `clean` in between steps, so hopefully I did everything correctly - but this is a pretty nice drop!