### PR TITLE
Excess property checks string index signature: use unknown

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Object Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Object Types.md
@@ -413,7 +413,7 @@ If `SquareConfig` can have `color` and `width` properties with the above types, 
 interface SquareConfig {
   color?: string;
   width?: number;
-  [propName: string]: any;
+  [propName: string]: unknown;
 }
 ```
 
@@ -426,7 +426,6 @@ Since assigning `squareOptions` won't undergo excess property checks, the compil
 interface SquareConfig {
   color?: string;
   width?: number;
-  [propName: string]: any;
 }
 
 function createSquare(config: SquareConfig): { color: string; area: number } {


### PR DESCRIPTION
In the Excess Property Checks section of the "Object Types" page, one of the recommendations for avoiding excess property errors is to add a string index signature to the interface. However, it used `any` in this string indexer. This PR suggests changing it to `unknown`.

I don't know what the team's thoughts are on `undefined` versus `any`, because I see other usages of `any` on the page. So I don't want to step on anyone's toes but this example in particular really only makes sense with `unknown`. Let me explain.

In this case, the string index signature says "this interface may have other properties **that we don't care about**". But if `any` were used, it would be possible for an interface consumer to accidentally "care about" (start using) a new property that is only covered by the string index signature. That would violate the original intent of the interface. Instead, if `unknown` is used an error would be generated. The effect would be that "if you do _care about_ a property, then you have to add it to the interface, instead of covering it under the catch-all string index signature of properties that you _don't_ care about".

That's a lot of words but I hope you understand what I'm getting at.