### PR TITLE
Correct a code example

### DIFF
--- a/packages/documentation/copy/en/reference/Variable Declarations.md
+++ b/packages/documentation/copy/en/reference/Variable Declarations.md
@@ -60,18 +60,15 @@ Even if `g` is called once `f` is done running, it will be able to access and mo
 function f() {
   var a = 1;
 
-  a = 2;
-  var b = g();
-  a = 3;
-
-  return b;
-
   function g() {
+    a += 1;
     return a;
   }
+
+  return g;
 }
 
-f(); // returns '2'
+f()(); // returns '2'
 ```
 
 ### Scoping rules


### PR DESCRIPTION
In the original code example, `g()` is called before `f()` being done.

