### PR TITLE
Fix: Resolve layout shrink issue of Monaco editor on handbook toggle

### DIFF
--- a/packages/playground/src/navigation.ts
+++ b/packages/playground/src/navigation.ts
@@ -34,7 +34,6 @@ export const hideNavForHandbook = (sandbox: Sandbox) => {
   if (!nav) return
   if (!nav.classList.contains("handbook")) return
 
-  showCode(sandbox)
   nav.style.display = "none"
 
   const leftDrag = document.querySelector(".playground-dragbar.left") as HTMLElement
@@ -43,6 +42,8 @@ export const hideNavForHandbook = (sandbox: Sandbox) => {
   const story = document.getElementById("editor-container")
   const possibleButtonToRemove = story?.querySelector("button")
   if (story && possibleButtonToRemove) story.removeChild(possibleButtonToRemove)
+
+  showCode(sandbox)
 }
 
 /**


### PR DESCRIPTION
It seemed like a simple problem, so I didn't make the issue first. Please let me know if you have any problems. Thank you always.

### What this PR solves
- Resolve layout shrink issue of Monaco editor on handbook toggle

### Summary
- When I click the help button, the 'showCode' function is called, and inside sandbox.editor.layout() failed to calculate the layout normally. So I solved it by putting width, height in the parameter
- I thought it would be okay to calculate it as 210px, which is the area of the 'navigation-container(class name)' area, but there was a slight error. So I applied it as 200px. Is there a better way to calculate it?
<img width="800" alt="스크린샷 2024-06-21 오후 8 04 36" src="https://github.com/microsoft/TypeScript-Website/assets/87258182/f9efcb9c-5c67-4f78-845e-e58baba37a8a">

### Steps to Reproduce
1. Go to typescript [playground](https://www.typescriptlang.org/play/)
2. Toggle the 'help' button in the sub-navigation area.

https://github.com/microsoft/TypeScript-Website/assets/87258182/07e3a361-1a02-4c85-abda-781beca0fa7c



### Modified screen

https://github.com/microsoft/TypeScript-Website/assets/87258182/8c4aaa44-6682-4e57-97ae-8c7fe82672b0


