### PR TITLE
`Host` uses `getDirectories` from `System`

### DIFF
--- a/.changeset/many-avocados-learn.md
+++ b/.changeset/many-avocados-learn.md
@@ -1,0 +1,5 @@
+---
+"@typescript/vfs": patch
+---
+
+Use System's getDirectories if it's provided when constructing Host

--- a/packages/ts-twoslasher/test/fixtures.test.ts
+++ b/packages/ts-twoslasher/test/fixtures.test.ts
@@ -9,6 +9,11 @@ expect.extend({ toMatchFile })
 // To add a test, create a file in the fixtures folder and it will will run through
 // as though it was the codeblock.
 
+const defaultCompilerOptions = {
+  // avoid extra annotations from @types/node
+  types: []
+}
+
 describe("with fixtures", () => {
   // Add all codefixes
   const fixturesFolder = join(__dirname, "fixtures")
@@ -27,7 +32,7 @@ describe("with fixtures", () => {
 
       const file = readFileSync(fixture, "utf8")
 
-      const fourslashed = twoslasher(file, extname(fixtureName).substr(1), { customTags: ["annotate"] })
+      const fourslashed = twoslasher(file, extname(fixtureName).substr(1), { customTags: ["annotate"], defaultCompilerOptions })
       const jsonString = format(JSON.stringify(cleanFixture(fourslashed)), { parser: "json" })
       expect(jsonString).toMatchFile(result)
     })
@@ -46,7 +51,7 @@ describe("with fixtures", () => {
 
       const file = readFileSync(fixture, "utf8")
 
-      const fourslashed = twoslasher(file, extname(fixtureName).substr(1))
+      const fourslashed = twoslasher(file, extname(fixtureName).substr(1), { defaultCompilerOptions })
       const jsonString = format(JSON.stringify(cleanFixture(fourslashed)), { parser: "json" })
       expect(jsonString).toMatchFile(result)
     })
@@ -65,7 +70,7 @@ describe("with fixtures", () => {
 
       const file = readFileSync(fixture, "utf8")
 
-      const fourslashed = twoslasher(file, extname(fixtureName).substr(1))
+      const fourslashed = twoslasher(file, extname(fixtureName).substr(1), { defaultCompilerOptions })
       const jsonString = format(JSON.stringify(cleanFixture(fourslashed)), { parser: "json" })
       expect(jsonString).toMatchFile(result)
     })
@@ -87,7 +92,7 @@ describe("with fixtures", () => {
 
       let thrown = false
       try {
-        twoslasher(file, extname(fixtureName).substr(1))
+        twoslasher(file, extname(fixtureName).substr(1), { defaultCompilerOptions })
       } catch (err) {
         thrown = true
         if (err instanceof Error) expect(err.message).toMatchFile(result)

--- a/packages/typescript-vfs/src/index.ts
+++ b/packages/typescript-vfs/src/index.ts
@@ -572,7 +572,6 @@ export function createVirtualCompilerHost(sys: System, compilerOptions: Compiler
       getCanonicalFileName: fileName => fileName,
       getDefaultLibFileName: () => "/" + ts.getDefaultLibFileName(compilerOptions), // '/lib.d.ts',
       // getDefaultLibLocation: () => '/',
-      getDirectories: () => [],
       getNewLine: () => sys.newLine,
       getSourceFile: (fileName, languageVersionOrOptions) => {
         return (

--- a/packages/typescript-vfs/test/fsbacked.test.ts
+++ b/packages/typescript-vfs/test/fsbacked.test.ts
@@ -58,3 +58,17 @@ it("can import files in the virtual fs", () => {
 
   expect(errs.map(e => e.messageText)).toEqual([])
 })
+
+it("searches node_modules/@types", () => {
+  const compilerOpts: ts.CompilerOptions = { target: ts.ScriptTarget.ES2016, esModuleInterop: true }
+  const monorepoRoot = __dirname
+
+  const fsMap = new Map<string, string>()
+  fsMap.set("index.ts", "it('found @types/jest', () => undefined)")
+
+  const system = createFSBackedSystem(fsMap, monorepoRoot, ts)
+  const env = createVirtualTypeScriptEnvironment(system, ["index.ts"], ts, compilerOpts)
+
+  const semDiags = env.languageService.getSemanticDiagnostics("index.ts")
+  expect(semDiags.length).toBe(0)
+})


### PR DESCRIPTION
I found that a `Host` created from `createVirtualCompilerHost`/`createVirtualTypeScriptEnvironment` ignores the `getDirectories` provided by the `System`, despite `getDirectories` being a required component of `System`. Instead it forces a function that returns `[]` in all cases.

This is problematic for fs-based systems. The end result in my application is that TypeScript fails to preload all the types in `node_modules/@types` because it's unable to list that directory.

This one-line fix works for my application, and I added a somewhat realistic test (via existing `jest` definitions in `node_modules/@types`) that works only with this change.