### PR TITLE
Fix: Resolving Command Errors due to Package Manager Changes

### DIFF
--- a/watcher.js
+++ b/watcher.js
@@ -146,7 +146,7 @@ client.on("error", function (error) {
   console.error("Error while talking to watchman: ", error)
 })
 
-client.capabilityCheck({ required: ["relative_root"] }, function (error, resp) {
+client.capabilityCheck({ required: ["relative_root"], optional: [] }, function (error, resp) {
   if (error) {
     console.error("Error checking capabilities:", error)
     return

--- a/watcher.js
+++ b/watcher.js
@@ -121,8 +121,8 @@ function watcher(error, resp) {
       const packageJSON = JSON.parse(readFileSync(packageJSONPath, "utf8"))
       if (!packageJSON.scripts || !packageJSON.scripts.build) return
 
-      if (packageJSON.scripts["build-fast"]) return `workspace ${packageJSON.name} run build-fast`
-      return `workspace ${packageJSON.name} run build`
+      if (packageJSON.scripts["build-fast"]) return `--filter=${packageJSON.name} run build-fast`
+      return `--filter=${packageJSON.name} run build`
     })
 
     if (commandToRun[0]) {


### PR DESCRIPTION
I posted a question on the discord channel saying that HMR is not working, but I noticed the problem! Please let me know if you have any problems.

## What this PR solves

- Resolving Command Errors due to Package Manager Changes
- Resolve type errors by adding factors to match `capabilityCheck` function parameter type

## Summary

### Resolving Command Errors due to Package Manager Changes

Previously, the package manager was yarn, so I think the `workspace` command was valid. However, it changed to pnpm and caused an error, so it was not `build` even though the changes existed. 

<img width="767" alt="스크린샷 2024-06-26 오후 7 15 34" src="https://github.com/microsoft/TypeScript-Website/assets/87258182/ef090a53-70af-4046-a654-0200dc2fdebc">

So I deleted the `workspace` and added `--filter`.

### Resolve type errors by adding factors to match `capabilityCheck` function parameter type

Added optional, which is the required value of the first factor of the capabilityCheck function
``` ts
export interface Capabilities {
    optional: any[];
    required: any[];
}

export class Client extends EventEmitter {
    ...
    capabilityCheck(
        caps: Capabilities,
        done: doneCallback,
    ): void;
}
```
## Steps to Reproduce
1. run `pnpm start`
2. Save your changes.
3. Check the terminal for errors.