### PR TITLE
chore: use `debug` package for debug logging

### DIFF
--- a/.changeset/chilled-bulldogs-cross.md
+++ b/.changeset/chilled-bulldogs-cross.md
@@ -1,0 +1,6 @@
+---
+"@typescript/vfs": patch
+"@typescript/twoslash": patch
+---
+
+Use `debug` package for debug logging

--- a/.changeset/chilled-bulldogs-cross.md
+++ b/.changeset/chilled-bulldogs-cross.md
@@ -1,5 +1,6 @@
 ---
 "@typescript/vfs": patch
+"@typescript/sandbox": patch
 "@typescript/twoslash": patch
 ---
 

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",
+    "@types/debug": "^4.1.12",
     "@types/jest": "^29.5.12",
     "dts-cli": "^2.0.5",
     "jest": "^29.5.0",

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@typescript/ata": "workspace:*",
     "@typescript/vfs": "workspace:*",
+    "debug": "^4.3.4",
     "lz-string": "^1.5.0"
   },
   "devDependencies": {

--- a/packages/ts-twoslasher/package.json
+++ b/packages/ts-twoslasher/package.json
@@ -28,6 +28,7 @@
     "lint": "dts lint"
   },
   "devDependencies": {
+    "@types/debug": "^4.1.12",
     "@types/jest": "^29.5.12",
     "@types/prettier": "^1.19.0",
     "dts-cli": "^2.0.5",
@@ -53,7 +54,7 @@
   },
   "dependencies": {
     "@typescript/vfs": "workspace:*",
-    "debug": "^4.1.1",
+    "debug": "^4.3.4",
     "lz-string": "^1.5.0"
   },
   "peerDependencies": {

--- a/packages/ts-twoslasher/src/index.ts
+++ b/packages/ts-twoslasher/src/index.ts
@@ -10,7 +10,7 @@ import { createSystem, createVirtualTypeScriptEnvironment, createFSBackedSystem 
 
 import Debug from 'debug'
 
-const log = Debug("typescript:vfs")
+const log = Debug("typescript:twoslash")
 
 // Hacking in some internal stuff
 declare module "typescript" {

--- a/packages/ts-twoslasher/src/index.ts
+++ b/packages/ts-twoslasher/src/index.ts
@@ -1,10 +1,3 @@
-let hasLocalStorage = false
-try {
-  hasLocalStorage = typeof localStorage !== `undefined`
-} catch (error) { }
-const hasProcess = typeof process !== `undefined`
-const shouldDebug = (hasLocalStorage && localStorage.getItem("DEBUG")) || (hasProcess && process.env.DEBUG)
-
 type LZ = typeof import("lz-string")
 type TS = typeof import("typescript")
 type CompilerOptions = import("typescript").CompilerOptions
@@ -15,7 +8,9 @@ import { validateInput, validateCodeForErrors } from "./validation"
 
 import { createSystem, createVirtualTypeScriptEnvironment, createFSBackedSystem } from "@typescript/vfs"
 
-const log = shouldDebug ? console.log : (_message?: any, ..._optionalParams: any[]) => ""
+import Debug from 'debug'
+
+const log = Debug("typescript:vfs")
 
 // Hacking in some internal stuff
 declare module "typescript" {

--- a/packages/typescript-vfs/package.json
+++ b/packages/typescript-vfs/package.json
@@ -41,9 +41,10 @@
     "typescript": false
   },
   "dependencies": {
-    "debug": "^4.1.1"
+    "debug": "^4.3.4"
   },
   "devDependencies": {
+    "@types/debug": "^4.1.12",
     "@types/jest": "^29.5.12",
     "babel-jest": "^29.7.0",
     "cpy-cli": "^3.1.1",

--- a/packages/typescript-vfs/src/index.ts
+++ b/packages/typescript-vfs/src/index.ts
@@ -17,14 +17,9 @@ interface LocalStorageLike {
 declare var localStorage: LocalStorageLike | undefined;
 declare var fetch: FetchLike | undefined;
 
-let hasLocalStorage = false
-try {
-  hasLocalStorage = typeof localStorage !== `undefined`
-} catch (error) { }
+import Debug from 'debug'
 
-const hasProcess = typeof process !== `undefined`
-const shouldDebug = (hasLocalStorage && localStorage!.getItem("DEBUG")) || (hasProcess && process.env.DEBUG)
-const debugLog = shouldDebug ? console.log : (_message?: any, ..._optionalParams: any[]) => ""
+const debugLog = Debug("typescript:vfs")
 
 export interface VirtualTypeScriptEnvironment {
   sys: System

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,9 @@ importers:
       '@typescript/vfs':
         specifier: workspace:*
         version: link:../typescript-vfs
+      debug:
+        specifier: ^4.3.4
+        version: 4.3.4
       lz-string:
         specifier: ^1.5.0
         version: 1.5.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,9 @@ importers:
       '@rollup/plugin-commonjs':
         specifier: ^25.0.7
         version: 25.0.8(rollup@3.29.4)
+      '@types/debug':
+        specifier: ^4.1.12
+        version: 4.1.12
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,12 +245,15 @@ importers:
         specifier: workspace:*
         version: link:../typescript-vfs
       debug:
-        specifier: ^4.1.1
+        specifier: ^4.3.4
         version: 4.3.4
       lz-string:
         specifier: ^1.5.0
         version: 1.5.0
     devDependencies:
+      '@types/debug':
+        specifier: ^4.1.12
+        version: 4.1.12
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12
@@ -303,9 +306,12 @@ importers:
   packages/typescript-vfs:
     dependencies:
       debug:
-        specifier: ^4.1.1
+        specifier: ^4.3.4
         version: 4.3.4
     devDependencies:
+      '@types/debug':
+        specifier: ^4.1.12
+        version: 4.1.12
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12
@@ -2489,6 +2495,9 @@ packages:
   '@types/debug@0.0.30':
     resolution: {integrity: sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ==}
 
+  '@types/debug@4.1.12':
+    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
@@ -2584,6 +2593,9 @@ packages:
 
   '@types/mkdirp@0.5.2':
     resolution: {integrity: sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==}
+
+  '@types/ms@0.7.34':
+    resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
 
   '@types/node-fetch@2.6.11':
     resolution: {integrity: sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==}
@@ -13056,6 +13068,10 @@ snapshots:
 
   '@types/debug@0.0.30': {}
 
+  '@types/debug@4.1.12':
+    dependencies:
+      '@types/ms': 0.7.34
+
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 7.29.0
@@ -13175,6 +13191,8 @@ snapshots:
   '@types/mkdirp@0.5.2':
     dependencies:
       '@types/node': 18.19.33
+
+  '@types/ms@0.7.34': {}
 
   '@types/node-fetch@2.6.11':
     dependencies:


### PR DESCRIPTION
Previously, `!!process.env.DEBUG` was used to check whether to debug in `@typescript/vfs` and `@typescript/twoslash`. However, most of the packages are using [the `debug` package](https://npmjs.com/debug) to debug. When we set `DEBUG=vite:hmr`, `@typescript/vfs` will output **lots** of things, which immediately fill the terminal and prevent us from watching logs from Vite.

Also, the `debug` package has been installed as a dependency in `@typescript/vfs`, but seems unused: https://github.com/microsoft/TypeScript-Website/blob/c341935c7f3b7b34812a7438b1b0de5c5cc42e04/packages/typescript-vfs/package.json#L44

And the README also said it's using the `debug` package: https://github.com/microsoft/TypeScript-Website/blob/c341935c7f3b7b34812a7438b1b0de5c5cc42e04/README.md?plain=1#L33