### PR TITLE
Fix: Playground errors when serializing logs

### DIFF
--- a/packages/playground/src/sidebar/runtime.ts
+++ b/packages/playground/src/sidebar/runtime.ts
@@ -234,18 +234,23 @@ function rewireLoggingToElement(
   }
 
   function produceOutput(args: any[]) {
-    let result: string = args.reduce((output: any, arg: any, index) => {
-      const textRep = objectToText(arg)
-      const showComma = index !== args.length - 1
-      const comma = showComma ? "<span class='comma'>, </span>" : ""
-      return output + textRep + comma + " "
-    }, "")
-
-    Object.keys(replacers).forEach(k => {
-      result = result.replace(new RegExp((replacers as any)[k], "g"), k)
-    })
-
-    return result
+    try {
+      let result: string = args.reduce((output: any, arg: any, index) => {
+        const textRep = objectToText(arg)
+        const showComma = index !== args.length - 1
+        const comma = showComma ? "<span class='comma'>, </span>" : ""
+        return output + textRep + comma + " "
+      }, "")
+  
+      Object.keys(replacers).forEach(k => {
+        result = result.replace(new RegExp((replacers as any)[k], "g"), k)
+      })
+  
+      return result
+    } catch (error) {
+      console.warn(i("play_run_log_fail"), error)
+      return i("play_run_log_fail")
+    }
   }
 }
 

--- a/packages/typescriptlang-org/src/copy/en/playground.ts
+++ b/packages/typescriptlang-org/src/copy/en/playground.ts
@@ -55,6 +55,7 @@ export const playCopy = {
   play_run_js: "Executed JavaScript",
   play_run_ts: "Executed transpiled TypeScript",
   play_run_js_fail: "Executed JavaScript Failed:",
+  play_run_log_fail: "Failed to serialize log",
   play_default_code_sample: `// Welcome to the TypeScript Playground, this is a website
 // which gives you a chance to write, share and learn TypeScript.
 


### PR DESCRIPTION
Related to https://github.com/microsoft/TypeScript-Website/pull/3169

Errors thrown in Playground's output serialization should be different than user code errors.

Before:
https://www.typescriptlang.org/play/?target=7#code/PTAEAEBcEMCcHMCmkBcoCiBlATABjwFADGA9gHYDOJANogHTUnwAUA3qNGgIw+9-8DBQ4ULKgAvgEoCQA
- ```ts
  // @target: ES2020
  console.log({ a: 11111111111111111111111111111111111111111111111111111n })
  ```
- Click "Run"
- > [ERR]: "Executed JavaScript Failed:" 
  > [ERR]: Do not know how to serialize a BigInt 

   thrown by https://github.com/microsoft/TypeScript-Website/blob/c341935c7f3b7b34812a7438b1b0de5c5cc42e04/packages/playground/src/sidebar/runtime.ts#L224

After:
- > [LOG]: Failed to serialize log

For comparison, user code error:
- ```ts
  // @target: ES2020
  JSON.stringify({ a: 11111111111111111111111111111111111111111111111111111n })
  ```
- > [ERR]: "Executed JavaScript Failed:" 
  > [ERR]: Do not know how to serialize a BigInt 
