### PR TITLE
Fix: Playground handle bigint in logs

### DIFF
--- a/packages/playground/src/sidebar/runtime.ts
+++ b/packages/playground/src/sidebar/runtime.ts
@@ -218,13 +218,17 @@ function rewireLoggingToElement(
       const nameWithoutObject = name && name === "Object" ? "" : htmlEscape(name)
       const prefix = nameWithoutObject ? `${nameWithoutObject}: ` : ""
 
-      // JSON.stringify omits any keys with a value of undefined. To get around this, we replace undefined with the text __undefined__ and then do a global replace using regex back to keyword undefined
       textRep =
         prefix +
-        JSON.stringify(arg, (_, value) => (value === undefined ? "__undefined__" : value), 2).replace(
-          /"__undefined__"/g,
-          "undefined"
-        )
+        JSON.stringify(
+          arg,
+          (_, value) => {
+            // JSON.stringify omits any keys with a value of undefined. To get around this, we replace undefined with the text __undefined__ and then do a global replace using regex back to keyword undefined
+            if (value === undefined) return "__undefined__"
+            return value
+          },
+          2
+        ).replace(/"__undefined__"/g, "undefined")
 
       textRep = htmlEscape(textRep)
     } else {

--- a/packages/playground/src/sidebar/runtime.ts
+++ b/packages/playground/src/sidebar/runtime.ts
@@ -225,6 +225,7 @@ function rewireLoggingToElement(
           (_, value) => {
             // JSON.stringify omits any keys with a value of undefined. To get around this, we replace undefined with the text __undefined__ and then do a global replace using regex back to keyword undefined
             if (value === undefined) return "__undefined__"
+            if (typeof value === 'bigint') return `BigInt('${value.toString()}')`
             return value
           },
           2


### PR DESCRIPTION
Related to https://github.com/microsoft/TypeScript-Website/pull/3168

Playground Logs should display bigints in logged objects

Before:
https://www.typescriptlang.org/play/?target=7#code/PTAEAEBcEMCcHMCmkBcoCiBlATABjwFADGA9gHYDOJANogHTUnwAUA3qNGgIw+9-8DBQ4ULKgAvgEoCQA
- ```ts
  // @target: ES2020
  console.log({ a: 11111111111111111111111111111111111111111111111111111n })
  ```
- Click "Run"
- > [ERR]: "Executed JavaScript Failed:" 
  > [ERR]: Do not know how to serialize a BigInt 

After:
- > \[LOG]: {
  >   "a": "BigInt('11111111111111111111111111111111111111111111111111111')"
  > }
