### PR TITLE
noUnusedParameters: add note about underscore prefix exception

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/noUnusedParameters.md
+++ b/packages/tsconfig-reference/copy/en/options/noUnusedParameters.md
@@ -13,3 +13,12 @@ const createDefaultKeyboard = (modelID: number) => {
   return { type: "keyboard", modelID: defaultModelID };
 };
 ```
+
+Parameters declaration with names starting with an underscore _ are exempt from the unused parameter checking. e.g.:
+
+```ts twoslash
+function returnNull(_a) {
+  // OK
+  return null;
+}
+```

--- a/packages/tsconfig-reference/copy/en/options/noUnusedParameters.md
+++ b/packages/tsconfig-reference/copy/en/options/noUnusedParameters.md
@@ -14,7 +14,7 @@ const createDefaultKeyboard = (modelID: number) => {
 };
 ```
 
-Parameters declaration with names starting with an underscore _ are exempt from the unused parameter checking. e.g.:
+Parameters declaration with names starting with an underscore (`_`) are exempt from the unused parameter checking. e.g.:
 
 ```ts twoslash
 // @noUnusedParameters

--- a/packages/tsconfig-reference/copy/en/options/noUnusedParameters.md
+++ b/packages/tsconfig-reference/copy/en/options/noUnusedParameters.md
@@ -17,8 +17,8 @@ const createDefaultKeyboard = (modelID: number) => {
 Parameters declaration with names starting with an underscore _ are exempt from the unused parameter checking. e.g.:
 
 ```ts twoslash
-function returnNull(_a) {
-  // OK
-  return null;
-}
+// @noUnusedParameters
+const createDefaultKeyboard = (_modelID: number) => {
+  return { type: "keyboard" };
+};
 ```


### PR DESCRIPTION
In the [release notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#flag-unused-declarations-with---nounusedparameters-and---nounusedlocals) for noUnusedParameters, there's a note about prefixing the parameter name with an underscore to bypass this error.

This PR adds that same note and example to the [noUnusedParameters](https://www.typescriptlang.org/tsconfig/#noUnusedParameters) documentation.

(thanks to @lindboe for noticing this and pointing me to the release docs!)
