### PR TITLE
tsconfig reference documents isolatedModules conditional activation

### DIFF
--- a/packages/documentation/copy/en/project-config/Compiler Options.md
+++ b/packages/documentation/copy/en/project-config/Compiler Options.md
@@ -701,7 +701,7 @@ tsc app.ts util.ts --target esnext --outfile index.js
   <td><code><a href='/tsconfig/#isolatedModules'>--isolatedModules</a></code></td>
   <td><p><code>boolean</code></p>
 </td>
-  <td><p><code>false</code></p>
+  <td><p><code>true</code> if <a href="#verbatimModuleSyntax"><code>verbatimModuleSyntax</code></a>; <code>false</code> otherwise.</p>
 </td>
 </tr>
 <tr class="option-description even"><td colspan="3">

--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -228,6 +228,7 @@ export const defaultsForOptions = {
   ],
   include: ["`[]` if [`files`](#files) is specified;", "`**/*` otherwise."],
   incremental: trueIf("composite"),
+  isolatedModules: trueIf("verbatimModuleSyntax"),
   jsxFactory: "React.createElement",
   locale: "Platform specific.",
   module: [


### PR DESCRIPTION
Following the discussion on https://github.com/microsoft/TypeScript/issues/59186, this PR documents the fact that `isolatedModules` is enabled automatically when `verbatimModuleSyntax` is enabled.