### PR TITLE
Add note on resolution to `typeRoots` documentation

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/typeRoots.md
+++ b/packages/tsconfig-reference/copy/en/options/typeRoots.md
@@ -19,3 +19,6 @@ If `typeRoots` is specified, _only_ packages under `typeRoots` will be included.
 
 This config file will include _all_ packages under `./typings` and `./vendor/types`, and no packages from `./node_modules/@types`.
 All paths are relative to the `tsconfig.json`.
+
+Note that packages within the specified directories are resolved as [directory modules](/docs/handbook/modules/reference.html#directory-modules-index-file-resolution),
+not [`node_modules` packages](/docs/handbook/modules/reference.html#node_modules-package-lookups).


### PR DESCRIPTION
The default `typeRoots` config looks within the `node_modules` directory, (specifically, `node_modules/@types`) to resolve imports. This gives the impression that the contents of a custom `typeRoots` directory are treated as [`node_modules` packages](https://www.typescriptlang.org/docs/handbook/modules/reference.html#node_modules-package-lookups), and therefore can make use of features like`package.json` `"exports"` field. However, this does not seem to be the case. I couldn't find it explicitly documented anywhere, but through trial and error it seems that they are actually treated as [directory modules](https://www.typescriptlang.org/docs/handbook/modules/reference.html#directory-modules-index-file-resolution). Hopefully, adding a note to the documentation will save some time for others looking into this.