### PR TITLE
Make "Declaring `this` in a Function" level 2 heading.

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -547,7 +547,7 @@ Callers can invoke this with either sort of value, and as an added bonus, we don
 
 > Always prefer parameters with union types instead of overloads when possible
 
-### Declaring `this` in a Function
+## Declaring `this` in a Function
 
 TypeScript will infer what the `this` should be in a function via code flow analysis, for example in the following:
 


### PR DESCRIPTION
"Declaring `this` in a Function" is not talking about "Function Overloads", it should be same level.