### PR TITLE
Update allowUnreachableCode.md

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/allowUnreachableCode.md
+++ b/packages/tsconfig-reference/copy/en/options/allowUnreachableCode.md
@@ -9,7 +9,7 @@ When:
 - `true` unreachable code is ignored
 - `false` raises compiler errors about unreachable code
 
-These warnings are only about code which is provably unreachable due to the use of JavaScript syntax, for example:
+These warnings are only about code which is probably unreachable due to the use of JavaScript syntax, for example:
 
 ```ts
 function fn(n: number) {


### PR DESCRIPTION
Fix/Update grammar
The word `provably` is deprecated and was only used in the Middle English period (1150—1500) https://www.oed.com/dictionary/provably_adj

This PR substitutes the obsolete word `provably` with `probably` which serves a better purpose according to the context.