### PR TITLE
ATA: `node:` module resolution

### DIFF
--- a/.changeset/plenty-deers-visit.md
+++ b/.changeset/plenty-deers-visit.md
@@ -2,4 +2,4 @@
 "@typescript/ata": patch
 ---
 
-Improve `node:` module resolution
+Always treat `node:` modules as Node, expand list of known Node modules

--- a/.changeset/plenty-deers-visit.md
+++ b/.changeset/plenty-deers-visit.md
@@ -1,0 +1,5 @@
+---
+"@typescript/ata": patch
+---
+
+Improve `node:` module resolution

--- a/packages/ata/src/edgeCases.ts
+++ b/packages/ata/src/edgeCases.ts
@@ -24,6 +24,7 @@ export const mapModuleNameToModule = (moduleSpecifier: string) => {
     "http2",
     "https",
     "inspector",
+    "inspector/promises",
     "module",
     "net",
     "os",
@@ -57,7 +58,15 @@ export const mapModuleNameToModule = (moduleSpecifier: string) => {
     "zlib",
   ]
 
-  if (builtInNodeMods.includes(moduleSpecifier.replace("node:", ""))) {
+  const builtInNodeModsWithMandatoryPrefix = [
+    "node:sea",
+    "node:sqlite",
+    "node:test",
+    "node:test/mock_loader",
+    "node:test/reporters",
+  ]
+
+  if (builtInNodeMods.includes(moduleSpecifier.replace(/^node:/, "")) || builtInNodeModsWithMandatoryPrefix.includes(moduleSpecifier)) {
     return "node"
   }
 

--- a/packages/ata/src/edgeCases.ts
+++ b/packages/ata/src/edgeCases.ts
@@ -58,15 +58,7 @@ export const mapModuleNameToModule = (moduleSpecifier: string) => {
     "zlib",
   ]
 
-  const builtInNodeModsWithMandatoryPrefix = [
-    "node:sea",
-    "node:sqlite",
-    "node:test",
-    "node:test/mock_loader",
-    "node:test/reporters",
-  ]
-
-  if (builtInNodeMods.includes(moduleSpecifier.replace(/^node:/, "")) || builtInNodeModsWithMandatoryPrefix.includes(moduleSpecifier)) {
+  if (moduleSpecifier.indexOf("node:") === 0 || builtInNodeMods.includes(moduleSpecifier)) {
     return "node"
   }
 

--- a/packages/ata/tests/edgeCases.spec.ts
+++ b/packages/ata/tests/edgeCases.spec.ts
@@ -9,6 +9,11 @@ describe(mapModuleNameToModule, () => {
     expect(mapModuleNameToModule("node:fs")).toEqual("node")
   })
 
+  it("handles mandatorily-prefixed node: identifiers", () => {
+    expect(mapModuleNameToModule("node:test")).toEqual("node")
+    expect(mapModuleNameToModule("test")).toEqual("test")
+  })
+
   it("strips module filepaths", () => {
     expect(mapModuleNameToModule("lodash/identity")).toEqual("lodash")
     expect(mapModuleNameToModule("@org/lodash/identity")).toEqual("@org/lodash")


### PR DESCRIPTION
- There are certain modules that Node doesn't expose without the `node:` prefix, to avoid clashing with existing packages. These are now resolved.
- Ensure that `node:` is only handled if it's a prefix (and not `"dnode:ns"` _etc._)
- Add `inspector/promises` to the module list.