### PR TITLE
Add missing line break between Privacy and Terms of Use links in footer

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/SiteFooter.tsx
+++ b/packages/typescriptlang-org/src/components/layout/SiteFooter.tsx
@@ -303,6 +303,7 @@ export const SiteFooter = (props: Props) => {
             >
             { lang === "ko" ? "개인정보처리방침 및 위치정보이용약관" : "Privacy"}
             </a>
+            <br />
             <a href="https://go.microsoft.com/fwlink/?LinkID=206977">Terms of Use</a>
             {lang === "fr" ?
               <a


### PR DESCRIPTION
The Privacy and Terms of Use links are joined together
<img width="572" alt="image" src="https://github.com/user-attachments/assets/11773561-5cc8-4431-ad30-8107f4c00b52">
