### PR TITLE
Adjusted description of the Partial type

### DIFF
--- a/packages/documentation/copy/en/reference/Utility Types.md
+++ b/packages/documentation/copy/en/reference/Utility Types.md
@@ -43,7 +43,7 @@ Released:
 
 </blockquote>
 
-Constructs a type with all properties of `Type` set to optional. This utility will return a type that represents all subsets of a given type.
+Constructs a type with all properties of `Type` set to optional. This utility will return a type that can have all subsets of the properties of a given type.
 
 ##### Example
 


### PR DESCRIPTION
Subsets of a given type cannot have less properties than the original type (which is not the case with partial types), so the original description was inconsistent with established type operations