### PR TITLE
Fix: Algolia search not working when directly entering the `/play` page

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/TopNav.tsx
+++ b/packages/typescriptlang-org/src/components/layout/TopNav.tsx
@@ -18,7 +18,7 @@ import { OpenInMyLangQuickJump } from "./LanguageRecommendation";
 export const SiteNav = (props: Props) => {
   const i = createInternational<typeof navCopy>(useIntl())
   const IntlLink = createIntlLink(props.lang)
-  const loadDocSearch = () => {
+  const loadDocSearch = (docsearch) => {
     const fixURL = (url: string) => {
       const u = new URL(url);
       if (u.host === document.location.host) return url;
@@ -47,26 +47,35 @@ export const SiteNav = (props: Props) => {
   useEffect(() => {
     setupStickyNavigation()
 
-    // @ts-ignore - this comes from the script above
-    if (window.docsearch) {
-      loadDocSearch();
-    }
-    if (document.getElementById("algolia-search")) return
-
     const searchScript = document.createElement('script');
     searchScript.id = "algolia-search"
-    const searchCSS = document.createElement('link');
 
     searchScript.src = withPrefix("/js/docsearch.js");
     searchScript.async = true;
-    searchScript.onload = () => {
-      // @ts-ignore - this comes from the script above
-      if (window.docsearch) {
-        loadDocSearch();
+    searchScript.onload = async () => {
+      // @ts-ignore this comes from the script above
+      let universalDocSearch = window.docsearch;
+  
+      if (global.require) {
+        universalDocSearch = await new Promise(resolve => {
+          const re: any = global.require;
+          re(['/js/docsearch.js'], (docsearch) => {
+            resolve(docsearch);
+          });
+        });
+      }
+  
+      if (universalDocSearch) {
+        loadDocSearch(universalDocSearch);
+      }
+
+      if (!document.querySelector("#docsearch-css")) {
+        const searchCSS = document.createElement('link');
 
         searchCSS.rel = 'stylesheet';
         searchCSS.href = withPrefix('/css/docsearch.css');
         searchCSS.type = 'text/css';
+        searchCSS.id = 'docsearch-css';
         document.body.appendChild(searchCSS);
 
         document.getElementById("search-form")?.classList.add("search-enabled")


### PR DESCRIPTION
When I accessed the `/play` page directly through a browser search, I found that the `Algoria` was not working properly.

## What this PR solves
- Fixing problems that do not activate `Algoria` Search when entering the `/play` page

https://github.com/user-attachments/assets/8785811e-41d0-4623-bcfa-94c7a0cbc37a


## Problem Summary
1. When entering the `/play` page, the `Play.tsx` and `TopNav.tsx` components are rendered.
2. Each component dynamically imports a script
3. `Play.tsx`'s `vs.loader.js` script is almost received first because it is relatively light and then becomes an AMD module environment.
4. The `docsearch` script of `TopNav.tsx`, which was later imported, does not bind `docsearch` to the `window` as a UMD module.
5. Therefore, the `loadDocSearch` function does not run because the conditional statement fails to pass, preventing `Algoria` from being activated.

## Problem Detail
I identified it as a problem caused by the failure of `docsearch` to bind to the `window` when importing `Algoria` scripts from `TopNav.tsx`.

``` ts
// TopNav.tsx
const searchScript = document.createElement('script');
 ...
searchScript.onload = () => {
  if (window.docsearch) { // Failed to pass
    loadDocSearch();
   }
 }
```

When entering the `/play` page, you will load the script `vs.loader.js`, which will allow you to use the AMD module through the define function.
([Description of loader](https://github.com/microsoft/TypeScript-Website/issues/130#issuecomment-809508862))

``` ts
// Play.tsx
getLoaderScript.src = withPrefix("/js/vs.loader.js");
```

`Play.tsx`'s `vs.loader.js` script is almost received first then `TopNav.tsx`'s `docsearch` because it is relatively light.

```
Play.tsx's vsloader.js: 9.3kb 
TopNav.tsx's docsearch.js: 47.4kb
```


Therefore, `docsearch` using UMD module is recognized as AMD environment and does not assign it to `window`.

To use `docsearch`, need to import the module through AMD method require.

``` ts
// TopNav.tsx
const re: any = global.require  

re(['/js/docsearch.js'], (docsearch) => {
 docsearch // ok
})
```

## Solution
I solved it through branching processing according to the module.

## Steps to Reproduce
1. Go to [play page](https://www.typescriptlang.org/play)
2. Page refresh (Command(Ctrl) + Shift + R )
7. Search Something.. 