### PR TITLE
feat: add print query to the website

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Narrowing.md
+++ b/packages/documentation/copy/en/handbook-v2/Narrowing.md
@@ -62,8 +62,6 @@ function padLeft(padding: number | string, input: string): string {
 
 There are a couple of different constructs TypeScript understands for narrowing.
 
-<div class="pagebreak"></div>
-
 ## `typeof` type guards
 
 As we've seen, JavaScript supports a `typeof` operator which can give very basic information about the type of values we have at runtime.
@@ -165,8 +163,6 @@ This at least prevents us from dreaded errors when we run our code like:
 TypeError: null is not iterable
 ```
 
-<div class="pagebreak"></div>
-
 Keep in mind though that truthiness checking on primitives can often be error prone.
 As an example, consider a different attempt at writing `printAll`
 
@@ -237,8 +233,6 @@ Since `string` is the only common type that both `x` and `y` could take on, Type
 Checking against specific literal values (as opposed to variables) works also.
 In our section about truthiness narrowing, we wrote a `printAll` function which was error-prone because it accidentally didn't handle empty strings properly.
 Instead we could have done a specific check to block out `null`s, and TypeScript still correctly removes `null` from the type of `strs`.
-
-<div class="pagebreak"></div>
 
 ```ts twoslash
 function printAll(strs: string | string[] | null) {

--- a/packages/documentation/copy/en/handbook-v2/Narrowing.md
+++ b/packages/documentation/copy/en/handbook-v2/Narrowing.md
@@ -62,6 +62,8 @@ function padLeft(padding: number | string, input: string): string {
 
 There are a couple of different constructs TypeScript understands for narrowing.
 
+<div class="pagebreak"></div>
+
 ## `typeof` type guards
 
 As we've seen, JavaScript supports a `typeof` operator which can give very basic information about the type of values we have at runtime.
@@ -163,6 +165,8 @@ This at least prevents us from dreaded errors when we run our code like:
 TypeError: null is not iterable
 ```
 
+<div class="pagebreak"></div>
+
 Keep in mind though that truthiness checking on primitives can often be error prone.
 As an example, consider a different attempt at writing `printAll`
 
@@ -233,6 +237,8 @@ Since `string` is the only common type that both `x` and `y` could take on, Type
 Checking against specific literal values (as opposed to variables) works also.
 In our section about truthiness narrowing, we wrote a `printAll` function which was error-prone because it accidentally didn't handle empty strings properly.
 Instead we could have done a specific check to block out `null`s, and TypeScript still correctly removes `null` from the type of `strs`.
+
+<div class="pagebreak"></div>
 
 ```ts twoslash
 function printAll(strs: string | string[] | null) {

--- a/packages/typescriptlang-org/src/components/handbook/Contributors.tsx
+++ b/packages/typescriptlang-org/src/components/handbook/Contributors.tsx
@@ -57,7 +57,7 @@ export const Contributors = (props: ContributorsProps) => {
   }, []);
 
   return (
-    <div className="whitespace-tight raised" style={{ padding: 0 }}>
+    <div className="whitespace-tight raised no-print" style={{ padding: 0 }}>
       <Row className="justify-between small-columns">
         <Section sKey="pr">
           <p>

--- a/packages/typescriptlang-org/src/components/handbook/NextPrev.tsx
+++ b/packages/typescriptlang-org/src/components/handbook/NextPrev.tsx
@@ -17,7 +17,7 @@ export const NextPrev = (props: NextPrevProps) => {
   const next = props.next && props.next.childMarkdownRemark.frontmatter
 
   return (
-    <div className="whitespace-tight raised">
+    <div className="whitespace-tight raised no-print">
       <Row className="justify-between">
         {!prev ? <EmptyLink /> : <LinkSection i={props.i} data={prev} InltLink={props.IntlLink} type="prev" />}
         <div className="hide-small vertical-line" />

--- a/packages/typescriptlang-org/src/components/layout/Sidebar.tsx
+++ b/packages/typescriptlang-org/src/components/layout/Sidebar.tsx
@@ -122,7 +122,7 @@ export const Sidebar = (props: Props) => {
   }
 
   return (
-    <nav id="sidebar">
+    <nav id="sidebar" className="np-print">
       <ul>
         {props.navItems.map(item => <RenderItem key={item.id} item={item} openAllSectionsExceptWhatsNew={props.openAllSectionsExceptWhatsNew} selectedID={props.selectedID} />)}
       </ul>

--- a/packages/typescriptlang-org/src/components/layout/SiteFooter.tsx
+++ b/packages/typescriptlang-org/src/components/layout/SiteFooter.tsx
@@ -235,7 +235,7 @@ export const SiteFooter = (props: Props) => {
   const hideDocs = props.suppressDocRecommendations
   const lang = props.lang
   return (
-    <footer id="site-footer" role="contentinfo">
+    <footer id="site-footer" role="contentinfo" className="no-print">
       {props.suppressCustomization ? null : <Customize />}
 
       {hideDocs ? null :

--- a/packages/typescriptlang-org/src/components/layout/TopNav.tsx
+++ b/packages/typescriptlang-org/src/components/layout/TopNav.tsx
@@ -87,7 +87,7 @@ export const SiteNav = (props: Props) => {
 
 
   return (
-    <header dir="ltr">
+    <header dir="ltr" className="no-print">
       <a className="skip-to-main" href={props.skipToAnchor || '#site-content'} tabIndex={0}>{i("skip_to_content")}</a>
 
       <div id="top-menu" className="up">

--- a/packages/typescriptlang-org/src/style/globals.scss
+++ b/packages/typescriptlang-org/src/style/globals.scss
@@ -47,3 +47,12 @@ $z-index-for-search: 100;
 $z-index-for-site-nav: 101;
 $z-index-for-handbook-nav: 99;
 $z-index-for-handbook-nav-button: 100;
+
+// add print media query
+@media print {
+    .no-print, .no-print * {
+        display: none !important;
+        color: greenyellow;
+    }
+    .pagebreak { page-break-before: always; } 
+  }

--- a/packages/typescriptlang-org/src/style/globals.scss
+++ b/packages/typescriptlang-org/src/style/globals.scss
@@ -53,5 +53,8 @@ $z-index-for-handbook-nav-button: 100;
     .no-print, .no-print * {
         display: none !important;
     }
-    .pagebreak { page-break-before: always; } 
+    .code-container {
+        display: block;
+        break-inside: avoid;
+    }
   }

--- a/packages/typescriptlang-org/src/style/globals.scss
+++ b/packages/typescriptlang-org/src/style/globals.scss
@@ -52,7 +52,6 @@ $z-index-for-handbook-nav-button: 100;
 @media print {
     .no-print, .no-print * {
         display: none !important;
-        color: greenyellow;
     }
     .pagebreak { page-break-before: always; } 
   }

--- a/packages/typescriptlang-org/src/templates/documentation.tsx
+++ b/packages/typescriptlang-org/src/templates/documentation.tsx
@@ -165,7 +165,7 @@ const HandbookTemplate: React.FC<Props> = (props) => {
                     <MarkdownHeadingTree tree={headerListToTree(sidebarHeaders)} className="handbook-on-this-page-section-list" slug={slug} />
                   </>
                   }
-                  <div id="like-dislike-subnav">
+                  <div id="like-dislike-subnav" className="no-print">
                     <h5>{i("handb_like_dislike_title")}</h5>
                     <div>
                       <button title="Like this page" id="like-button"><LikeUnfilledSVG /> {i("handb_like_desc")}</button>


### PR DESCRIPTION
This PR adds print query to the website and show a minimum example of using pagebreak feature. 

The no-print class hide the element on print, and the pagebreak add new page before the related div. 
Here is the first issue about this: https://github.com/microsoft/TypeScript-Website/issues/3204


This PR improve printing a webpage and hide the unnecessary details here is an example: 

| Before| After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/9289826b-5257-46ba-870f-1ffacf4dbb64)  | ![image](https://github.com/user-attachments/assets/660b845d-6c39-4f29-9e60-cdb4881cc04e) |
| ![image](https://github.com/user-attachments/assets/c6ca7354-13aa-4379-984e-69655ec9e10a) | ![image](https://github.com/user-attachments/assets/9e771077-c727-4d63-9fca-fcc60b0f27eb) | 

Page breaks should be added and tested manually which requires a lot of work that I decided to do only if this approach were approved. 

