### PR TITLE
Fix default `maxNodeNodeJsDepth`

### DIFF
--- a/packages/documentation/copy/en/project-config/Compiler Options.md
+++ b/packages/documentation/copy/en/project-config/Compiler Options.md
@@ -811,7 +811,7 @@ tsc app.ts util.ts --target esnext --outfile index.js
   <td><code><a href='/tsconfig/#maxNodeModuleJsDepth'>--maxNodeModuleJsDepth</a></code></td>
   <td><p><code>number</code></p>
 </td>
-  <td><p><code>0</code></p>
+  <td><p><code>0</code>, <code>2</code> when the project has root JavaScript files</p>
 </td>
 </tr>
 <tr class="option-description even"><td colspan="3">

--- a/packages/tsconfig-reference/copy/en/options/maxNodeModuleJsDepth.md
+++ b/packages/tsconfig-reference/copy/en/options/maxNodeModuleJsDepth.md
@@ -7,5 +7,7 @@ The maximum dependency depth to search under `node_modules` and load JavaScript 
 
 This flag can only be used when [`allowJs`](#allowJs) is enabled, and is used if you want to have TypeScript infer types for all of the JavaScript inside your `node_modules`.
 
-Ideally this should stay at 0 (the default), and `d.ts` files should be used to explicitly define the shape of modules.
+By default this is set to 2 when the project contains root JavaScript files, and 0 otherwise.
+
+Ideally this should be 0, and `d.ts` files should be used to explicitly define the shape of modules.
 However, there are cases where you may want to turn this on at the expense of speed and potential accuracy.


### PR DESCRIPTION
Verify here that this is correct: https://github.com/microsoft/TypeScript/blob/533ed3d665c4bb0ecb08dd2eae95fe0aa2e1c973/src/testRunner/unittests/tsserver/maxNodeModuleJsDepth.ts#L16