### PR TITLE
Update header from 'Class Heritage' to 'Class Inheritance' in handbook-v2

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -296,7 +296,7 @@ class MyClass {
 Because the index signature type needs to also capture the types of methods, it's not easy to usefully use these types.
 Generally it's better to store indexed data in another place instead of on the class instance itself.
 
-## Class Heritage
+## Class Inheritance
 
 Like other languages with object-oriented features, classes in JavaScript can inherit from base classes.
 


### PR DESCRIPTION
This change improves the accuracy of the terminology used in the documentation. 'Inheritance' is the more commonly used and technically correct term in Object-Oriented Programming (OOP).

This update helps maintain consistency with standard OOP terminology and may improve clarity for readers, especially those new to the concept.