### PR TITLE
Change 'robust' to 'strict'.md

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Template Literal Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Template Literal Types.md
@@ -87,7 +87,7 @@ person.on("firstNameChanged", (newValue) => {
 });
 ```
 
-Notice that `on` listens on the event `"firstNameChanged"`, not just `"firstName"`. Our naive specification of `on()` could be made more robust if we were to ensure that the set of eligible event names was constrained by the union of attribute names in the watched object with "Changed" added at the end. While we are comfortable with doing such a calculation in JavaScript i.e. ``Object.keys(passedObject).map(x => `${x}Changed`)``, template literals _inside the type system_ provide a similar approach to string manipulation:
+Notice that `on` listens on the event `"firstNameChanged"`, not just `"firstName"`. Our naive specification of `on()` could be made more strict if we were to ensure that the set of eligible event names was constrained by the union of attribute names in the watched object with "Changed" added at the end. While we are comfortable with doing such a calculation in JavaScript i.e. ``Object.keys(passedObject).map(x => `${x}Changed`)``, template literals _inside the type system_ provide a similar approach to string manipulation:
 
 ```ts twoslash
 type PropEventSource<Type> = {


### PR DESCRIPTION
- Change 'robust' to 'strict'
### I think using the word 'strict' is better than 'robust', because robust in engineering refers to the strength of a system against external or internal changes; But there is no such purpose here. Here, if we want to say that the ‍‍`on()` function is robust, it must also work with the `'firstName'` event. (Remove the effect of external change)