### PR TITLE
Bind `console.info` in playground

### DIFF
--- a/packages/playground/src/sidebar/runtime.ts
+++ b/packages/playground/src/sidebar/runtime.ts
@@ -144,6 +144,7 @@ function rewireLoggingToElement(
     const replace = {} as any
     bindLoggingFunc(replace, rawConsole, "log", "LOG")
     bindLoggingFunc(replace, rawConsole, "debug", "DBG")
+    bindLoggingFunc(replace, rawConsole, "info", "INF")
     bindLoggingFunc(replace, rawConsole, "warn", "WRN")
     bindLoggingFunc(replace, rawConsole, "error", "ERR")
     replace["clear"] = clearLogs


### PR DESCRIPTION
This seems to have been removed in 2a32d32b75d3d6f4fa79ad1c154ca3f98658efcd. I don't see a reason to remove it, so I'm assuming it was accidental.