### PR TITLE
Fix: Prev Next Link incorrectly linking to "Nightly Builds" page by d…

### DIFF
--- a/packages/typescriptlang-org/lib/bootup/ingestion/createPagesForDocumentation.ts
+++ b/packages/typescriptlang-org/lib/bootup/ingestion/createPagesForDocumentation.ts
@@ -83,8 +83,8 @@ export const createDocumentationPages = async (
     }
     const id = findWithPage(fakeTopRoot, permalink)
 
-    let previousID = undefined
-    let nextID = undefined
+    let previousID = null
+    let nextID = null
     if (id) {
       const previousPath = getPreviousPageID(handbookNav, id)
       if (previousPath) {


### PR DESCRIPTION
# Issue
Currently, on many handbook pages, the "Previous" and "Next" link blocks at the bottom of the page incorrectly point to the "Nightly Builds" page by default when there should be no link at all.

For example:
- https://www.typescriptlang.org/docs/handbook/intro.html
- https://www.typescriptlang.org/docs/handbook/2/modules.html
- https://www.typescriptlang.org/docs/handbook/asp-net-core.html
- https://www.typescriptlang.org/docs/handbook/nightly-builds.html
- ... and others.

![image](https://github.com/user-attachments/assets/bf63910f-fab7-4b1a-abf9-6a7853b62618)

---
# Cause
This issue occurs due to the context variables `previousID` and `nextID` being passed as `undefined` when no relevant links are found.
These variables are used in the eq filter here:
https://github.com/microsoft/TypeScript-Website/blob/ac68b8b8e4a621113c4ee45c4051002fd55ede24/packages/typescriptlang-org/src/templates/documentation.tsx#L269

The context variables are set here:
https://github.com/microsoft/TypeScript-Website/blob/ac68b8b8e4a621113c4ee45c4051002fd55ede24/packages/typescriptlang-org/lib/bootup/ingestion/createPagesForDocumentation.ts#L120-L121

Gatsby's graphql query explicitly only [handles](https://www.gatsbyjs.com/docs/query-filters/#comparator-details) string, number, boolean and null values in `eq`. When undefined is passed, the filter gets ignored, which in this case results in the "Nightly Builds" page being linked by default.

**GraphQL explorer output:**
- When `undefined` is passed
![image](https://github.com/user-attachments/assets/9c8247df-c7da-4063-b2b2-ce6fedec0253)

- When `null` is passed
![image](https://github.com/user-attachments/assets/4508af1a-f9ed-4b5c-895d-79a54bcdbdf3)

---
# Solution
This PR resolves the issue by setting the `previousID` and `nextID` variables to `null` by default instead of `undefined`. If the next or previous page is found, these variables will be updated accordingly; otherwise, they remain null.

**Fixed handbook/intro.html:**
![image](https://github.com/user-attachments/assets/5eeee347-1f38-41df-bf57-e06b8a9e7553)
