### PR TITLE
Remove mentions of ES3 from docs

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Basics.md
+++ b/packages/documentation/copy/en/handbook-v2/Basics.md
@@ -388,10 +388,10 @@ to
 Why did this happen?
 
 Template strings are a feature from a version of ECMAScript called ECMAScript 2015 (a.k.a. ECMAScript 6, ES2015, ES6, etc. - _don't ask_).
-TypeScript has the ability to rewrite code from newer versions of ECMAScript to older ones such as ECMAScript 3 or ECMAScript 5 (a.k.a. ES3 and ES5).
+TypeScript has the ability to rewrite code from newer versions of ECMAScript to older ones such as ECMAScript 3 or ECMAScript 5 (a.k.a. ES5).
 This process of moving from a newer or "higher" version of ECMAScript down to an older or "lower" one is sometimes called _downleveling_.
 
-By default TypeScript targets ES3, an extremely old version of ECMAScript.
+By default TypeScript targets ES5, an extremely old version of ECMAScript.
 We could have chosen something a little bit more recent by using the [`target`](/tsconfig#target) option.
 Running with `--target es2015` changes TypeScript to target ECMAScript 2015, meaning code should be able to run wherever ECMAScript 2015 is supported.
 So running `tsc --target es2015 hello.ts` gives us the following output:
@@ -403,7 +403,7 @@ function greet(person, date) {
 greet("Maddison", new Date());
 ```
 
-> While the default target is ES3, the great majority of current browsers support ES2015.
+> While the default target is ES5, the great majority of current browsers support ES2015.
 > Most developers can therefore safely specify ES2015 or above as a target, unless compatibility with certain ancient browsers is important.
 
 ## Strictness

--- a/packages/documentation/copy/en/project-config/Compiler Options.md
+++ b/packages/documentation/copy/en/project-config/Compiler Options.md
@@ -824,7 +824,7 @@ tsc app.ts util.ts --target esnext --outfile index.js
   <td><code><a href='/tsconfig/#module'>--module</a></code></td>
   <td><p><code>none</code>, <code>commonjs</code>, <code>amd</code>, <code>umd</code>, <code>system</code>, <code>es6</code>/<code>es2015</code>, <code>es2020</code>, <code>es2022</code>, <code>esnext</code>, <code>node16</code>, <code>nodenext</code>, or <code>preserve</code></p>
 </td>
-  <td><p><code>CommonJS</code> if <a href="#target"><code>target</code></a> is <code>ES3</code> or <code>ES5</code>; <code>ES6</code>/<code>ES2015</code> otherwise.</p>
+  <td><p><code>CommonJS</code> if <a href="#target"><code>target</code></a> is <code>ES5</code>; <code>ES6</code>/<code>ES2015</code> otherwise.</p>
 </td>
 </tr>
 <tr class="option-description even"><td colspan="3">
@@ -1429,7 +1429,7 @@ tsc app.ts util.ts --target esnext --outfile index.js
   <td><code><a href='/tsconfig/#target'>--target</a></code></td>
   <td><p><code>es3</code>, <code>es5</code>, <code>es6</code>/<code>es2015</code>, <code>es2016</code>, <code>es2017</code>, <code>es2018</code>, <code>es2019</code>, <code>es2020</code>, <code>es2021</code>, <code>es2022</code>, <code>es2023</code>, or <code>esnext</code></p>
 </td>
-  <td><p><code>ES3</code></p>
+  <td><p><code>ES5</code></p>
 </td>
 </tr>
 <tr class="option-description odd"><td colspan="3">

--- a/packages/documentation/copy/en/reference/Iterators and Generators.md
+++ b/packages/documentation/copy/en/reference/Iterators and Generators.md
@@ -71,9 +71,9 @@ for (let pet of pets) {
 
 ### Code generation
 
-#### Targeting ES5 and ES3
+#### Targeting ES5
 
-When targeting an ES5 or ES3-compliant engine, iterators are only allowed on values of `Array` type.
+When targeting an ES5-compliant engine, iterators are only allowed on values of `Array` type.
 It is an error to use `for..of` loops on non-Array values, even if these non-Array values implement the `Symbol.iterator` property.
 
 The compiler will generate a simple `for` loop for a `for..of` loop, for instance:

--- a/packages/tsconfig-reference/copy/en/options/lib.md
+++ b/packages/tsconfig-reference/copy/en/options/lib.md
@@ -18,7 +18,7 @@ In TypeScript 4.5, lib files can be overridden by npm modules, find out more [in
 
 | Name         | Contents                                                                                                                                          |
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ES5`        | Core definitions for all ES3 and ES5 functionality                                                                                                |
+| `ES5`        | Core definitions for all ES5 functionality                                                                                                        |
 | `ES2015`     | Additional APIs available in ES2015 (also known as ES6) - `array.find`, `Promise`, `Proxy`, `Symbol`, `Map`, `Set`, `Reflect`, etc.               |
 | `ES6`        | Alias for "ES2015"                                                                                                                                |
 | `ES2016`     | Additional APIs available in ES2016 - `array.include`, etc.                                                                                       |

--- a/packages/tsconfig-reference/scripts/schema/result/schema.json
+++ b/packages/tsconfig-reference/scripts/schema/result/schema.json
@@ -563,7 +563,7 @@
             "target": {
               "description": "Set the JavaScript language version for emitted JavaScript and include compatible library declarations.",
               "type": "string",
-              "default": "ES3",
+              "default": "ES5",
               "anyOf": [
                 {
                   "enum": [

--- a/packages/tsconfig-reference/scripts/schema/vendor/base.json
+++ b/packages/tsconfig-reference/scripts/schema/vendor/base.json
@@ -545,7 +545,7 @@
             "target": {
               "description": "Set the JavaScript language version for emitted JavaScript and include compatible library declarations.",
               "type": "string",
-              "default": "ES3",
+              "default": "ES5",
               "anyOf": [
                 {
                   "enum": [

--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -232,7 +232,7 @@ export const defaultsForOptions = {
   jsxFactory: "React.createElement",
   locale: "Platform specific.",
   module: [
-    "`CommonJS` if [`target`](#target) is `ES3` or `ES5`;",
+    "`CommonJS` if [`target`](#target) is `ES5`;",
     "`ES6`/`ES2015` otherwise.",
   ],
   moduleResolution: [
@@ -260,7 +260,7 @@ export const defaultsForOptions = {
   useUnknownInCatchVariables: trueIf("strict"),
   strictPropertyInitialization: trueIf("strict"),
   strictNullChecks: trueIf("strict"),
-  target: "ES3",
+  target: "ES5",
   useDefineForClassFields: [
     "`true` if [`target`](#target) is `ES2022` or higher, including `ESNext`;",
     "`false` otherwise.",


### PR DESCRIPTION
https://philipwalton.com/articles/the-state-of-es5-on-the-web/ reminded me to actually do this