### PR TITLE
updated the type name

### DIFF
--- a/packages/documentation/copy/en/reference/JSX.md
+++ b/packages/documentation/copy/en/reference/JSX.md
@@ -41,7 +41,7 @@ You can specify this mode using either the [`jsx`](/tsconfig#jsx) command line f
 Recall how to write a type assertion:
 
 ```ts
-const foo = <foo>bar;
+const foo = <Foo>bar;
 ```
 
 This asserts the variable `bar` to have the type `foo`.
@@ -51,7 +51,7 @@ Since the above syntax cannot be used in `.tsx` files, an alternate type asserti
 The example can easily be rewritten with the `as` operator.
 
 ```ts
-const foo = bar as foo;
+const foo = bar as Foo;
 ```
 
 The `as` operator is available in both `.ts` and `.tsx` files, and is identical in behavior to the angle-bracket type assertion style.

--- a/packages/documentation/copy/en/reference/JSX.md
+++ b/packages/documentation/copy/en/reference/JSX.md
@@ -44,7 +44,7 @@ Recall how to write a type assertion:
 const foo = <Foo>bar;
 ```
 
-This asserts the variable `bar` to have the type `foo`.
+This asserts the variable `bar` to have the type `Foo`.
 Since TypeScript also uses angle brackets for type assertions, combining it with JSX's syntax would introduce certain parsing difficulties. As a result, TypeScript disallows angle bracket type assertions in `.tsx` files.
 
 Since the above syntax cannot be used in `.tsx` files, an alternate type assertion operator should be used: `as`.


### PR DESCRIPTION
although the variable and the type having the same name works, to avoid confusion among the users, I've changed the type name