### PR TITLE
Patch gatsby-remark-shiki-twoslash to add in tabindex

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     },
     "patchedDependencies": {
       "react-server-dom-webpack@0.0.0-experimental-c8b778b7f-20220825": "patches/react-server-dom-webpack@0.0.0-experimental-c8b778b7f-20220825.patch",
-      "react-intl@3.12.1": "patches/react-intl@3.12.1.patch"
+      "react-intl@3.12.1": "patches/react-intl@3.12.1.patch",
+      "gatsby-remark-shiki-twoslash@3.0.38": "patches/gatsby-remark-shiki-twoslash@3.0.38.patch"
     }
   },
   "jest": {

--- a/patches/gatsby-remark-shiki-twoslash@3.0.38.patch
+++ b/patches/gatsby-remark-shiki-twoslash@3.0.38.patch
@@ -1,0 +1,24 @@
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+deleted file mode 100644
+index 6036d987fc2889ec9bc230f7774013ae4f736dd9..0000000000000000000000000000000000000000
+diff --git a/src/index.js b/src/index.js
+index e16676ef50b660d520a0efc0b73b68411db349af..bb21bc500a34ac31063774ba4ba133daed2c4f14 100755
+--- a/src/index.js
++++ b/src/index.js
+@@ -4,7 +4,15 @@ const { setupForFile, remarkVisitor }  = require("remark-shiki-twoslash")
+ 
+ const remarkShiki = async function ({ markdownAST }, userConfig) {
+   const {settings, highlighters} = await setupForFile(userConfig)
+-  visit(markdownAST, "code", remarkVisitor(highlighters, settings))
++  const orig = remarkVisitor(highlighters, settings)
++  /** @type {typeof orig} */
++  const visitor = (node) => {
++    orig(node)
++    // Hack to make shiki twoslash code blocks focusable; not needed in modern shiki but we're using an old version
++    node.value = node.value.replace(/(class='code-container')/g, "$1 tabindex='0'")
++  }
++  visit(markdownAST, "code", visitor);
+ }
+ 
+ module.exports = remarkShiki
++

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ overrides:
   sharp: 0.28.1
 
 patchedDependencies:
+  gatsby-remark-shiki-twoslash@3.0.38:
+    hash: prtace25mhevaarvvizifk2ksu
+    path: patches/gatsby-remark-shiki-twoslash@3.0.38.patch
   react-intl@3.12.1:
     hash: yqkzm4v5lxjbatodvsvpq7o7bq
     path: patches/react-intl@3.12.1.patch
@@ -413,7 +416,7 @@ importers:
         version: 6.13.1(gatsby@5.13.5(babel-eslint@10.1.0(eslint@7.32.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.18.2)(typescript@5.6.2))
       gatsby-remark-shiki-twoslash:
         specifier: ^3.0.36
-        version: 3.0.38
+        version: 3.0.38(patch_hash=prtace25mhevaarvvizifk2ksu)
       gatsby-remark-smartypants:
         specifier: ^6.6.0
         version: 6.13.1(gatsby@5.13.5(babel-eslint@10.1.0(eslint@7.32.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@4.18.2)(typescript@5.6.2))
@@ -17416,7 +17419,7 @@ snapshots:
       lodash: 4.17.21
       unist-util-visit: 2.0.3
 
-  gatsby-remark-shiki-twoslash@3.0.38:
+  gatsby-remark-shiki-twoslash@3.0.38(patch_hash=prtace25mhevaarvvizifk2ksu):
     dependencies:
       remark-shiki-twoslash: 3.1.3(typescript@5.6.2)
       typescript: 5.6.2


### PR DESCRIPTION
Modern shiki does this automatically, but we're using an old version without it. Patch it in for now until we can wholesale upgrade

closes #3253