### PR TITLE
docs: example of enum in JSDoc

### DIFF
--- a/packages/documentation/copy/en/reference/Enums.md
+++ b/packages/documentation/copy/en/reference/Enums.md
@@ -443,4 +443,24 @@ walk(EDirection.Left);
 run(ODirection.Right);
 ```
 
+In plain JavaScript syntax:
+```js
+/**
+ * @enum {typeof Direction[keyof typeof Direction]}
+ */
+const Direction = /** @type {const} */({
+  Up: 'up',
+  Down: 'down',
+  Left: 'left',
+  Right: 'right',
+});
+
+/** @type {Direction} */
+const valid = 'up';
+
+/** @type {Direction} */
+// @ts-expect-error
+const bad = 'sideways';
+```
+
 The biggest argument in favour of this format over TypeScript's `enum` is that it keeps your codebase aligned with the state of JavaScript, and [when/if](https://github.com/rbuckton/proposal-enum) enums are added to JavaScript then you can move to the additional syntax.


### PR DESCRIPTION
The https://www.typescriptlang.org/docs/handbook/enums.html page explains how in `.ts` syntax to use plain JS objects for an enum.

This adds an example for `.js` syntax.

[Playground example](https://www.typescriptlang.org/play/?filetype=js#code/PQKhCgAIUgBBTAdgVwLaQN4BcCeAHeAewDNIARASwCd4BjLCwxAbQGt4cTJcCvKb6jRAF0AvlBDBwtJgGcs5anQZNIAXkigYsHvEwzE80dGAAKDOACqeAFyQA5Mjz2ANODKEA7ojv2AJl6IruAAMvDEWL4ANuFYwQBKFADmABaRDlTJacGiAJQA3ODgWnC6mPzKQsaS0nIKAG4AhlEUfuoOTvaFxWCl+HoYFYJM1VLAwKWyALTwAB4E9DNUVIRUtYYKAEaNbRr2sq3wno04sl3gQA)