### PR TITLE
Fix small typo

### DIFF
--- a/packages/documentation/copy/en/release-notes/TypeScript 3.9.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 3.9.md
@@ -138,7 +138,7 @@ Pick `ts-expect-error` if:
 
 - you're writing test code where you actually want the type system to error on an operation
 - you expect a fix to be coming in fairly quickly and you just need a quick workaround
-- you're in a reasonably-sized project with a proactive team that wants to remove suppression comments as soon affected code is valid again
+- you're in a reasonably-sized project with a proactive team that wants to remove suppression comments as soon as affected code is valid again
 
 Pick `ts-ignore` if:
 


### PR DESCRIPTION
Change "as soon affected code" to "as soon as affected code"