### PR TITLE
fix: remove redirection by changing `/play` route to direct routing

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/TopNav.tsx
+++ b/packages/typescriptlang-org/src/components/layout/TopNav.tsx
@@ -104,7 +104,7 @@ export const SiteNav = (props: Props) => {
               <li className="nav-item" role="none presentation"><IntlLink id="tab2" role="tab" to="/docs/"><span>{i("nav_documentation_short")}</span></IntlLink></li>
               <li className="nav-item show-only-large" role="none presentation"><IntlLink id="tab3" role="tab" to="/docs/handbook/intro.html">{i("nav_handbook")}</IntlLink></li>
               <li className="nav-item" role="none presentation"><IntlLink id="tab4" role="tab" to="/community">{i("nav_community")}</IntlLink></li>
-              <li className="nav-item show-only-largest" role="none presentation"><IntlLink id="tab5" role="tab" to="/play">{i("nav_playground")}</IntlLink></li>
+              <li className="nav-item show-only-largest" role="none presentation"><IntlLink id="tab5" role="tab" to="/play/">{i("nav_playground")}</IntlLink></li>
               <li className="nav-item" role="none presentation"><IntlLink id="tab6" role="tab" to="/tools">{i("nav_tools")}</IntlLink></li>
             </ul>
           </nav>


### PR DESCRIPTION
While looking at the ways to improve the rendering performance of the /play page, I discovered a redirect occurring when navigating to the page. Please let me know if you have any problems. Thank you always.

## What this PR solves
- remove redirection by changing `/play` route to `/play/`

## Expected Benefits
- Eliminates ~570ms delay on /play page load during slow network conditions
<img width="1622" alt="스크린샷 2024-11-05 오후 2 53 13" src="https://github.com/user-attachments/assets/fdc3d604-8364-47ce-96d2-6e4ca654de20">

### AS-IS

https://github.com/user-attachments/assets/fe171de2-f4b2-4a05-b332-f23cb41d46d1

### TO-BE

https://github.com/user-attachments/assets/7780f864-c3a6-4c88-b09f-4ea83e5911f1