### PR TITLE
Fix: wrong typescript announcement link for release version

### DIFF
--- a/packages/typescriptlang-org/scripts/getTypeScriptNPMVersions.js
+++ b/packages/typescriptlang-org/scripts/getTypeScriptNPMVersions.js
@@ -110,7 +110,7 @@ const getTypeScriptNPMVersions = async () => {
   // prettier-ignore
   let siteReleaseNotesURL = `/docs/handbook/release-notes/typescript-${semver.major(stable)}-${semver.minor(stable)}.html`
   // prettier-ignore
-  let releasePostURL = `https://devblogs.microsoft.com/typescript/announcing-typescript-${semver.major(rc)}-${semver.minor(rc)}/`
+  let releasePostURL = `https://devblogs.microsoft.com/typescript/announcing-typescript-${semver.major(stable)}-${semver.minor(stable)}/`
   // prettier-ignore
   let releaseNotesMDPath = `../../documentation/copy/en/release-notes/TypeScript ${semver.major(stable)}.${semver.minor(stable)}.md`
   // prettier-ignore


### PR DESCRIPTION
**Issue:**
The link it is redirecting to is wrong.


![image](https://github.com/user-attachments/assets/3172a6f4-b86a-48ec-909a-93b69382fa7e)
is redirecting to
![image](https://github.com/user-attachments/assets/fcff12d9-7ac1-472d-b6f0-2fc2d490132d)
Here the minor version number is wrong.

**Fix:**
Fixed this issue by changing the wrong 'rc' variable to 'stable' to build the url from stable version instead of the release candidate one. 
