### PR TITLE
Fix z-index conflict between aside and sidebar in mobile view

### DIFF
--- a/packages/typescriptlang-org/src/templates/documentation.scss
+++ b/packages/typescriptlang-org/src/templates/documentation.scss
@@ -1,13 +1,11 @@
 @import "../style/globals.scss";
 
 #beta {
-  background: repeating-linear-gradient(
-    45deg,
-    #9b9a4e,
-    #9b9a4e 10px,
-    #6e6a33 10px,
-    #6e6a33 20px
-  );
+  background: repeating-linear-gradient(45deg,
+      #9b9a4e,
+      #9b9a4e 10px,
+      #6e6a33 10px,
+      #6e6a33 20px);
   background-color: "#c63131";
   text-align: center;
   color: white;
@@ -32,7 +30,7 @@
   }
 
   // Page title
-  & > h1 {
+  &>h1 {
     font-size: 3.5rem;
     line-height: 3.5rem;
     font-weight: 400;
@@ -136,6 +134,7 @@
     }
 
     .like-dislike-subnav {
+
       #like-button,
       #dislike-button {
         cursor: pointer;
@@ -478,6 +477,6 @@
   overflow: auto;
   max-height: 80vh;
   ul {
-    padding-left: 0.5em !important;
+    padding-left: .5em !important;
   }
 }

--- a/packages/typescriptlang-org/src/templates/documentation.scss
+++ b/packages/typescriptlang-org/src/templates/documentation.scss
@@ -1,11 +1,13 @@
 @import "../style/globals.scss";
 
 #beta {
-  background: repeating-linear-gradient(45deg,
-      #9b9a4e,
-      #9b9a4e 10px,
-      #6e6a33 10px,
-      #6e6a33 20px);
+  background: repeating-linear-gradient(
+    45deg,
+    #9b9a4e,
+    #9b9a4e 10px,
+    #6e6a33 10px,
+    #6e6a33 20px
+  );
   background-color: "#c63131";
   text-align: center;
   color: white;
@@ -30,7 +32,7 @@
   }
 
   // Page title
-  &>h1 {
+  & > h1 {
     font-size: 3.5rem;
     line-height: 3.5rem;
     font-weight: 400;
@@ -81,7 +83,7 @@
       position: relative;
       top: 0;
       width: 100%;
-      z-index: 1000;
+      z-index: 98;
       margin-left: 0;
       order: 1;
     }
@@ -134,7 +136,6 @@
     }
 
     .like-dislike-subnav {
-
       #like-button,
       #dislike-button {
         cursor: pointer;
@@ -477,6 +478,6 @@
   overflow: auto;
   max-height: 80vh;
   ul {
-    padding-left: .5em !important;
+    padding-left: 0.5em !important;
   }
 }


### PR DESCRIPTION
This PR fixes a CSS z-index conflict in mobile view where the aside is overlapping the sidebar. 
- The aside had a z-index of 1000, which caused it to appear above the sidebar (z-index: 99).
- Changed the aside z-index to 98, ensuring it stays behind the sidebar in mobile view.