### PR TITLE
Change bot token secret name

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
           filter: blob:none
-          token: ${{ secrets.GITHUB_BOT_TOKEN }}
+          token: ${{ secrets.TS_BOT_TOKEN }}
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: "18.x"
@@ -37,5 +37,5 @@ jobs:
         with:
           publish: pnpm ci:publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TS_BOT_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }} 


### PR DESCRIPTION
Secrets starting with `GITHUB_` are no longer allowed and cannot be updated.