### PR TITLE
Resolve transitive dependencies based on package.json

### DIFF
--- a/.changeset/clever-bulldogs-retire.md
+++ b/.changeset/clever-bulldogs-retire.md
@@ -1,0 +1,6 @@
+---
+"@typescript/sandbox": patch
+"@typescript/ata": patch
+---
+
+Added new ATA flag (resolveDependenciesFromPackageJson) to resolve transitive dependencies

--- a/packages/ata/src/index.ts
+++ b/packages/ata/src/index.ts
@@ -29,8 +29,8 @@ export interface ATABootstrapConfig {
   fetcher?: typeof fetch
   /** If you need a custom logger instead of the console global */
   logger?: Logger
-  /** Wheather to use package.json as the source of truth for transitive dependencies' versions */
-  usePackageJson?: boolean
+  /** Whether to use package.json as the source of truth for transitive dependencies' versions */
+  resolveDependenciesFromPackageJson?: boolean
 }
 
 type PackageJsonDependencies = {
@@ -144,7 +144,7 @@ export const setupTypeAcquisition = (config: ATABootstrapConfig) => {
 
           // Recurse through deps
           let typesPackageJson
-          if (config.usePackageJson){
+          if (config.resolveDependenciesFromPackageJson){
             typesPackageJson = moduleMap.get(dts.moduleName)?.typesPackageJson
           }
           await resolveDeps(dtsCode, depth + 1, typesPackageJson)

--- a/packages/ata/src/index.ts
+++ b/packages/ata/src/index.ts
@@ -91,7 +91,7 @@ export const setupTypeAcquisition = (config: ATABootstrapConfig) => {
     const mightBeOnDT = treesOnly.filter(t => !hasDTS.includes(t))
     const dtTrees = await Promise.all(
       // TODO: Switch from 'latest' to the version from the original tree which is user-controlled
-      mightBeOnDT.map(f => getFileTreeForModuleWithTag(config, `@types/${getDTName(f.moduleName)}`, f.version))
+      mightBeOnDT.map(f => getFileTreeForModuleWithTag(config, `@types/${getDTName(f.moduleName)}`, "latest"))
     )
 
     const dtTreesOnly = dtTrees.filter(t => !("error" in t)) as NPMTreeMeta[]

--- a/packages/ata/src/userFacingTypes.d.ts
+++ b/packages/ata/src/userFacingTypes.d.ts
@@ -20,6 +20,8 @@ export interface ATABootstrapConfig {
   fetcher?: typeof fetch
   /** If you need a custom logger instead of the console global */
   logger?: Logger
+  /** Whether to use package.json as the source of truth for transitive dependencies' versions */
+  resolveDependenciesFromPackageJson?: boolean;
 }
 
 type ModuleMeta = { state: "loading" }

--- a/packages/ata/tests/ata.spec.ts
+++ b/packages/ata/tests/ata.spec.ts
@@ -16,6 +16,49 @@ describe(getReferencesForModule, () => {
     const code = "import {asda} from '123' // types: 1.2.3"
     expect(getReferencesForModule(ts, code)[0]).toEqual({ module: "123", version: "1.2.3" })
   })
+
+  describe("given a package.json", () => {
+    const moduleName = 'some-module'
+    const version = '^1.0.0'
+    const packageJsons = [
+      {
+        key: "dependencies",
+        pkgJsonContent: {
+          dependencies: {
+            [moduleName]: version
+          }
+        } 
+      },
+      {
+        key: "devDependencies",
+        pkgJsonContent: {
+          devDependencies: {
+            [moduleName]: version
+          }
+        } 
+      },
+      {
+        key: "peerDependencies",
+        pkgJsonContent: {
+          peerDependencies: {
+            [moduleName]: version
+          }
+        } 
+      },
+      {
+        key: "optionalDependencies",
+        pkgJsonContent: {
+          optionalDependencies: {
+            [moduleName]: version
+          }
+        } 
+      },
+    ]
+    it.each(packageJsons)("uses $key as source of truth for the module's version", (pkgJson) => {
+      const code = `import {asda} from '${moduleName}'`
+      expect(getReferencesForModule(ts, code, pkgJson.pkgJsonContent)[0]).toEqual({ module: moduleName, version: version })
+    })
+  })
 })
 
 describe("ignores lib references", () => {

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -209,6 +209,7 @@ export const createTypeScriptSandbox = (
     projectName: "TypeScript Playground",
     typescript: ts,
     logger: console,
+    resolveDependenciesFromPackageJson: true,
     delegate: {
       receivedFile: addLibraryToRuntime,
       progress: (downloaded: number, total: number) => {


### PR DESCRIPTION
When the newly added `resolveDependenciesFromPackageJson` flag is set to true, ATA will resolve the versions of any transitive dependency according to the `package.json` file of the same module (unless any `// types:` comment is specified).