### PR TITLE
Link `outDir` to `exclude` in the tsconfig docs

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -134,7 +134,7 @@ export const relatedTo: [AnOption, AnOption[]][] = [
   ["esModuleInterop", ["allowSyntheticDefaultImports"]],
 
   ["out", ["outDir", "outFile"]],
-  ["outDir", ["out", "outFile"]],
+  ["outDir", ["out", "outFile", "exclude"]],
   ["outFile", ["out", "outDir"]],
 
   ["diagnostics", ["extendedDiagnostics"]],


### PR DESCRIPTION
My build started failing when I upgraded from TypeScript 5.3 to TypeScript 5.7.

* This turned out to be because of a bugfix: https://github.com/microsoft/TypeScript/pull/58335
* I was still confused as to how a bugfix could impact my code, so I filed https://github.com/microsoft/TypeScript/issues/60867.

There, I got my answer: the default value of `exclude` is `outDir`! I didn't realize this, because I was only looking at things from the `outDir` side. If there were a link from `outDir` to `exclude`, I would have clicked that link and learned the answer much sooner!