### PR TITLE
remove comment about Internet explorer 10 support

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -597,9 +597,6 @@ class MsgError extends Error {
 However, any subclass of `MsgError` will have to manually set the prototype as well.
 For runtimes that don't support [`Object.setPrototypeOf`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf), you may instead be able to use [`__proto__`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto).
 
-Unfortunately, [these workarounds will not work on Internet Explorer 10 and prior](<https://msdn.microsoft.com/en-us/library/s4esdbwz(v=vs.94).aspx>).
-One can manually copy methods from the prototype onto the instance itself (i.e. `MsgError.prototype` onto `this`), but the prototype chain itself cannot be fixed.
-
 ## Member Visibility
 
 You can use TypeScript to control whether certain methods or properties are visible to code outside the class.


### PR DESCRIPTION
Internet explorer 10 reached end of life five years ago, is it still relevant to include this comment?