### PR TITLE
Rename for consistent example snippet

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/More on Functions.md
+++ b/packages/documentation/copy/en/handbook-v2/More on Functions.md
@@ -601,7 +601,7 @@ This pattern is common with callback-style APIs, where another object typically 
 // @errors: 7041 7017
 interface User {
   id: number;
-  isAdmin: boolean;
+  admin: boolean;
 }
 declare const getDB: () => DB;
 // ---cut---


### PR DESCRIPTION
`User` has `admin` property in other example snippets so as in the playground