### PR TITLE
Fix module-class.d.ts incorrect export as namespace syntax

### DIFF
--- a/packages/documentation/copy/en/declaration-files/templates/module-class.d.ts.md
+++ b/packages/documentation/copy/en/declaration-files/templates/module-class.d.ts.md
@@ -50,7 +50,7 @@ To handle both importing via UMD and modules:
  *~ loaded outside a module loader environment, declare that global here.
  *~ Otherwise, delete this declaration.
  */
-export as namespace "super-greeter";
+export as namespace myClassLib;
 
 /*~ This declaration specifies that the class constructor function
  *~ is the exported object from the file


### PR DESCRIPTION
namespace with a string literal is not a valid syntax in typescript. And the example code here was not consistent with the comment too. The comment said we name the module-class's UMD format as 'myClassLib', which mean we can access 'myClassLib' as global property in context which has loaded the module-class.