### PR TITLE
Add TypeScript 5.0 defaults to the JSON schema

### DIFF
--- a/packages/tsconfig-reference/scripts/schema/result/schema.json
+++ b/packages/tsconfig-reference/scripts/schema/result/schema.json
@@ -396,6 +396,7 @@
             "newLine": {
               "description": "Set the newline character for emitting files.",
               "type": "string",
+              "default": "lf",
               "anyOf": [
                 {
                   "enum": ["crlf", "lf"]
@@ -641,7 +642,7 @@
             "forceConsistentCasingInFileNames": {
               "description": "Ensure that casing is correct in imports.",
               "type": "boolean",
-              "default": false,
+              "default": true,
               "markdownDescription": "Ensure that casing is correct in imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames"
             },
             "generateCpuProfile": {

--- a/packages/tsconfig-reference/scripts/schema/vendor/base.json
+++ b/packages/tsconfig-reference/scripts/schema/vendor/base.json
@@ -376,6 +376,7 @@
             "newLine": {
               "description": "Set the newline character for emitting files.",
               "type": "string",
+              "default": "lf",
               "anyOf": [
                 {
                   "enum": [
@@ -658,7 +659,7 @@
             "forceConsistentCasingInFileNames": {
               "description": "Ensure that casing is correct in imports.",
               "type": "boolean",
-              "default": false,
+              "default": true,
               "markdownDescription": "Ensure that casing is correct in imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames"
             },
             "generateCpuProfile": {


### PR DESCRIPTION
As mentioned in Discord, I have noticed that defaults of `newLine` and `forceConsistentCasingInFileNames` were not updated to reflect the change in TypeScript 5.0. Reference: https://github.com/microsoft/TypeScript/pull/52298

Already fixed in schemastore repo: https://github.com/SchemaStore/schemastore/pull/4371

EDIT Information in the website is correct. This is only the JSON schema issue.