### PR TITLE
Fix default value of esModuleInterop

### DIFF
--- a/packages/documentation/copy/en/project-config/Compiler Options.md
+++ b/packages/documentation/copy/en/project-config/Compiler Options.md
@@ -549,7 +549,7 @@ tsc app.ts util.ts --target esnext --outfile index.js
   <td><code><a href='/tsconfig/#esModuleInterop'>--esModuleInterop</a></code></td>
   <td><p><code>boolean</code></p>
 </td>
-  <td><p><code>true</code> if <a href="#module"><code>module</code></a> is <code>node16</code> or <code>nodenext</code>; <code>false</code> otherwise.</p>
+  <td><p><code>true</code> if <a href="#module"><code>module</code></a> is <code>node16</code>, <code>nodenext</code>, or <code>preserve</code>; <code>false</code> otherwise.</p>
 </td>
 </tr>
 <tr class="option-description odd"><td colspan="3">

--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -217,7 +217,7 @@ export const defaultsForOptions = {
   alwaysStrict: trueIf("strict"),
   declaration: trueIf("composite"),
   esModuleInterop: [
-    "`true` if [`module`](#module) is `node16` or `nodenext`;",
+    "`true` if [`module`](#module) is `node16`, `nodenext`, or `preserve`;",
     "`false` otherwise.",
   ],
   exclude: [


### PR DESCRIPTION
Based on https://github.com/microsoft/TypeScript/blob/v5.7.3/src/compiler/utilities.ts#L9001-L9006

Should I also mention `"node18"`? It seems it is not released yet.