### PR TITLE
Fixing unsafe HTML constructed from library input

### DIFF
--- a/packages/playground/src/ds/createDesignSystem.ts
+++ b/packages/playground/src/ds/createDesignSystem.ts
@@ -328,7 +328,12 @@ export const createDesignSystem = (sandbox: Sandbox) => {
         if (key === "kind") {
           suffix = ` (SyntaxKind.${info.name})`
         }
-        li.innerHTML = `${key}: <span class='${typeofSpan}'>${value}</span>${suffix}`
+        li.textContent = `${key}: `;
+        const span = document.createElement('span');
+        span.className = typeofSpan;
+        span.textContent = value;
+        li.appendChild(span);
+        li.appendChild(document.createTextNode(suffix));
         return li
       }
 


### PR DESCRIPTION
This pr fixes a CodeQL bug <https://liquid.microsoft.com/codeql/issues/78803302-8be1-4d5e-8881-4a8da5f5df37?copilot_promptid=E91B0CE9-0C1B-4AC2-8A46-33F49B67E058>