### PR TITLE
docs: remove the word 'duck typing' in structural-type-system section.

### DIFF
--- a/packages/documentation/copy/en/get-started/TS for JS Programmers.md
+++ b/packages/documentation/copy/en/get-started/TS for JS Programmers.md
@@ -208,7 +208,7 @@ backpack.add(23);
 
 ## Structural Type System
 
-One of TypeScript's core principles is that type checking focuses on the _shape_ that values have. This is sometimes called "duck typing" or "structural typing".
+One of TypeScript's core principles is that type checking focuses on the _shape_ that values have. This is sometimes called "structural typing".
 
 In a structural type system, if two objects have the same shape, they are considered to be of the same type.
 


### PR DESCRIPTION
In the [Structural Type System](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html#structural-type-system) section, the documentation states that TypeScript’s type checking can be referred to as `duck typing` because it compares the shape of values. However, this is incorrect due to the following reasons:

-  `duck typing` compares types based on **behavior**.
- `structural typing` compares types based on their **structure** (or) the **members** they contain.

This PR resolves the above issue.