### PR TITLE
Update TS for Functional Programmers.md

### DIFF
--- a/packages/documentation/copy/en/get-started/TS for Functional Programmers.md
+++ b/packages/documentation/copy/en/get-started/TS for Functional Programmers.md
@@ -427,7 +427,7 @@ type Shape =
   | { kind: "square"; x: number }
   | { kind: "triangle"; x: number; y: number };
 // ---cut---
-function height(s: Shape) {
+function width(s: Shape) {
   if (s.kind === "circle") {
     return 2 * s.radius;
   } else {


### PR DESCRIPTION
function `height()` is actually calculating width.

The height of a triangle would be given by `s.y` (which isn't in the `"square"` variant).