### PR TITLE
add oneline description to rewriteRelativeImportExtensions

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/rewriteRelativeImportExtensions.md
+++ b/packages/tsconfig-reference/copy/en/options/rewriteRelativeImportExtensions.md
@@ -1,6 +1,6 @@
 ---
 display: "rewriteRelativeImportExtensions"
-oneline: "Does something"
+oneline: "Rewrite TypeScript extensions of relative import paths to their JavaScript equivalent."
 ---
 Rewrite .ts, .tsx, .mts, and .cts file extensions in relative import paths to their JavaScript equivalent in output files.
  


### PR DESCRIPTION
I noticed the short description of `rewriteRelativeImportExtensions` was a placeholder (I think?) on the playground.

<img width="410" alt="Screenshot 2025-02-08 at 9 55 30 PM" src="https://github.com/user-attachments/assets/c5e1e65a-2d45-47ce-a8c0-234c8bfd2131" />

I tracked it down to this file and I made it a slightly shorter version of the full description to try and match the length of the other `oneline` properties. Please edit as needed 😄 