### PR TITLE
Consistently style code blocks in tsconfig reference

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/customConditions.md
+++ b/packages/tsconfig-reference/copy/en/options/customConditions.md
@@ -8,7 +8,7 @@ These conditions are added to whatever existing conditions a resolver will use b
 
 For example, when this field is set in a `tsconfig.json` as so:
 
-```jsonc
+```json tsconfig
 {
     "compilerOptions": {
         "target": "es2022",

--- a/packages/tsconfig-reference/copy/en/options/disableFilenameBasedTypeAcquisition.md
+++ b/packages/tsconfig-reference/copy/en/options/disableFilenameBasedTypeAcquisition.md
@@ -7,7 +7,7 @@ TypeScript's type acquisition can infer what types should be added based on file
 
 You can disable this via `disableFilenameBasedTypeAcquisition`.
 
-```json
+```json tsconfig
 {
   "typeAcquisition": {
     "disableFilenameBasedTypeAcquisition": true

--- a/packages/tsconfig-reference/copy/en/options/enable.md
+++ b/packages/tsconfig-reference/copy/en/options/enable.md
@@ -5,7 +5,7 @@ oneline: "Disable the type acquisition for JavaScript projects."
 
 Disables automatic type acquisition in JavaScript projects:
 
-```json
+```json tsconfig
 {
   "typeAcquisition": {
     "enable": false

--- a/packages/tsconfig-reference/copy/en/options/explainFiles.md
+++ b/packages/tsconfig-reference/copy/en/options/explainFiles.md
@@ -16,7 +16,7 @@ example
 
 Using a `tsconfig.json` which has `explainFiles` set to true:
 
-```json
+```json tsconfig
 {
   "compilerOptions": {
     "target": "es5",

--- a/packages/tsconfig-reference/copy/en/options/include.md
+++ b/packages/tsconfig-reference/copy/en/options/include.md
@@ -6,7 +6,7 @@ oneline: "Specify a list of glob patterns that match files to be included in com
 Specifies an array of filenames or patterns to include in the program.
 These filenames are resolved relative to the directory containing the `tsconfig.json` file.
 
-```json
+```json tsconfig
 {
   "include": ["src/**/*", "tests/**/*"]
 }

--- a/packages/tsconfig-reference/copy/en/options/typeAcquisition.md
+++ b/packages/tsconfig-reference/copy/en/options/typeAcquisition.md
@@ -8,7 +8,7 @@ This is called automatic type acquisition, and you can customize it using the `t
 
 If you would like to disable or customize this feature, create a `jsconfig.json` in the root of your project:
 
-```json
+```json tsconfig
 {
   "typeAcquisition": {
     "enable": false
@@ -18,7 +18,7 @@ If you would like to disable or customize this feature, create a `jsconfig.json`
 
 If you have a specific module which should be included (but isn't in `node_modules`):
 
-```json
+```json tsconfig
 {
   "typeAcquisition": {
     "include": ["jest"]
@@ -28,7 +28,7 @@ If you have a specific module which should be included (but isn't in `node_modul
 
 If a module should not be automatically acquired, for example if the library is available in your `node_modules` but your team has agreed to not use it:
 
-```json
+```json tsconfig
 {
   "typeAcquisition": {
     "exclude": ["jquery"]

--- a/packages/tsconfig-reference/copy/en/options/typeAcquisition/exclude.md
+++ b/packages/tsconfig-reference/copy/en/options/typeAcquisition/exclude.md
@@ -5,7 +5,7 @@ oneline: "Specify a list of modules which to exclude from type acquisition."
 
 Offers a config for disabling the type-acquisition for a certain module in JavaScript projects. This can be useful for projects which include other libraries in testing infrastructure which aren't needed in the main application.
 
-```json
+```json tsconfig
 {
   "typeAcquisition": {
     "exclude": ["jest", "mocha"]

--- a/packages/tsconfig-reference/copy/en/options/typeAcquisition/include.md
+++ b/packages/tsconfig-reference/copy/en/options/typeAcquisition/include.md
@@ -7,7 +7,7 @@ If you have a JavaScript project where TypeScript needs additional guidance to u
 
 You can use `include` to specify which types should be used from DefinitelyTyped:
 
-```json
+```json tsconfig
 {
   "typeAcquisition": {
     "include": ["jquery"]

--- a/packages/tsconfig-reference/copy/en/sections/buildOptions.md
+++ b/packages/tsconfig-reference/copy/en/sections/buildOptions.md
@@ -4,7 +4,7 @@ Type Acquisition is only important for JavaScript projects. In TypeScript projec
 
 You may not want this, in which case you can turn off type acquisition by having this `jsconfig.json` in the root of your project:
 
-```json
+```json tsconfig
 {
   "typeAcquisition": {
     "enable": false
@@ -14,7 +14,7 @@ You may not want this, in which case you can turn off type acquisition by having
 
 Common uses for this section of a `jsconfig.json` is to tell TypeScript to download additional definitions for your tooling experience:
 
-```json
+```json tsconfig
 {
   "typeAcquisition": {
     "include": ["jquery"]


### PR DESCRIPTION
Use `json tsconfig` language identifier for all tsconfig snippets for uniform syntax highlighting on <https://www.typescriptlang.org/tsconfig>.