### PR TITLE
Clearer `NoInfer<Type>` example

### DIFF
--- a/packages/documentation/copy/en/reference/Utility Types.md
+++ b/packages/documentation/copy/en/reference/Utility Types.md
@@ -466,16 +466,23 @@ identical to `Type`.
 
 ##### Example
 
-```ts
+```ts twoslash
+// @errors: 2345
+function laxCreateStreetLight<C extends string>(
+  colors: C[],
+  defaultColor?: C,
+) { /* ... */ }
+
+laxCreateStreetLight(["red", "yellow", "green"], "blue");
+// ^?
+
 function createStreetLight<C extends string>(
   colors: C[],
   defaultColor?: NoInfer<C>,
-) {
-  // ...
-}
+) { /* ... */ }
 
-createStreetLight(["red", "yellow", "green"], "red");  // OK
-createStreetLight(["red", "yellow", "green"], "blue");  // Error
+createStreetLight(["red", "yellow", "green"], "blue");
+// ^?
 ```
 
 ## `ThisParameterType<Type>`


### PR DESCRIPTION
For people (such as myself two hours ago) who don’t know that the multiple-arguments union inference (described as “undesirable” in the release notes) occurs in TypeScript, the current example, and thus `NoInfer<Type>`’s usefulness, is incomprehensible.