### PR TITLE
Make links in code blocks inherit syntax highlighter colors

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/main.scss
+++ b/packages/typescriptlang-org/src/components/layout/main.scss
@@ -138,6 +138,10 @@ html.font-open-dyslexic {
   a {
     color: var(--link-color);
   }
+  pre code a {
+    // Don't interfere with syntax highlighting in code blocks
+    color: inherit;
+  }
 
   h1,
   h2,


### PR DESCRIPTION
See https://github.com/microsoft/TypeScript-Website/pull/3335#issuecomment-2669857953 and preceding discussion.