### PR TITLE
[TS Workbench] Correctly HTML escape rendered code

### DIFF
--- a/packages/playground/src/ds/createDesignSystem.ts
+++ b/packages/playground/src/ds/createDesignSystem.ts
@@ -154,7 +154,7 @@ export const createDesignSystem = (sandbox: Sandbox) => {
       createCodePre.setAttribute("tabindex", "0")
       const codeElement = document.createElement("code")
 
-      codeElement.innerHTML = code
+      codeElement.textContent = code
 
       createCodePre.appendChild(codeElement)
       container.appendChild(createCodePre)


### PR DESCRIPTION
This has been bugging me for a while

Before:
<img width="909" alt="before" src="https://github.com/user-attachments/assets/9401a549-0f2b-4158-8bf4-e4d97acf8ca0" />


After:
<img width="906" alt="after" src="https://github.com/user-attachments/assets/4825058f-5d77-403f-8105-72e84b40b478" />
