### PR TITLE
change noCheck release version for 5.6

### DIFF
--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -314,8 +314,8 @@ function formatAllowedValues(type: CommandLineOption["type"]) {
 
 export const releaseToConfigsMap: { [key: string]: AnOption[] } = {
   "5.7": ["rewriteRelativeImportExtensions"],
-  "5.6": ["strictBuiltinIteratorReturn", "noUncheckedSideEffectImports"],
-  "5.5": ["isolatedDeclarations", "noCheck"],
+  "5.6": ["strictBuiltinIteratorReturn", "noUncheckedSideEffectImports", "noCheck"],
+  "5.5": ["isolatedDeclarations"],
   "5.0": [
     "allowArbitraryExtensions",
     "allowImportingTsExtensions",


### PR DESCRIPTION
There is no mention of `noCheck` in the [5.5. release notes ](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html)

They are in the [5.6 release notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-6.html#the---nocheck-option)