### PR TITLE
Fix getScriptSnapshot for file with empty content

### DIFF
--- a/.changeset/spicy-swans-work.md
+++ b/.changeset/spicy-swans-work.md
@@ -1,0 +1,5 @@
+---
+"@typescript/vfs": patch
+---
+
+Fix getScriptSnapshot for file with empty content

--- a/packages/typescript-vfs/src/index.ts
+++ b/packages/typescript-vfs/src/index.ts
@@ -671,7 +671,7 @@ export function createVirtualLanguageServiceHost(
     getScriptFileNames: () => fileNames.slice(),
     getScriptSnapshot: fileName => {
       const contents = sys.readFile(fileName)
-      if (contents && typeof contents === "string") {
+      if (typeof contents === "string") {
         return ts.ScriptSnapshot.fromString(contents)
       }
       return

--- a/packages/typescript-vfs/test/index.test.ts
+++ b/packages/typescript-vfs/test/index.test.ts
@@ -245,3 +245,16 @@ it("moduleDetection options", async () => {
   program.emit()
   expect(fsMap.get("index.js")).toEqual(`define(["require", "exports"], function (require, exports) {\n    "use strict";\n    Object.defineProperty(exports, "__esModule", { value: true });\n    var foo = 'foo';\n});\n`)
 })
+
+it("update file content to empty string", () => {
+  const options: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+  }
+  const fsMap = createDefaultMapFromNodeModules(options, ts)
+  fsMap.set("index.ts", "console.logx('')")
+  const system = createSystem(fsMap)
+  const env = createVirtualTypeScriptEnvironment(system, ["index.ts"], ts, options)
+  env.updateFile("index.ts", "")
+  const diagnostics = env.languageService.getSemanticDiagnostics("index.ts")
+  expect(diagnostics.length).toBe(0)
+})


### PR DESCRIPTION
After applying `env.updateFile` to reset a file's content to empty, then use any env.languageService.* method, it would throw an error message stating "Could not find source file: 'index.ts'"

```ts
import {
  createDefaultMapFromCDN,
  createSystem,
  createVirtualTypeScriptEnvironment,
} from '@typescript/vfs';
import ts from 'typescript';

const fsMap = await createDefaultMapFromCDN(
  { target: ts.ScriptTarget.ES2018 },
  '5.7.2',
  false,
  ts
);

const system = createSystem(fsMap);

const compilerOpts = {};
const env = createVirtualTypeScriptEnvironment(system, [], ts, compilerOpts);

env.createFile('/index.ts', 'console.logx()');

env.updateFile('/index.ts', '');

// throws error: Could not find source file: 'index.ts'.
env.languageService.getSemanticDiagnostics('index.ts');
```

Here is the repro: https://stackblitz.com/edit/vitejs-vite-obbb75xc?file=src%2Findex.ts

This PR fixes this