### PR TITLE
Fix punctuation in Narrowing section of handbook

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Narrowing.md
+++ b/packages/documentation/copy/en/handbook-v2/Narrowing.md
@@ -276,7 +276,7 @@ function multiplyValue(container: Container, factor: number) {
 JavaScript has an operator for determining if an object or its prototype chain has a property with a name: the `in` operator.
 TypeScript takes this into account as a way to narrow down potential types.
 
-For example, with the code: `"value" in x`. where `"value"` is a string literal and `x` is a union type.
+For example, with the code `"value" in x`, where `"value"` is a string literal and `x` is a union type.
 The "true" branch narrows `x`'s types which have either an optional or required property `value`, and the "false" branch narrows to types which have an optional or missing property `value`.
 
 ```ts twoslash


### PR DESCRIPTION
Noticed some incorrect punctuation in the "Narrowing" section of the handbook, so I'm submitting a change that fixes the punctuation without modifying anything else.

Even with this change, I think the sentence flow in this paragraph is awkward and could use further editing.