### PR TITLE
Document auto-accessors in classes

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -285,15 +285,15 @@ By adding the `accessor` keyword in front of a class field, you can define a get
 
 ```ts twoslash
 class Person {
-  accessor name: string | undefined;
+  accessor name = "";
 }
 ```
 
-The above roughly desugars to:
+The above is roughly equivalent to:
 
-```js
+```ts twoslash
 class Person {
-  #name;
+  #name = "";
 
   get name() {
     return this.#name;

--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -279,6 +279,32 @@ class Thing {
 }
 ```
 
+### Auto-Accessors
+
+By adding the `accessor` keyword in front of a class field, you can define a getter and a setter at once:
+
+```ts twoslash
+class Person {
+  accessor name: string | undefined;
+}
+```
+
+The above roughly desugars to:
+
+```js
+class Person {
+  #name;
+
+  get name() {
+    return this.#name;
+  }
+
+  set name(value) {
+    this.#name = value;
+  }
+}
+```
+
 ### Index Signatures
 
 Classes can declare index signatures; these work the same as [Index Signatures for other object types](/docs/handbook/2/objects.html#index-signatures):


### PR DESCRIPTION
As I was mentioning on Discord, currently the handbook does not document auto-accessors. This feature was shipped with TypeScript 4.9, but it is still in Stage 3.

To put the text together, I used these sources:
- release notes, https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html?#auto-accessors-in-classes
- pull request description, https://github.com/microsoft/TypeScript/pull/49705
- proposal, https://github.com/tc39/proposal-decorators?tab=readme-ov-file#class-auto-accessors

