### PR TITLE
Also mention override modifier in Parameter Properties section of handbook

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -1225,7 +1225,7 @@ if (box.hasValue()) {
 ## Parameter Properties
 
 TypeScript offers special syntax for turning a constructor parameter into a class property with the same name and value.
-These are called _parameter properties_ and are created by prefixing a constructor argument with one of the visibility modifiers `public`, `private`, `protected`, or `readonly`.
+These are called _parameter properties_ and are created by prefixing a constructor parameter with one of the modifiers `public`, `private`, `protected`, `readonly`, or `override`.
 The resulting field gets those modifier(s):
 
 ```ts twoslash


### PR DESCRIPTION
Prefixing with override modifier also turns a constructor parameter into a parameter property.

https://www.typescriptlang.org/play/?#code/MYGwhgzhAEDKCuAHApgJ2gbwFDV9R8ARiAJbDRgBc0AdvALaFrQC80ADANxYC+WWoSDAAKYVGHoxkADwAuyGgBMYCFOmy5gAexoRZqeMFlbUAChx4CxMtFTIwinSACe0adTqM0AGgu5EqFryRsiK0M4eDEyovnj4qCQAbmDy0ABekV4xftBaiWgJisgUmdGx0ACUmDkQSGimFdxxAPTN0AByWtCEWoquNMjAyFBizhZ8PEA