### PR TITLE
Remove broken link in Triple-Slash Directives.md

### DIFF
--- a/packages/documentation/copy/en/reference/Triple-Slash Directives.md
+++ b/packages/documentation/copy/en/reference/Triple-Slash Directives.md
@@ -58,7 +58,6 @@ For example, including `/// <reference types="node" />` in a declaration file de
 and thus, this package needs to be included in the compilation along with the declaration file.
 
 For declaring a dependency on an `@types` package in a `.ts` file, use [`types`](/tsconfig#types) on the command line or in your `tsconfig.json` instead.
-See [using `@types`, `typeRoots` and `types` in `tsconfig.json` files](/docs/handbook/tsconfig-json.html#types-typeroots-and-types) for more details.
 
 ## `/// <reference lib="..." />`
 


### PR DESCRIPTION
**Page URL**: https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-types-

**Description**: I noticed that a link in the article has become invalid because the section it referenced (`@types`, `typeRoots`, and `types`) was removed in commit 6d5e794. Keeping the broken link might confuse readers, so removing it is the appropriate fix.  