### PR TITLE
[ATA] Remove duplicate modules from getReferencesForModule

### DIFF
--- a/.changeset/khaki-spoons-double.md
+++ b/.changeset/khaki-spoons-double.md
@@ -1,0 +1,5 @@
+---
+"@typescript/ata": patch
+---
+
+Remove duplicate modules from getReferencesForModule

--- a/packages/ata/src/index.ts
+++ b/packages/ata/src/index.ts
@@ -173,19 +173,21 @@ export const getReferencesForModule = (ts: typeof import("typescript"), code: st
     .filter(f => !isDtsFile(f.fileName))
     .filter(d => !libMap.has(d.fileName))
 
-  return references.map(r => {
-    let version = undefined
-    if (!r.fileName.startsWith(".")) {
-      version = "latest"
-      const line = code.slice(r.end).split("\n")[0]!
-      if (line.includes("// types:")) version = line.split("// types: ")[1]!.trim()
-    }
+  return references
+    .map(r => {
+      let version = undefined
+      if (!r.fileName.startsWith(".")) {
+        version = "latest"
+        const line = code.slice(r.end).split("\n")[0]!
+        if (line.includes("// types:")) version = line.split("// types: ")[1]!.trim()
+      }
 
-    return {
-      module: r.fileName,
-      version,
-    }
-  })
+      return {
+        module: r.fileName,
+        version,
+      }
+    })
+    .filter((r, index, self) => self.findIndex(m => m.module === r.module && m.version === r.version) === index)
 }
 
 /** A list of modules from the current sourcefile which we don't have existing files for */

--- a/packages/ata/tests/ata.spec.ts
+++ b/packages/ata/tests/ata.spec.ts
@@ -16,6 +16,11 @@ describe(getReferencesForModule, () => {
     const code = "import {asda} from '123' // types: 1.2.3"
     expect(getReferencesForModule(ts, code)[0]).toEqual({ module: "123", version: "1.2.3" })
   })
+
+  it("removes duplicate imports", () => {
+    const code = "import 'abc'; import {asda} from 'abc'"
+    expect(getReferencesForModule(ts, code).map(m => m.module)).toEqual(["abc"])
+  })
 })
 
 describe("ignores lib references", () => {


### PR DESCRIPTION
Why?

Go to the playground and try to use the following code:

```ts
import { Client } from "@modelcontextprotocol/sdk/client/index.js";
```

[Link](https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBAbzgYQDbAKYDt4F84BmUEIcARAAIgQAmGqAxhDhgB4xjEwROoD0AZxoBrPg3TYYfYFjqsAdACsBZANwAoIA)

This can trigger 1000s of calls to jsdelivr because imports to zod are not de-duped, resulting in ERR_INSUFFICENT_RESOURCES errors.

This fix removes duplicate modules within the same file (they are already handled cross file).

