### PR TITLE
fix: improve accessibility of "Subtype vs Assignment" table

### DIFF
--- a/packages/documentation/copy/en/reference/Type Compatibility.md
+++ b/packages/documentation/copy/en/reference/Type Compatibility.md
@@ -307,7 +307,7 @@ For practical purposes, type compatibility is dictated by assignment compatibili
 
 The following table summarizes assignability between some abstract types.
 Rows indicate what each is assignable to, columns indicate what is assignable to them.
-A "<span class='black-tick'>✓</span>" indicates a combination that is compatible only when [`strictNullChecks`](/tsconfig#strictNullChecks) is off.
+A "<span class='tick-if-not-strict'>✓</span>" indicates a combination that is compatible only when [`strictNullChecks`](/tsconfig#strictNullChecks) is off.
 
 <!-- This is the rendered form of https://github.com/microsoft/TypeScript-Website/pull/1490 -->
 <table class="data">
@@ -370,19 +370,19 @@ A "<span class='black-tick'>✓</span>" indicates a combination that is compatib
 <td>undefined →</td>
 <td align="center"><span class="blue-tick">✓</span></td>
 <td align="center"><span class="blue-tick">✓</span></td>
-<td align="center"><span class="black-tick">✓</span></td>
+<td align="center"><span class="tick-if-not-strict">✓</span></td>
 <td align="center"><span class="blue-tick">✓</span></td>
 <td align="center"></td>
-<td align="center"><span class="black-tick">✓</span></td>
+<td align="center"><span class="tick-if-not-strict">✓</span></td>
 <td align="center"><span class="red-cross">✕</span></td>
 </tr>
 <tr>
 <td>null →</td>
 <td align="center"><span class="blue-tick">✓</span></td>
 <td align="center"><span class="blue-tick">✓</span></td>
-<td align="center"><span class="black-tick">✓</span></td>
-<td align="center"><span class="black-tick">✓</span></td>
-<td align="center"><span class="black-tick">✓</span></td>
+<td align="center"><span class="tick-if-not-strict">✓</span></td>
+<td align="center"><span class="tick-if-not-strict">✓</span></td>
+<td align="center"><span class="tick-if-not-strict">✓</span></td>
 <td align="center"></td>
 <td align="center"><span class="red-cross">✕</span></td>
 </tr>

--- a/packages/typescriptlang-org/src/templates/markdown.scss
+++ b/packages/typescriptlang-org/src/templates/markdown.scss
@@ -132,9 +132,17 @@
     font-size: 1.2rem;
   }
 
-  .black-tick {
-    color: $ts-muted-green;
+  .tick-if-not-strict {
+    color: $ts-main-blue-color;
     font-size: 1.2rem;
+  }
+
+  .tick-if-not-strict:after {
+    content: "*";
+  }
+
+  td > .tick-if-not-strict:after {
+    position: absolute;
   }
 
   .red-cross {


### PR DESCRIPTION
Currently, the two styles of tick are rather hard to distinguish: two similar shades of blue / green, and two similar font weights. This PR addresses that.

Before:

<img width="924" alt="image" src="https://github.com/user-attachments/assets/84d8e53f-e9aa-407a-9cba-100572dd05be" />

After:

<img width="927" alt="image" src="https://github.com/user-attachments/assets/320eef09-289b-4a0c-9cff-da5eab401be1" />

The "only if not strict" is now indicated by "✓*" (as opposed to just "✓").

The ✓* is now the same colour as the ✓, the "main blue", since the "muted green" was really hard to distinguish anyway, so served no purpose.

It _might_ even be better to have these marks changed to "✕*", and comment that it's not compatible as long as `strictNullChecks` is `true`. Even though it's not the default, I think it's probably recognised as being good practice.
