### PR TITLE
The `|` and `&` operators are ignored before the first element

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Everyday Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Everyday Types.md
@@ -252,7 +252,7 @@ printId("202");
 printId({ myID: 22342 });
 ```
 
-> The separator of the union members is allowed before the first element, so you could also write this:
+> The `|` operator is ignored when used before the first element, so you could also write this:
 > ```ts twoslash
 > function printTextOrNumberOrBool(
 >   textOrNumberOrBool:

--- a/packages/documentation/copy/en/handbook-v2/Object Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Object Types.md
@@ -578,6 +578,20 @@ draw({ color: "blue", radius: 42 });
 draw({ color: "red", raidus: 42 });
 ```
 
+> The `&` operator is ignored when used before the first element, so you could also write this:
+> ```ts twoslash
+> function draw(
+>   circle:
+>     & Colorful
+>     & Circle
+>     & Coordinates
+> ) {
+>   console.log(`Color was ${circle.color}`);
+>   console.log(`Radius was ${circle.radius}`);
+>   console.log(`Coordinates was ${circle.coordinates}`);
+> }
+> ```
+
 ## Interface Extension vs. Intersection
 
 We just looked at two ways to combine types which are similar, but are actually subtly different.


### PR DESCRIPTION
Changed note about `|` to be more explicit about how the first `|` actually behaves before the first element (it just gets ignored).