### PR TITLE
Update README to use correct generation command for tsconfig-references

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ A set of tools and scripts for generating a comprehensive API reference for the 
 
 ```sh
 # Generate JSON from the typescript cli
-pnpm run --filter=tsconfig-reference generate-json
+pnpm run --filter=tsconfig-reference generate:json
 # Jams them all into a single file
-pnpm run --filter=tsconfig-reference generate-markdown
+pnpm run --filter=tsconfig-reference generate:md
 ```
 
 Validate the docs:

--- a/packages/glossary/README.md
+++ b/packages/glossary/README.md
@@ -36,9 +36,9 @@ The TSConfig reference is created by a two step process:
 You can run these commands from the root of the repo:
 
 ```sh
-pnpm run --filter=tsconfig-reference generate-json
+pnpm run --filter=tsconfig-reference generate:json
 
-pnpm run --filter=tsconfig-reference generate-markdown
+pnpm run --filter=tsconfig-reference generate:md
 ```
 
 You can validate any codeblocks which use twoslash via the script:

--- a/packages/tsconfig-reference/README.md
+++ b/packages/tsconfig-reference/README.md
@@ -36,9 +36,9 @@ The TSConfig reference is created by a two step process:
 You can run these commands from the root of the repo:
 
 ```sh
-pnpm run --filter=tsconfig-reference generate-json
+pnpm run --filter=tsconfig-reference generate:json
 
-pnpm run --filter=tsconfig-reference generate-markdown
+pnpm run --filter=tsconfig-reference generate:md
 ```
 
 You can validate any codeblocks which use twoslash via the script:


### PR DESCRIPTION
`pnpm run --filter=tsconfig-reference generate-json` and `pnpm run --filter=tsconfig-reference generate-markdown` were written in the README, but these were wrong.
https://github.com/microsoft/TypeScript-Website/blob/c65adad8abd490be32e3bf9d6cbfe7aef9df4477/packages/tsconfig-reference/package.json#L11-L15
This PR replaces them with the correct command.
