### PR TITLE
Fix error and error-behind css classes out-of-sync

### DIFF
--- a/packages/typescriptlang-org/src/templates/markdown-twoslash.scss
+++ b/packages/typescriptlang-org/src/templates/markdown-twoslash.scss
@@ -165,11 +165,15 @@ pre .error {
   position: absolute;
   background-color: #fee;
   border-left: 2px solid #bf1818;
-  margin-right: -2px;
-  /* Give the space to the error code */
   display: flex;
   align-items: center;
   color: black;
+  padding-left: 12px;
+  padding-right: 8px;
+}
+
+pre .error > span {
+  margin-right: 12px;
 }
 
 pre .error .code {


### PR DESCRIPTION
The `error-behind` in some cases line breaks before `error` does, e.g. in docs/handbook/2/objects.html: 

![Bildschirmfoto 2025-05-21 um 12 15 29](https://github.com/user-attachments/assets/aeef6426-cc48-4541-bb6c-2e73a0ad6bf6)

you can see

> 'string[]'.

of the `error-behind`, which is supposed to be invisible, in the next line.

The problem is that the CSS classes `error` and `behind-error` are slightly out of sync: 

1. The `margin-right: -2px` is obsolete
- this rule is no longer necessary due to the padding adjustments described below
2. The padding of `error` should be `6px 8px 6px 12px`
- it was `6px 6px 6px 14px`, but `14px` is too much since the ancestor `<pre class="shiki light-plus twoslash lsp" ...>` has a border of `1px` + `12px` padding
- since the `error` class has a `border-right: 2px` which hangs `1px` over the border of the `<pre>` element, the padding should be `12px` 
- the right padding of `8px` compensates the removed `margin-right: -2px`
- incorrect padding lead to misalignment:

![Bildschirmfoto 2025-05-28 um 12 00 25](https://github.com/user-attachments/assets/85496edb-da97-40ba-9032-877605c6ec4d)

3. the `error-behind` span line breaks before the `error` span
- since `error` is absolute, it ignores the right padding of the ancestor `<pre>` of `12px`
- therefore, the inner span of `error` needs a `margin-right: 12px` to wrap simultaneously  