### PR TITLE
"Build Options" renamed to "Build Commands" in "tsc CLI Options" page.

### DIFF
--- a/packages/documentation/copy/en/project-config/Compiler Options.md
+++ b/packages/documentation/copy/en/project-config/Compiler Options.md
@@ -119,7 +119,7 @@ tsc app.ts util.ts --target esnext --outfile index.js
 
 </tbody></table>
 
-<h3>Build Options</h3>
+<h3>Build Commands</h3>
 <table class="cli-option" width="100%">
   <thead>
     <tr>


### PR DESCRIPTION
This is a wording fix:

On the "[tsc CLI Options](https://www.typescriptlang.org/docs/handbook/compiler-options.html)" page, the `tsc` build commands are summarized as build options, which is wrong as these commands are no options, i.e., they cannot be configured in a `tsconfig.json` file. Instead, they are commands, instructing the `tsc` compiler to perform an action.

My pull request straightens the wording.