### PR TITLE
fix: incorrect deprecation link on Advanced Types page of old handbook

### DIFF
--- a/packages/documentation/copy/en/reference/Advanced Types.md
+++ b/packages/documentation/copy/en/reference/Advanced Types.md
@@ -3,7 +3,7 @@ title: Advanced Types
 layout: docs
 permalink: /docs/handbook/advanced-types.html
 oneline: Advanced concepts around types in TypeScript
-deprecated_by: /docs/handbook/2/types-from-types.html
+deprecated_by: "/docs/handbook/2/narrowing.html#using-type-predicates"
 
 # prettier-ignore
 deprecation_redirects: [


### PR DESCRIPTION
Fixes the "Go to New Page" buttons on the Advanced Types page of the old handbook so they redirect to the same subsection of the v2 handbook 