### PR TITLE
docs: clarify export {} comment in global-modifying-module templates Improvements: #3410 (Issue)

### DIFF
--- a/packages/documentation/copy/en/declaration-files/templates/global-modifying-module.d.ts.md
+++ b/packages/documentation/copy/en/declaration-files/templates/global-modifying-module.d.ts.md
@@ -67,6 +67,19 @@ export interface StringFormatOptions {
 /*~ For example, declaring a method on the module (in addition to its global side effects) */
 export function doSomething(): void;
 
-/*~ If your module exports nothing, you'll need this line. Otherwise, delete it */
+/*~ 
+ If your module does not export anything, include this line to explicitly mark the file as a module.
+
+ By default, TypeScript treats files without any import or export statements as scripts, 
+ meaning their declarations are considered global. This can cause conflicts, such as 
+ duplicate identifier errors, especially when you are augmenting or extending global types.
+
+ Adding `export {}` tells TypeScript that this file is a module. This scopes the declarations 
+ to the module, preventing them from leaking into the global scope and avoiding naming conflicts.
+
+ For more information on how TypeScript distinguishes between scripts and modules, see:
+ https://www.typescriptlang.org/docs/handbook/modules.html#code-organization
+*/
 export {};
+
 ```


### PR DESCRIPTION
# docs: clarify `export {}` comment in global-modifying-module template ( #3410 )

## Related Issue

Closes [#3410](https://github.com/microsoft/TypeScript-Website/issues/3410)

## Summary

This PR improves the comment in the [`global-modifying-module-d-ts`](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/global-modifying-module-d-ts.html) declaration file template by providing a clearer explanation of why the `export {}` line is necessary when the module exports nothing.

## Problem

The original comment was:

```ts
/*~ If your module exports nothing, you'll need this line. Otherwise, delete it */
export {};
```

## Changes Made
- Expanded the comment to clarify that export {} ensures TypeScript treats the file as a module.

- Explained the consequences of omitting the line (e.g., leaking declarations to the global scope, causing identifier conflicts).

- Included an official link to the TypeScript Handbook on module code organization.

## New Updated looks like : 
<img width="775" height="333" alt="now" src="https://github.com/user-attachments/assets/d41a41b9-6e0f-4f7b-8bfe-68354f6ae27e" />

## Notes
-- This change is documentation-only and has no impact on runtime behavior.
