### PR TITLE
Improve accessibility of blockquotes in docs

### DIFF
--- a/packages/typescriptlang-org/src/templates/markdown.scss
+++ b/packages/typescriptlang-org/src/templates/markdown.scss
@@ -54,7 +54,7 @@
   blockquote {
     border-left: 2px solid var(--border-color);
     background-color: var(--inline-code-background-color);
-    font-size: 0.8rem;
+    font-size: 1rem;
     margin: auto;
     padding: 0.1rem 2rem;
 


### PR DESCRIPTION
The TypeScript documentation is solid. There's a small change I'd like to suggest, please, to improve the readability and accessibility of the docs: Currently, the blockquotes render at `12.8px` based on a `font-size: 0.8rem` rule. This makes the text too small to read. I think the blockquotes often have important content that should be easily readable and have the same font size as the body text. If you deem that `16px (1rem)` is too large, could we make it at least `14px (0.875rem)`, please?

Thank you in advance for considering this change 🙏 