### PR TITLE
Add missing commas in v5.5 release notes

### DIFF
--- a/packages/documentation/copy/en/release-notes/TypeScript 5.5.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 5.5.md
@@ -644,7 +644,7 @@ For example, imagine the following `tsconfig.base.json`:
 {
     "compilerOptions": {
         "typeRoots": [
-            "./node_modules/@types"
+            "./node_modules/@types",
             "./custom-types"
         ],
         "outDir": "dist"
@@ -670,7 +670,7 @@ This means that the above `tsconfig.base.json` could be rewritten as:
 {
     "compilerOptions": {
         "typeRoots": [
-            "${configDir}/node_modules/@types"
+            "${configDir}/node_modules/@types",
             "${configDir}/custom-types"
         ],
         "outDir": "${configDir}/dist"


### PR DESCRIPTION
Noticed this when I copy/pasted from the docs and got an error.