### PR TITLE
Remove the clause about changes on aliased variables

### DIFF
--- a/packages/documentation/copy/en/reference/Namespaces.md
+++ b/packages/documentation/copy/en/reference/Namespaces.md
@@ -237,7 +237,6 @@ let sq = new polygons.Square(); // Same as 'new Shapes.Polygons.Square()'
 
 Notice that we don't use the `require` keyword; instead we assign directly from the qualified name of the symbol we're importing.
 This is similar to using `var`, but also works on the type and namespace meanings of the imported symbol.
-Importantly, for values, `import` is a distinct reference from the original symbol, so changes to an aliased `var` will not be reflected in the original variable.
 
 ## Working with Other JavaScript Libraries
 


### PR DESCRIPTION
Consider an example:

```ts
namespace Shapes {
  export namespace Polygons {
    export var S = 5;
  }
}

import polygons = Shapes.Polygons;

console.log(polygons.S); // 5

polygons.S = 123;

console.log(polygons.S); // 123
console.log(Shapes.Polygons.S); // 123
```

According to

> Importantly, for values, `import` is a distinct reference from the original symbol, so changes to an aliased `var` will not be reflected in the original variable.

the `S` shouldn't be changed in this example, right? But it changes.

I'm not sure what "distinct reference" means exactly here. Maybe I just misinterpret this clause. Or maybe something changed in TS and it's not true anymore. Anyhow, its meaning isn't very clear.

It's also impossible to reassign an alias. Was it possible in the far past? If it is, then maybe this clause alludes to such a scenario.