### PR TITLE
TypeScript 3.7.md: Fix writing error

### DIFF
--- a/packages/documentation/copy/en/release-notes/TypeScript 3.7.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 3.7.md
@@ -109,7 +109,7 @@ function barPercentage(foo?: { bar: number }) {
 }
 ```
 
-More more details, you can [read up on the proposal](https://github.com/tc39/proposal-optional-chaining/) and [view the original pull request](https://github.com/microsoft/TypeScript/pull/33294).
+For more details, you can [read up on the proposal](https://github.com/tc39/proposal-optional-chaining/) and [view the original pull request](https://github.com/microsoft/TypeScript/pull/33294).
 
 ## Nullish Coalescing
 


### PR DESCRIPTION
Fixing a small error: "More more details" -> "For more details"