### PR TITLE
Fix: correct filename for src/tsconfig-base.json in docs

### DIFF
--- a/packages/documentation/copy/en/project-config/Project References.md
+++ b/packages/documentation/copy/en/project-config/Project References.md
@@ -172,7 +172,7 @@ Another good practice is to have a "solution" `tsconfig.json` file that simply h
 
 This presents a simple entry point; e.g. in the TypeScript repo we simply run `tsc -b src` to build all endpoints because we list all the subprojects in `src/tsconfig.json`
 
-You can see these patterns in the TypeScript repo - see `src/tsconfig_base.json`, `src/tsconfig.json`, and `src/tsc/tsconfig.json` as key examples.
+You can see these patterns in the TypeScript repo - see `src/tsconfig-base.json`, `src/tsconfig.json`, and `src/tsc/tsconfig.json` as key examples.
 
 ### Structuring for relative modules
 


### PR DESCRIPTION
Fixing small typo for filename in Project References docs: `src/tsconfig_base.json` -> `src/tsconfig-base.json`