### PR TITLE
Clarify that `experimentalDecorators` refers to the much older proposal

### DIFF
--- a/packages/documentation/copy/en/reference/Decorators.md
+++ b/packages/documentation/copy/en/reference/Decorators.md
@@ -6,7 +6,7 @@ oneline: TypeScript Decorators overview
 translatable: true
 ---
 
-> NOTE&nbsp; This document refers to an experimental stage 2 decorators implementation. Stage 3 decorator support is available since Typescript 5.0.
+> NOTE&nbsp; This document refers to an older experimental stage 2 decorators implementation from 2018. Stage 3 decorator support is available since Typescript 5.0.
 > See: [Decorators in Typescript 5.0](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#decorators)
 
 ## Introduction


### PR DESCRIPTION
When I first read this, I thought it was implying that `experimentalDecorators` means some more recent update to the current stage 3 proposal. I think it would be worth mentioning that it refers to something older, not newer.

BTW, when searching for "decorators" in the current docs, this is what comes up. It would be good to include documentation for the latest proposal in the official docs in addition to that blog post announcing Typescript 5.0.