### PR TITLE
fix missing defaults in tsconfig documentation

### DIFF
--- a/packages/tsconfig-reference/scripts/cli/generateJSON.ts
+++ b/packages/tsconfig-reference/scripts/cli/generateJSON.ts
@@ -40,7 +40,7 @@ export interface CompilerOptionJSON extends CommandLineOptionBase {
   deprecated?: string;
   internal?: true;
   recommended?: true;
-  defaultValue?: string;
+  defaultValue?: string | number | boolean;
   hostObj: string;
 }
 

--- a/packages/tsconfig-reference/scripts/cli/generateMarkdown.ts
+++ b/packages/tsconfig-reference/scripts/cli/generateMarkdown.ts
@@ -107,7 +107,7 @@ languages.forEach((lang) => {
       markdownChunks.push(`  <td>${parseMarkdown(optType)}</td>`);
 
       if (!opts?.noDefaults) {
-        markdownChunks.push(`  <td>${parseMarkdown(option.defaultValue)}</td>`);
+        markdownChunks.push(`  <td>${parseMarkdown(JSON.stringify(option.defaultValue))}</td>`);
       }
       markdownChunks.push(`</tr>`);
 

--- a/packages/tsconfig-reference/scripts/cli/generateMarkdown.ts
+++ b/packages/tsconfig-reference/scripts/cli/generateMarkdown.ts
@@ -94,11 +94,11 @@ languages.forEach((lang) => {
           // @ts-ignore
           const or = new Intl.ListFormat(lang, { type: "disjunction" });
           optType = or.format(
-            option.allowedValues.map((v) => v.replace(/^[-.0-9_a-z]+$/i, "`$&`"))
+            option.allowedValues.map((v) => v.replace(/^[-.0-9_a-z]+$/i, "`"$&"`"))
           );
         } else {
           optType = option.allowedValues
-            .map((v) => v.replace(/^[-.0-9_a-z]+$/i, "`$&`"))
+            .map((v) => v.replace(/^[-.0-9_a-z]+$/i, "`"$&"`"))
             .join(", ");
         }
       } else {

--- a/packages/tsconfig-reference/scripts/tsconfig/generateJSON.ts
+++ b/packages/tsconfig-reference/scripts/tsconfig/generateJSON.ts
@@ -48,7 +48,7 @@ export interface CompilerOptionJSON extends CommandLineOptionBase {
   deprecated?: string;
   internal?: true;
   recommended?: true;
-  defaultValue?: string;
+  defaultValue?: string | number | boolean;
   hostObj: string;
 }
 

--- a/packages/tsconfig-reference/scripts/tsconfig/generateMarkdown.ts
+++ b/packages/tsconfig-reference/scripts/tsconfig/generateMarkdown.ts
@@ -248,7 +248,7 @@ languages.forEach((lang) => {
           mdTableRows.push(["Internal"]);
         }
 
-        if (option.defaultValue) {
+        if (option.defaultValue !== undefined) {
           mdTableRows.push(["Default", String(option.defaultValue)]);
         }
 

--- a/packages/tsconfig-reference/scripts/tsconfig/generateMarkdown.ts
+++ b/packages/tsconfig-reference/scripts/tsconfig/generateMarkdown.ts
@@ -249,11 +249,11 @@ languages.forEach((lang) => {
         }
 
         if (option.defaultValue !== undefined) {
-          mdTableRows.push(["Default", String(option.defaultValue)]);
+          mdTableRows.push(["Default", JSON.stringify(option.defaultValue)]);
         }
 
         if (option.allowedValues) {
-          mdTableRows.push(["Allowed", option.allowedValues]);
+          mdTableRows.push(["Allowed", option.allowedValues.map(JSON.stringify)]);
         }
 
         if (option.related) {

--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -202,7 +202,7 @@ function trueIf(name: string) {
 
 export const defaultsForOptions = {
   ...Object.fromEntries(
-    ts.optionDeclarations.map((option) => [
+    [...ts.optionDeclarations, ...ts.optionsForWatch].map((option) => [
       option.name,
       typeof option.defaultValueDescription === "object"
         ? option.defaultValueDescription.message


### PR DESCRIPTION
https://www.typescriptlang.org/tsconfig/noEmitOnError.html
https://www.typescriptlang.org/tsconfig/allowUnusedLabels.html
https://www.typescriptlang.org/tsconfig/forceConsistentCasingInFileNames.html
https://www.typescriptlang.org/docs/handbook/compiler-options.html

`noEmitOnError` was added in TS 1.4 but doesn't currently have a documented default; in fact most boolean options don't, because they mostly default to `false` which doesn't show up.

The only options with a documented default of simply `false` (instead of a conditional) are special cased:

https://github.com/microsoft/TypeScript-Website/blob/c95f3eb8a2e86eb158947a0582ee211a577a1438/packages/tsconfig-reference/scripts/tsconfig/generateJSON.ts#L79-L93

The defaultValue is statically typed to be a `string` here (inaccurately):

https://github.com/microsoft/TypeScript-Website/blob/c95f3eb8a2e86eb158947a0582ee211a577a1438/packages/tsconfig-reference/scripts/cli/generateJSON.ts#L43
https://github.com/microsoft/TypeScript-Website/blob/c95f3eb8a2e86eb158947a0582ee211a577a1438/packages/tsconfig-reference/scripts/tsconfig/generateJSON.ts#L51

But many non-boolean options are also still missing the `defaultValue` field, though, even if sometimes their default is documented in their description.

https://www.typescriptlang.org/tsconfig/#watch-excludeDirectories