### PR TITLE
Add proper localStorage availability checks to support Node v25 in @typescript/vfs

### DIFF
--- a/.changeset/famous-pillows-kiss.md
+++ b/.changeset/famous-pillows-kiss.md
@@ -1,0 +1,5 @@
+---
+"@typescript/vfs": patch
+---
+
+Modify localStorage check to prevent crashes in Node 25

--- a/packages/typescript-vfs/src/index.ts
+++ b/packages/typescript-vfs/src/index.ts
@@ -23,7 +23,7 @@ try {
 } catch (error) { }
 
 const hasProcess = typeof process !== `undefined`
-const shouldDebug = (hasLocalStorage && localStorage!.getItem("DEBUG")) || (hasProcess && process.env.DEBUG)
+const shouldDebug = (hasLocalStorage && typeof localStorage!.getItem === 'function' && localStorage!.getItem("DEBUG")) || (hasProcess && process.env.DEBUG)
 const debugLog = shouldDebug ? console.log : (_message?: any, ..._optionalParams: any[]) => ""
 
 export interface VirtualTypeScriptEnvironment {


### PR DESCRIPTION
The package assumes it's running in a browser environment and directly calls localStorage.getItem("DEBUG"), however:, due to https://github.com/nodejs/node/pull/57666:

Node.js <25: `hasLocalStorage` is false because `localStorage` is `undefined`, so the `localStorage` check is skipped entirely ✅
Node.js <=25: `hasLocalStorage` is true because `localStorage` exists, but it's a mock object that doesn't implement the full API ❌

So in Node.js 25, `localStorage` exists but `localStorage.getItem` is not a function. 

### Node <25, check if `localStorage` exists

Run:

```sh
node -e "console.log('localStorage exists:', typeof localStorage !== 'undefined'); console.log('localStorage type:', typeof localStorage); console.log('localStorage.getItem type:', typeof localStorage?.getItem);"
```

Prints:

```
localStorage exists: true
localStorage type: object
localStorage.getItem type: undefined
(node:30907) Warning: `--localstorage-file` was provided without a valid path
(Use `node --trace-warnings ...` to show where the warning was created)
```

### Node 25, check if `localStorage` exists

Run:

```sh
node -e "console.log('localStorage exists:', typeof localStorage !== 'undefined'); console.log('localStorage type:', typeof localStorage); console.log('localStorage.getItem type:', typeof localStorage?.getItem);"
```

Prints:

```sh
localStorage exists: false
localStorage type: undefined
[eval]:1
console.log('localStorage exists:', typeof localStorage !== 'undefined'); console.log('localStorage type:', typeof localStorage); console.log('localStorage.getItem type:', typeof localStorage?.getItem);
                                                                                                                                                                                   ^

ReferenceError: localStorage is not defined
    at [eval]:1:180
    at runScriptInThisContext (node:internal/vm:219:10)
    at node:internal/process/execution:451:12
    at [eval]-wrapper:6:24
    at runScriptInContext (node:internal/process/execution:449:60)
    at evalFunction (node:internal/process/execution:283:30)
    at evalTypeScript (node:internal/process/execution:295:3)
    at node:internal/main/eval_string:71:3
```

This PR fixes it.

Closes #3449 