### PR TITLE
Correct type reference in Mapped Types example

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Type Manipulation/Mapped Types.md
+++ b/packages/documentation/copy/en/handbook-v2/Type Manipulation/Mapped Types.md
@@ -30,7 +30,7 @@ type OptionsFlags<Type> = {
 };
 ```
 
-In this example, `OptionsFlags` will take all the properties from the type `Type` and change their values to be a boolean.
+In this example, `OptionsFlags` will take all the properties from the type `Features` and change their values to be a boolean.
 
 ```ts twoslash
 type OptionsFlags<Type> = {


### PR DESCRIPTION
Updated the type reference from 'Type' to 'Features' in the Mapped Types section of the TypeScript Handbook.