### PR TITLE
[docs] Fix typo in Narrowing.md

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Narrowing.md
+++ b/packages/documentation/copy/en/handbook-v2/Narrowing.md
@@ -429,8 +429,8 @@ function isFish(pet: Fish | Bird): pet is Fish {
 }
 ```
 
-`pet is Fish` is our type predicate in this example.
-A predicate takes the form `parameterName is Type`, where `parameterName` must be the name of a parameter from the current function signature.
+`pet as Fish` is our type predicate in this example.
+A predicate takes the form `parameterName as Type`, where `parameterName` must be the name of a parameter from the current function signature.
 
 Any time `isFish` is called with some variable, TypeScript will _narrow_ that variable to that specific type if the original type is compatible.
 


### PR DESCRIPTION
Fix a typo (`is` -> `as`)