### PR TITLE
style: use --code-font for code sections

### DIFF
--- a/packages/typescriptlang-org/src/templates/markdown-twoslash.scss
+++ b/packages/typescriptlang-org/src/templates/markdown-twoslash.scss
@@ -128,7 +128,7 @@ pre .code-container:focus a {
 
 pre code {
   font-size: 15px;
-  font-family: "JetBrains Mono", Menlo, Monaco, Consolas, Courier New, monospace;
+  font-family: var(--code-font);
   white-space: pre;
   -webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
Replace hard-coded JetBrains Mono font stack with the custom chosen font
saved in `--code-font` in markdown-twoslash.scss to ensure consistent code
font theming across the site.