### PR TITLE
Docs: `erasableSyntaxOnly` should mention type assertions

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/erasableSyntaxOnly.md
+++ b/packages/tsconfig-reference/copy/en/options/erasableSyntaxOnly.md
@@ -13,6 +13,7 @@ That means the following constructs are not supported:
 * `namespace`s and `module`s with runtime code
 * parameter properties in classes
 * Non-ECMAScript `import =` and `export =` assignments
+* `<prefix>`-style type assertions
 
 ```ts
 // ❌ error: An `import ... = require(...)` alias
@@ -43,6 +44,9 @@ enum Direction {
     Left,
     Right,
 }
+
+// ❌ error: <prefix>-style type assertion.
+const num = <number>1;
 ```
 
 Similar tools like [ts-blank-space](https://github.com/bloomberg/ts-blank-space) or [Amaro](https://github.com/nodejs/amaro) (the underlying library for type-stripping in Node.js) have the same limitations.


### PR DESCRIPTION
`<prefix>` type assertions are errors under this mode.

https://www.typescriptlang.org/play/?alwaysStrict=false&target=99&jsx=0&erasableSyntaxOnly=true&ssl=11&ssc=18&pln=11&pc=25#code/FASwdgLgpgTgZgQwMZQAQAkEGcBiIoA2AJqgN7CqWpz7EBcqWEM4A5gNzAC+wwUAHgAcA9jAiokBbFlQBhADwAVAHyoB0MERkBBGDAQBPJapABbQQSimokGZly0S5KqkEBXAEYEQSao4CEDEwsYBy8LtYQABbCRMYAFNEgWAz2eIREADSoCAD8QcxsAJQMAG7CIE4ULpRJWAB0NBmoALw5OTLBbJw1lEjCYEyo-K2o8mBuph6wygCMPVQ8PEA