### PR TITLE
Disable CI jobs in forks

### DIFF
--- a/.github/workflows/close-preview.yml
+++ b/.github/workflows/close-preview.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   close:
     runs-on: ubuntu-latest
+    if: github.repository == 'microsoft/TypeScript-Website'
     steps:
       - uses: Azure/static-web-apps-deploy@v1
         with:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: github.repository == 'microsoft/TypeScript-Website'
     steps:
       - name: Get PR/workflow run info
         id: get-info

--- a/.github/workflows/deploy-prod-static.yml
+++ b/.github/workflows/deploy-prod-static.yml
@@ -24,6 +24,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'microsoft/TypeScript-Website'
 
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
@@ -64,6 +65,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    if: github.repository == 'microsoft/TypeScript-Website'
     steps:      
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   keepalive:
     runs-on: ubuntu-latest
+    if: github.repository == 'microsoft/TypeScript-Website'
 
     permissions:
       contents: write

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -14,6 +14,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'microsoft/TypeScript-Website'
 
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0


### PR DESCRIPTION
I keep getting emails about failed deploys from people's forks. Just disable this.