### PR TITLE
docs: remove extra 'it' in experimental decorators section of tsconfig

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/experimentalDecorators.md
+++ b/packages/tsconfig-reference/copy/en/options/experimentalDecorators.md
@@ -6,6 +6,6 @@ oneline: "Enable experimental support for TC39 stage 2 draft decorators."
 Enables [experimental support for decorators](https://github.com/tc39/proposal-decorators), which is a version of decorators that predates the TC39 standardization process.
 
 Decorators are a language feature which hasn't yet been fully ratified into the JavaScript specification.
-This means that the implementation version in TypeScript may differ from the implementation in JavaScript when it it decided by TC39.
+This means that the implementation version in TypeScript may differ from the implementation in JavaScript when it is decided by TC39.
 
 You can find out more about decorator support in TypeScript in [the handbook](/docs/handbook/decorators.html).


### PR DESCRIPTION
In the doc for experimental decorators, there's a typo that repeats "it it" instead of stating "it is". This PR corrects that.