### PR TITLE
docs: document that extends can be an array

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/extends.md
+++ b/packages/tsconfig-reference/copy/en/options/extends.md
@@ -3,8 +3,10 @@ display: "Extends"
 oneline: "Specify one or more path or node module references to base configuration files from which settings are inherited."
 ---
 
-The value of `extends` is a string which contains a path to another configuration file to inherit from.
+The value of `extends` is a string or array of strings which contains a path to another configuration file to inherit from.
 The path may use Node.js style resolution.
+
+When using an array, the configurations are applied from left to right, with later entries overriding earlier ones. This allows you to compose multiple base configurations together.
 
 The configuration from the base file are loaded first, then overridden by those in the inheriting config file. All relative paths found in the configuration file will be resolved relative to the configuration file they originated in.
 
@@ -45,5 +47,18 @@ Currently, the only top-level property that is excluded from inheritance is [`re
   }
 }
 ```
+
+`tsconfig.multiple.json`:
+
+```json tsconfig
+{
+  "extends": ["./configs/base", "./configs/strict"],
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
+}
+```
+
+Properties with relative paths found in the configuration file, which aren't excluded from inheritance, will be resolved relative to the configuration file they originated in.
 
 Properties with relative paths found in the configuration file, which aren't excluded from inheritance, will be resolved relative to the configuration file they originated in.


### PR DESCRIPTION
Updates the tsconfig extends option documentation to reflect that it can accept an array of strings (added in PR #50403). Includes explanation of left-to-right application order and adds example showing array usage.

Fixes #62915