### PR TITLE
Moved "Parameter Properties" section above "this  Types"

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Classes.md
+++ b/packages/documentation/copy/en/handbook-v2/Classes.md
@@ -1079,6 +1079,29 @@ This method makes the opposite trade-offs of the arrow function approach:
 - Only one function per class definition gets allocated, rather than one per class instance
 - Base method definitions can still be called via `super`.
 
+## Parameter Properties
+
+TypeScript offers special syntax for turning a constructor parameter into a class property with the same name and value.
+These are called _parameter properties_ and are created by prefixing a constructor argument with one of the visibility modifiers `public`, `private`, `protected`, or `readonly`.
+The resulting field gets those modifier(s):
+
+```ts twoslash
+// @errors: 2341
+class Params {
+  constructor(
+    public readonly x: number,
+    protected y: number,
+    private z: number
+  ) {
+    // No body necessary
+  }
+}
+const a = new Params(1, 2, 3);
+console.log(a.x);
+//            ^?
+console.log(a.z);
+```
+
 ## `this` Types
 
 In classes, a special type called `this` refers _dynamically_ to the type of the current class.
@@ -1220,29 +1243,6 @@ if (box.hasValue()) {
   box.value;
   //  ^?
 }
-```
-
-## Parameter Properties
-
-TypeScript offers special syntax for turning a constructor parameter into a class property with the same name and value.
-These are called _parameter properties_ and are created by prefixing a constructor argument with one of the visibility modifiers `public`, `private`, `protected`, or `readonly`.
-The resulting field gets those modifier(s):
-
-```ts twoslash
-// @errors: 2341
-class Params {
-  constructor(
-    public readonly x: number,
-    protected y: number,
-    private z: number
-  ) {
-    // No body necessary
-  }
-}
-const a = new Params(1, 2, 3);
-console.log(a.x);
-//            ^?
-console.log(a.z);
 ```
 
 ## Class Expressions
@@ -1468,3 +1468,4 @@ fn(window);
 fn({});
 fn(fn);
 ```
+


### PR DESCRIPTION
In the [`this-based type guards`](https://www.typescriptlang.org/docs/handbook/2/classes.html#this-based-type-guards) subsection of the [`this Types`](https://www.typescriptlang.org/docs/handbook/2/classes.html#this-types) section there is an example that uses a parameter property. This may confuse readers that are reading this article from top to bottom since you are using a feature that has not been explained yet.