### PR TITLE
docs(tsconfig-reference): fix optional property syntax - ? is suffix not prefix

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/exactOptionalPropertyTypes.md
+++ b/packages/tsconfig-reference/copy/en/options/exactOptionalPropertyTypes.md
@@ -3,7 +3,7 @@ display: "Exact Optional Property Types"
 oneline: "Interpret optional property types as written, rather than adding `undefined`."
 ---
 
-With exactOptionalPropertyTypes enabled, TypeScript applies stricter rules around how it handles properties on `type` or `interfaces` which have a `?` prefix.
+With exactOptionalPropertyTypes enabled, TypeScript applies stricter rules around how it handles properties on `type` or `interfaces` which have a `?` suffix.
 
 For example, this interface declares that there is a property which can be one of two strings: 'dark' or 'light' or it should not be in the object.
 


### PR DESCRIPTION
## Summary

Fixes a technical inaccuracy in the tsconfig reference for `exactOptionalPropertyTypes`.

## Problem

The documentation states that optional properties "have a `?` prefix", but in TypeScript the `?` comes **after** the property name:

```typescript
interface Example {
  optionalProp?: string;  // ? is a SUFFIX to the property name
}
```

## Solution

Changed "prefix" to "suffix" (single-word fix) in packages/tsconfig-reference/copy/en/options/exactOptionalPropertyTypes.md:6.

## Checklist

- [x] Documentation-only change (no changeset required)
- [x] Follows repository conventions
- [ ] CLA signed (bot will prompt if needed)