### PR TITLE
Fix Ctrl+[arrow keys] in Firefox.

### DIFF
--- a/.changeset/poor-bears-hear.md
+++ b/.changeset/poor-bears-hear.md
@@ -1,5 +1,0 @@
----
-"@typescript/vfs": patch
----
-
-Update for compatibility with TypeScript 6.0.

--- a/.changeset/poor-bears-hear.md
+++ b/.changeset/poor-bears-hear.md
@@ -1,0 +1,5 @@
+---
+"@typescript/vfs": patch
+---
+
+Update for compatibility with TypeScript 6.0.

--- a/.changeset/sandbox-firefox.md
+++ b/.changeset/sandbox-firefox.md
@@ -1,0 +1,5 @@
+---
+"@typescript/sandbox": patch
+---
+
+Fix Ctrl+arrow keys in Firefox.

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -77,7 +77,7 @@ const sharedEditorOptions: import("monaco-editor").editor.IEditorOptions = {
   },
   acceptSuggestionOnCommitCharacter: !isAndroid,
   acceptSuggestionOnEnter: !isAndroid ? "on" : "off",
-  accessibilitySupport: !isAndroid ? "on" : "off",
+  accessibilitySupport: !isAndroid ? "auto" : "off",
   inlayHints: {
     enabled: true,
   },


### PR DESCRIPTION
`auto` is the (suggested) default anyway, and this is a known bug in monaco-editor.

Fixes #2954.

https://github.com/microsoft/monaco-editor/issues/4892
