### PR TITLE
docs: clarify path base for project references

### DIFF
--- a/packages/documentation/copy/en/project-config/Project References.md
+++ b/packages/documentation/copy/en/project-config/Project References.md
@@ -68,6 +68,7 @@ Project references can solve all of these problems and more.
 ```
 
 The `path` property of each reference can point to a directory containing a `tsconfig.json` file, or to the config file itself (which may have any name).
+Reference `path` values are resolved relative to the `tsconfig.json` file they appear in.
 
 When you reference a project, new things happen:
 

--- a/packages/tsconfig-reference/copy/en/options/references.md
+++ b/packages/tsconfig-reference/copy/en/options/references.md
@@ -6,4 +6,6 @@ oneline: "Specify an array of objects that specify paths for projects. Used in p
 Project references are a way to structure your TypeScript programs into smaller pieces.
 Using Project References can greatly improve build and editor interaction times, enforce logical separation between components, and organize your code in new and improved ways.
 
+Each `path` entry in `references` is resolved relative to the `tsconfig.json` file that contains it.
+
 You can read more about how references works in the [Project References](/docs/handbook/project-references.html) section of the handbook


### PR DESCRIPTION
References: https://github.com/microsoft/TypeScript/issues/50529

This clarifies what `references[].path` is resolved against in both places users look for project references docs:

- `tsconfig` option docs (`/tsconfig#references`)
- Handbook page (`/docs/handbook/project-references.html`)

Added explicit wording that each reference path is resolved relative to the `tsconfig.json` file where it appears.