### PR TITLE
Fix up glossary scripts.

### DIFF
--- a/packages/glossary/tsconfig.json
+++ b/packages/glossary/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "resolveJsonModule": true,
     "allowJs": true,
-    "types": ["*"]
+    "noEmit": true,
+    "types": ["node"]
   }
 }


### PR DESCRIPTION
I was having issues with actually running `pnpm bootstrap`. I also couldn't build/edit error-free with the built-in 5.9 or with the native preview because we're missing https://github.com/microsoft/typescript-go/pull/2688. 

There's also an error if you open up the `tsconfig.json` because `lint.js` is assumed to be an input and output file at the same time.

So this PR just uses an explicit `types` array and turns off emit for this package.