### PR TITLE
fix(sandbox): getInitialCode should not use URL hash without full prefix

### DIFF
--- a/.changeset/small-animals-switch.md
+++ b/.changeset/small-animals-switch.md
@@ -1,0 +1,5 @@
+---
+"@typescript/sandbox": patch
+---
+
+getInitialCode should not use URL hash without full prefix

--- a/packages/sandbox/src/getInitialCode.ts
+++ b/packages/sandbox/src/getInitialCode.ts
@@ -7,13 +7,13 @@ import lzstring from "./vendor/lzstring.min"
  */
 export const getInitialCode = (fallback: string, location: Location) => {
   // Old school support
-  if (location.hash.startsWith("#src")) {
+  if (location.hash.startsWith("#src=")) {
     const code = location.hash.replace("#src=", "").trim()
     return decodeURIComponent(code)
   }
 
   // New school support
-  if (location.hash.startsWith("#code")) {
+  if (location.hash.startsWith("#code/")) {
     const code = location.hash.replace("#code/", "").trim()
     let userCode = lzstring.decompressFromEncodedURIComponent(code)
     // Fallback incase there is an extra level of decoding:


### PR DESCRIPTION
I'm hunting down https://github.com/typescript-eslint/typescript-eslint/issues/8780 (see more context in the issue discussion), and I finally got to `getInitialCode`. It turns out that the hash may start with `#code` but then not start with `#code/`, causing malformed initial code to be parsed.