### PR TITLE
docs: fix broken JSDoc reference link in d.ts-from-js guide

### DIFF
--- a/packages/documentation/copy/en/javascript/Creating DTS files From JS.md
+++ b/packages/documentation/copy/en/javascript/Creating DTS files From JS.md
@@ -10,7 +10,7 @@ translatable: true
 TypeScript added support for generating .d.ts files from JavaScript using JSDoc syntax.
 
 This set up means you can own the editor experience of TypeScript-powered editors without porting your project to TypeScript, or having to maintain .d.ts files in your codebase.
-TypeScript supports most JSDoc tags, you can find [the reference here](/docs/handbook/type-checking-javascript-files.html#supported-jsdoc).
+TypeScript supports most JSDoc tags; see the [JSDoc Reference](/docs/handbook/jsdoc-supported-types.html).
 
 ## Setting up your Project to emit .d.ts files
 


### PR DESCRIPTION
## Summary
- replace the outdated handbook anchor with the JSDoc Reference page
- update the link text to clearly describe the destination

Fixes #3214

## Validation
- verified the target permalink exists in `packages/documentation/copy/en/javascript/JSDoc Reference.md`
- inspected the resulting diff with `git diff -- packages/documentation/copy/en/javascript/Creating DTS files From JS.md`
