### PR TITLE
Accessibility bug fix 2737382

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/Sidebar.scss
+++ b/packages/typescriptlang-org/src/components/layout/Sidebar.scss
@@ -183,7 +183,7 @@ nav#sidebar {
     bottom: 120px;
     padding: 10px;
     margin-bottom: env(safe-area-inset-bottom);
-    background-color: #c4c4c4;
+    background-color: #808080;
     border-radius: 6px;
 
     z-index: $z-index-for-handbook-nav-button;


### PR DESCRIPTION
## Fix: Color contrast ratio for hamburger menu button

The hamburger menu button (#small-device-button-sidebar) had a white SVG icon (#fff) on a #c4c4c4 background, giving a contrast ratio of only 1.74:1. WCAG 1.4.11 requires a minimum 3:1 ratio for non-text graphical objects.

### Changes
- Changed the button background-color from #c4c4c4 to #808080 in Sidebar.scss`n- New contrast ratio: 3.95:1 (passes 3:1 requirement)

### Verification
- Tested with axe-core: 0 color contrast violations
- Active state (#575757 background) still passes at 7.23:1

Fixes [Bug 2737382](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2737382)

Verified the fix manually