### PR TITLE
Accessibility bug fix 2737338

### DIFF
--- a/packages/playground/src/createConfigDropdown.ts
+++ b/packages/playground/src/createConfigDropdown.ts
@@ -106,7 +106,11 @@ export const createConfigDropdown = (sandbox: Sandbox, monaco: Monaco) => {
     .forEach(categoryID => {
       const categoryDiv = document.createElement("div")
       const header = document.createElement("h4")
+      const headerId = "category-header-" + categoryID
+      header.id = headerId
       const ol = document.createElement("ol")
+      ol.setAttribute("role", "group")
+      ol.setAttribute("aria-labelledby", headerId)
 
       Object.keys(categoryMap[categoryID]).forEach(optID => {
         const optSummary = categoryMap[categoryID][optID]


### PR DESCRIPTION
## Fix: Associate category labels with checkbox groups in playground config

The TypeScript Playground TS Config panel displays boolean compiler options as checkboxes grouped under category headings (e.g., 'Output Formatting', 'Emit', 'Type Checking'). These category headings were not programmatically associated with their checkbox groups, violating WCAG 1.3.1 (Info and Relationships).

### Changes
- Added `id` attribute to each category `<h4>` heading
- Added `role='group'` and `aria-labelledby` to each `<ol>` containing checkboxes
- All 9 category groups are now properly labeled for screen readers

### Verification
- Tested with axe-core: all ARIA attributes pass validation
- `aria-allowed-attr`, `aria-required-attr`, `aria-valid-attr-value` all pass

Fixes [Bug 2737338](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2737338)

I have verified this fix manually and it fixes the issue.