### PR TITLE
Accessibility bug fix 2737380

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/Sidebar.scss
+++ b/packages/typescriptlang-org/src/components/layout/Sidebar.scss
@@ -209,6 +209,7 @@ nav#sidebar {
     z-index: $z-index-for-handbook-nav;
     margin-left: -800px;
     width: 90%;
+    visibility: hidden;
 
     ul {
       padding-bottom: 200px;
@@ -223,6 +224,7 @@ nav#sidebar {
 
     &.show {
       margin-left: 0px;
+      visibility: visible;
     }
 
     & > ul > li,

--- a/packages/typescriptlang-org/src/components/layout/Sidebar.tsx
+++ b/packages/typescriptlang-org/src/components/layout/Sidebar.tsx
@@ -44,11 +44,15 @@ const toggleNavigationSection: MouseEventHandler = (event) => {
 export const SidebarToggleButton = () => {
   const toggleClick = () => {
     const navSidebar = document.getElementById("sidebar")
+    const toggleButton = document.getElementById("small-device-button-sidebar")
     const isOpen = navSidebar?.classList.contains("show")
     if (isOpen) {
       navSidebar?.classList.remove("show")
+      navSidebar?.setAttribute("inert", "")
+      toggleButton?.focus()
     } else {
       navSidebar?.classList.add("show")
+      navSidebar?.removeAttribute("inert")
     }
   }
 
@@ -126,6 +130,23 @@ export const Sidebar = (props: Props) => {
       )
     }
   }
+
+  useEffect(() => {
+    const sidebar = document.getElementById("sidebar")
+    if (!sidebar) return
+
+    const mq = window.matchMedia("(max-width: 800px)")
+    const sync = () => {
+      if (mq.matches && !sidebar.classList.contains("show")) {
+        sidebar.setAttribute("inert", "")
+      } else {
+        sidebar.removeAttribute("inert")
+      }
+    }
+    sync()
+    mq.addEventListener("change", sync)
+    return () => mq.removeEventListener("change", sync)
+  }, [])
 
   return (
     <nav aria-label="sidebar" id="sidebar">


### PR DESCRIPTION
When the sidebar is collapsed on small viewports, it was only hidden by moving it off-screen (margin-left: -800px). Elements inside remained focusable, causing keyboard users to tab through invisible items.

Added visibility: hidden to the collapsed sidebar and visibility: visible when the .show class is applied. The visibility transition is synchronized with the margin-left transition so the slide animation still works correctly.

Fixes ADO Bug [2737380](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2737380/?view=edit)

I have verified this manually. 