### PR TITLE
Accessibility bug fix 2737374

### DIFF
--- a/packages/typescriptlang-org/src/components/layout/Sidebar.tsx
+++ b/packages/typescriptlang-org/src/components/layout/Sidebar.tsx
@@ -54,7 +54,7 @@ export const SidebarToggleButton = () => {
 
 
   return (
-    <button id="small-device-button-sidebar" onClick={toggleClick}>
+    <button id="small-device-button-sidebar" aria-label="Toggle sidebar navigation" onClick={toggleClick}>
       <svg fill="none" height="26" viewBox="0 0 26 26" width="26" xmlns="http://www.w3.org/2000/svg"><g fill="#fff"><path d="m0 1c0-.552285.447715-1 1-1h24c.5523 0 1 .447715 1 1v3h-26z" /><path d="m0 11h13 13v4h-26z" /><path d="m0 22h26v3c0 .5523-.4477 1-1 1h-24c-.552284 0-1-.4477-1-1z" /></g></svg>
     </button>
   )


### PR DESCRIPTION
The #small-device-button-sidebar button only contained an SVG icon with no discernible text for screen readers. Added aria-label='Toggle sidebar navigation' to satisfy WCAG button-name rule.

Fixes ADO Bug [2737374](https://devdiv.visualstudio.com/DevDiv/_queries/edit/2737374/?queryId=a1bad941-dac4-4682-b876-d79612402dba)