### PR TITLE
Accessibility bug fix 2737342

### DIFF
--- a/packages/typescriptlang-org/src/templates/documentation.tsx
+++ b/packages/typescriptlang-org/src/templates/documentation.tsx
@@ -91,7 +91,7 @@ const HandbookTemplate: React.FC<Props> = (props) => {
       <section id="doc-layout" >
         <SidebarToggleButton />
 
-        <div className="page-popup" id="page-helpful-popup" style={{ opacity: 0, display: "none" }}>
+        <div className="page-popup" id="page-helpful-popup" role="status" aria-live="polite" style={{ opacity: 0, display: "none" }}>
           <p>Was this page helpful?</p>
           <div>
             <button className="first" id="like-button-popup" title="Like this page"><LikeUnfilledSVG /></button>
@@ -161,7 +161,7 @@ const HandbookTemplate: React.FC<Props> = (props) => {
                     <MarkdownHeadingTree tree={headerListToTree(sidebarHeaders)} className="handbook-on-this-page-section-list" slug={slug} />
                   </>
                   }
-                  <div id="like-dislike-subnav">
+                  <div id="like-dislike-subnav" role="status" aria-live="polite">
                     <h5>{i("handb_like_dislike_title")}</h5>
                     <div>
                       <button title="Like this page" id="like-button"><LikeUnfilledSVG /> {i("handb_like_desc")}</button>


### PR DESCRIPTION
Add role=status and aria-live=polite to both the sidebar (#like-dislike-subnav) and popup (#page-helpful-popup) feedback containers so screen readers announce the 'Thanks for the feedback' message when users click Like/Dislike.

Fixes MAS 1.3.1 - Info and Relationships accessibility violation.

Fixes Bug [2737342](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2737342/?view=edit)

I have verified this manually.