### PR TITLE
[codex] docs: rename callback example getter

### DIFF
--- a/packages/documentation/copy/en/declaration-files/Do's and Don'ts.md
+++ b/packages/documentation/copy/en/declaration-files/Do's and Don'ts.md
@@ -79,7 +79,7 @@ function fn(x: () => void) {
 ```ts
 /* WRONG */
 interface Fetcher {
-  getObject(done: (data: unknown, elapsedTime?: number) => void): void;
+  fetchObject(done: (data: unknown, elapsedTime?: number) => void): void;
 }
 ```
 
@@ -93,7 +93,7 @@ it's always legal to provide a callback that accepts fewer arguments.
 ```ts
 /* OK */
 interface Fetcher {
-  getObject(done: (data: unknown, elapsedTime: number) => void): void;
+  fetchObject(done: (data: unknown, elapsedTime: number) => void): void;
 }
 ```
 


### PR DESCRIPTION
## Summary
- rename the `Fetcher` example method from `getObject` to `fetchObject`
- keep the callback parameter guidance unchanged
- make the example read like callback-based async work instead of a getter returning `void`

Closes #3501.

## Validation
- docs-only change; reviewed the markdown diff locally
