### PR TITLE
Add declare global guidance to the declaration reference

### DIFF
--- a/packages/documentation/copy/en/declaration-files/By Example.md
+++ b/packages/documentation/copy/en/declaration-files/By Example.md
@@ -249,3 +249,35 @@ Use `declare function` to declare functions.
 declare function greet(greeting: string): void;
 ```
 
+## Global augmentation with `declare global`
+
+_Documentation_
+
+> The `magic-string-time` module adds a `startsWithHello()` method to every string when it is imported.
+
+_Code_
+
+```ts
+import "magic-string-time";
+
+"hello world".startsWithHello();
+```
+
+_Declaration_
+
+If a library is imported but adds types to the global scope, put those declarations inside `declare global {}`.
+This is how you describe global-modifying modules and other cases where module code augments existing global types.
+
+```ts
+export {};
+
+declare global {
+  interface String {
+    startsWithHello(): boolean;
+  }
+}
+```
+
+`declare global` only works from inside a module, so the declaration file needs at least one `import` or `export`.
+If the file already has an `import` or `export`, you can remove the `export {}` line.
+For more about how global augmentation works, see [Declaration Merging](/docs/handbook/declaration-merging.html#global-augmentation) and the [global-modifying module template](/docs/handbook/declaration-files/templates/global-modifying-module-d-ts.html).


### PR DESCRIPTION
## Summary

This adds a new `declare global` section to the Declaration Reference handbook page.

The change explains:
- what `declare global` is used for
- how to describe a global-modifying module
- why `export {}` is needed in declaration files that only use `declare global`
- where to read more about global augmentation

This also improves searchability for people looking for `declare global`, since the term and explanation now appear directly on the page mentioned in the issue.

Closes #3409.

## Validation

- Verified the markdown diff with `git diff --check`
- Did not run the repo's `pnpm` checks in this environment because `pnpm` is not installed on this machine
