### PR TITLE
fix removeComments `true` example

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/removeComments.md
+++ b/packages/tsconfig-reference/copy/en/options/removeComments.md
@@ -17,7 +17,6 @@ When `removeComments` is set to `true`:
 ```ts twoslash
 // @showEmit
 // @removeComments: true
-/** The translation of 'Hello world' into Portuguese */
 export const helloWorldPTBR = "Olá Mundo";
 ```
 


### PR DESCRIPTION
The `removeComments` docs show the same outcome for the `true` and `false` values