### PR TITLE
Add publishConfig to typescript6 package

### DIFF
--- a/packages/typescript6/package.json
+++ b/packages/typescript6/package.json
@@ -32,5 +32,8 @@
     ],
     "dependencies": {
         "typescript": "^6"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }


### PR DESCRIPTION
I guess the other packages were grandfathered in. I always forget this.