### PR TITLE
docs: fix README spelling in sandbox description

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ To optimize even more, the env var `NO_TRANSLATIONS` as truthy will make the web
 
 ## Sandbox
 
-The editor aspect of the TypeScript Playground REPL, useable for all sites which want to show a monaco editor
+The editor aspect of the TypeScript Playground REPL, usable for all sites which want to show a monaco editor
 with TypeScript or JavaScript code.
 
 ## Playground


### PR DESCRIPTION
Summary
- fix the "usable" spelling in the README sandbox description

Related issue
- N/A (trivial docs typo fix)

Guideline alignment
- docs-only wording fix in one file
- no behavior changes

Validation
- Ran `git diff --check`
