### PR TITLE
docs: replace re-use in JavaScript examples README

### DIFF
--- a/packages/playground-examples/copy/en/JavaScript/README.md
+++ b/packages/playground-examples/copy/en/JavaScript/README.md
@@ -2,4 +2,4 @@
 
 These examples are to cover the how TypeScript handles JavaScript. They
 can use TypeScript features lightly, but the focus should be to show people 
-how they can re-use their JavaScript knowledge in TypeScript. 
+how they can reuse their JavaScript knowledge in TypeScript.


### PR DESCRIPTION
Summary
- replace "re-use" with "reuse" in the JavaScript examples README

Related issue
- N/A (trivial docs wording fix)

Guideline alignment
- docs-only wording fix in one file
- no behavior changes

Validation
- Ran `git diff --check`
