### PR TITLE
docs: fix deploy workflow comment spelling

### DIFF
--- a/.github/workflows/deploy-prod-static.yml
+++ b/.github/workflows/deploy-prod-static.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
-      # Builds the modules, and boostraps the other modules
+      # Builds the modules, and bootstraps the other modules
       - name: Build website
         run: |
           pnpm install


### PR DESCRIPTION
Summary
- fix the workflow comment spelling in the production deploy workflow

Related issue
- N/A (trivial comment typo fix)

Guideline alignment
- one-file comment fix only
- no behavior changes

Validation
- Ran `git diff --check`
