### PR TITLE
fix: replace deprecated Sass lighten() with color.adjust() in community.scss

### DIFF
--- a/packages/typescriptlang-org/src/templates/pages/css/community.scss
+++ b/packages/typescriptlang-org/src/templates/pages/css/community.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @import "./grid.scss";
 
 .community {
@@ -102,7 +103,7 @@
 
       &.bug {
         background-image: url("../../../assets/community/connect-github-icon.png");
-        background-color: lighten(black, 30%);
+        background-color: color.adjust(black, $lightness: 30%);
       }
     }
   }


### PR DESCRIPTION
## Problem
The community.scss file uses the deprecated Sass lighten() color 
function which will be removed in Dart Sass 3.0.0:
' ' '
DEPRECATION WARNING [color-functions]: lighten() is deprecated
' ' '

## Fix
- Added @use "sass:color" module at the top of community.scss
- Replaced lighten(black, 30%) with color.adjust(black, $lightness: 30%)
## Testing
- Verified community page renders correctly at /community
- color-functions deprecation warning no longer appears in build output
- No visual changes to the page