### PR TITLE
Add tsserverlibrary shim to @typescript/typescript6

### DIFF
--- a/.changeset/floppy-garlics-sort.md
+++ b/.changeset/floppy-garlics-sort.md
@@ -1,0 +1,5 @@
+---
+"@typescript/typescript6": patch
+---
+
+Add tsserverlibrary shim

--- a/packages/typescript6/lib/tsserverlibrary.d.ts
+++ b/packages/typescript6/lib/tsserverlibrary.d.ts
@@ -1,0 +1,2 @@
+import ts = require("typescript");
+export = ts;

--- a/packages/typescript6/lib/tsserverlibrary.js
+++ b/packages/typescript6/lib/tsserverlibrary.js
@@ -1,0 +1,1 @@
+module.exports = require("typescript");


### PR DESCRIPTION
Fixes https://github.com/Microsoft/TypeScript/issues/63422

Can't believe this is still required. `tsserverlibrary` has been a forwarding shim since TS 5.3.