### PR TITLE
docs: Make example more idiomatic

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Narrowing.md
+++ b/packages/documentation/copy/en/handbook-v2/Narrowing.md
@@ -242,7 +242,7 @@ function printAll(strs: string | string[] | null) {
         //            ^?
         console.log(s);
       }
-    } else if (typeof strs === "string") {
+    } else {
       console.log(strs);
       //          ^?
     }


### PR DESCRIPTION
The `else if` part is unnecessary here, and may ultimately lead to confusion and give the impression it's necessary.

<img width="1245" height="665" alt="image" src="https://github.com/user-attachments/assets/bdc05786-83bf-40b8-9b7b-d69c40877015" />
