### PR TITLE
docs: update `"target"` default value to `"es2025"`

### DIFF
--- a/packages/documentation/copy/en/project-config/Compiler Options.md
+++ b/packages/documentation/copy/en/project-config/Compiler Options.md
@@ -1465,7 +1465,7 @@ tsc app.ts util.ts --target esnext --outfile index.js
   <td><code><a href='/tsconfig/#target'>--target</a></code></td>
   <td><p><code>es3</code>, <code>es5</code>, <code>es6</code>/<code>es2015</code>, <code>es2016</code>, <code>es2017</code>, <code>es2018</code>, <code>es2019</code>, <code>es2020</code>, <code>es2021</code>, <code>es2022</code>, <code>es2023</code>, <code>es2024</code>, <code>es2025</code>, or <code>esnext</code></p>
 </td>
-  <td><p><code>es2023</code> if <a href="#module"><code>module</code></a> is <code>node20</code>; <code>esnext</code> if <a href="#module"><code>module</code></a> is <code>nodenext</code>; <code>ES5</code> otherwise.</p>
+  <td><p><code>ES2025</code></p>
 </td>
 </tr>
 <tr class="option-description odd"><td colspan="3">

--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -266,11 +266,7 @@ export const defaultsForOptions = {
   useUnknownInCatchVariables: trueIf("strict"),
   strictPropertyInitialization: trueIf("strict"),
   strictNullChecks: trueIf("strict"),
-  target: [
-    "`es2023` if [`module`](#module) is `node20`;",
-    "`esnext` if [`module`](#module) is `nodenext`;",
-    "`ES5` otherwise.",
-  ],
+  target: "`es2025`",
   useDefineForClassFields: [
     "`true` if [`target`](#target) is `ES2022` or higher, including `ESNext`;",
     "`false` otherwise.",


### PR DESCRIPTION
References:

Previous change default `target` to `latestStandard`.
https://github.com/microsoft/TypeScript/commit/95e3aaa903

Later change updated `latestStandard` to `ES2025`.
https://github.com/microsoft/TypeScript/commit/ee09569714#diff-e9fd483341eea176a38fbd370590e1dc65ce2d9bf70bfd317c5407f04dba9560R7679-R7680

This pull request updates the default value for the TypeScript `target` compiler option to `ES2025` in both the documentation and the configuration scripts. Previously, the default depended on the value of the `module` option, but now it is always set to `ES2025`.

**Documentation update:**

* Updated the default value for `--target` in `Compiler Options.md` to always be `ES2025`, removing the conditional logic based on the `module` setting.

**Configuration script update:**

* Changed the `target` default in `tsconfigRules.ts` to `ES2025`, replacing the previous conditional default logic.