### PR TITLE
docs(tsconfig): document array form of `extends` (TS 5.0)

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/extends.md
+++ b/packages/tsconfig-reference/copy/en/options/extends.md
@@ -6,6 +6,8 @@ oneline: "Specify one or more path or node module references to base configurati
 The value of `extends` is a string which contains a path to another configuration file to inherit from.
 The path may use Node.js style resolution.
 
+Since TypeScript 5.0, `extends` may also be an array of strings, in order to extend from multiple configuration files. In that case, configurations are applied in order from first to last, with later entries overriding earlier ones on conflict. The inheriting configuration file itself is applied last.
+
 The configuration from the base file are loaded first, then overridden by those in the inheriting config file. All relative paths found in the configuration file will be resolved relative to the configuration file they originated in.
 
 It's worth noting that [`files`](#files), [`include`](#include), and [`exclude`](#exclude) from the inheriting config file _overwrite_ those from the
@@ -47,3 +49,38 @@ Currently, the only top-level property that is excluded from inheritance is [`re
 ```
 
 Properties with relative paths found in the configuration file, which aren't excluded from inheritance, will be resolved relative to the configuration file they originated in.
+
+##### Example extending multiple files
+
+In TypeScript 5.0 and later, `extends` can be set to an array of paths. Each entry is resolved using the same rules as the single-string form (relative path, Node.js-style package resolution, or a path into a package such as `@tsconfig/strictest/tsconfig.json`).
+
+`tsconfig1.json`:
+
+```json tsconfig
+{
+  "compilerOptions": {
+    "strictNullChecks": true
+  }
+}
+```
+
+`tsconfig2.json`:
+
+```json tsconfig
+{
+  "compilerOptions": {
+    "noImplicitAny": true
+  }
+}
+```
+
+`tsconfig.json`:
+
+```json tsconfig
+{
+  "extends": ["./tsconfig1.json", "./tsconfig2.json"],
+  "files": ["./index.ts"]
+}
+```
+
+The resulting configuration enables both `strictNullChecks` and `noImplicitAny`. If both base files set the same option, the value from `tsconfig2.json` wins because it appears later in the array.


### PR DESCRIPTION
## Summary

- The `extends` reference page (`packages/tsconfig-reference/copy/en/options/extends.md`) still described the value as "a string", with no mention of the array form added in TypeScript 5.0.
- Adds a short inline note up top and a second `##### Example extending multiple files` section that shows the array syntax and the "later overrides earlier" merge order.
- Follows the structure used by sibling option pages (no `##` top-level headings, `##### Example` h5 subheads, `json tsconfig` fences, filenames in backticks).

Closes #3489

## Test plan

- [x] Visual diff of the rendered page in the v2 site preview.
- [x] Confirm the new section renders under the existing `Example` heading and that code fences use `json tsconfig` highlighting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)