### PR TITLE
docs: refresh the d.ts-from-JS JSDoc intro

### DIFF
--- a/packages/documentation/copy/en/javascript/Creating DTS files From JS.md
+++ b/packages/documentation/copy/en/javascript/Creating DTS files From JS.md
@@ -6,11 +6,10 @@ oneline: "How to add d.ts generation to JavaScript projects"
 translatable: true
 ---
 
-[With TypeScript 3.7](/docs/handbook/release-notes/typescript-3-7.html#--declaration-and---allowjs),
-TypeScript added support for generating .d.ts files from JavaScript using JSDoc syntax.
+TypeScript can generate `.d.ts` files from JavaScript using JSDoc syntax.
 
-This set up means you can own the editor experience of TypeScript-powered editors without porting your project to TypeScript, or having to maintain .d.ts files in your codebase.
-TypeScript supports most JSDoc tags, you can find [the reference here](/docs/handbook/type-checking-javascript-files.html#supported-jsdoc).
+This setup means you can own the editor experience of TypeScript-powered editors without porting your project to TypeScript, or having to maintain `.d.ts` files in your codebase.
+TypeScript supports most JSDoc tags; see the [JSDoc Reference](/docs/handbook/jsdoc-supported-types.html).
 
 ## Setting up your Project to emit .d.ts files
 


### PR DESCRIPTION
## Summary

Fixes #3214

## Changes
- replace the stale `supported-jsdoc` anchor with the dedicated JSDoc Reference page
- remove the outdated TypeScript 3.7 release-note lead-in while keeping the page focused on current guidance
- tighten the introductory wording (`setup`, inline `.d.ts` formatting)

## Testing
- ran `pnpm exec prettier --check packages/documentation/copy/en/javascript/Creating DTS files From JS.md`
- ran `git diff --check`