### PR TITLE
fix: redirect legacy docs home URLs to docs root

### DIFF
--- a/packages/typescriptlang-org/src/redirects/setupRedirects.ts
+++ b/packages/typescriptlang-org/src/redirects/setupRedirects.ts
@@ -4,9 +4,9 @@ const veryOldRedirects = {
   Tutorial: "/docs",
   Handbook: "/docs",
   samples: "/docs",
-  "/docs/home.html": "/docs/home",
+  "/docs/home.html": "/docs/",
   "/playground": "/play/",
-  "/docs/home": "/docs",
+  "/docs/home": "/docs/",
 }
 
 // These were .html files in the handbook with some redirection work


### PR DESCRIPTION
## Summary

Fixes #3247

## Changes
- redirect `/docs/home.html` directly to `/docs/`
- redirect `/docs/home` directly to `/docs/`
- remove the intermediate hop that currently points legacy docs-home URLs at a broken route

## Testing
- ran `pnpm exec prettier --check packages/typescriptlang-org/src/redirects/setupRedirects.ts`
- ran `git diff --check`
- confirmed the redirect table now sends both legacy URLs to `/docs/`