### PR TITLE
Document array values for tsconfig extends

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/extends.md
+++ b/packages/tsconfig-reference/copy/en/options/extends.md
@@ -3,10 +3,10 @@ display: "Extends"
 oneline: "Specify one or more path or node module references to base configuration files from which settings are inherited."
 ---
 
-The value of `extends` is a string which contains a path to another configuration file to inherit from.
-The path may use Node.js style resolution.
+The value of `extends` is a string which contains a path to another configuration file to inherit from, or an array of paths to multiple base configuration files.
+The path or paths may use Node.js style resolution.
 
-The configuration from the base file are loaded first, then overridden by those in the inheriting config file. All relative paths found in the configuration file will be resolved relative to the configuration file they originated in.
+Base configuration files are loaded first, then overridden by those in the inheriting config file. When `extends` is an array, later entries override earlier entries. All relative paths found in the configuration file will be resolved relative to the configuration file they originated in.
 
 It's worth noting that [`files`](#files), [`include`](#include), and [`exclude`](#exclude) from the inheriting config file _overwrite_ those from the
 base config file, and that circularity between configuration files is not allowed.
@@ -43,6 +43,15 @@ Currently, the only top-level property that is excluded from inheritance is [`re
   "compilerOptions": {
     "strictNullChecks": false
   }
+}
+```
+
+`tsconfig.app.json`:
+
+```json tsconfig
+{
+  "extends": ["./configs/base", "./tsconfig.nostrictnull"],
+  "files": ["main.ts", "app.ts"]
 }
 ```
 


### PR DESCRIPTION
## Summary
- Update the tsconfig `extends` option docs to describe string arrays
- Clarify that later entries in the array override earlier entries
- Add a short example using multiple base configs

## Related issue
- microsoft/TypeScript#62915

## Testing
- Ran `git diff --check`
- Documentation-only change; site build not run because Node.js / npm / pnpm are unavailable in this environment