### PR TITLE
docs(handbook): fix heading level for "Truthiness narrowing"

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Narrowing.md
+++ b/packages/documentation/copy/en/handbook-v2/Narrowing.md
@@ -106,7 +106,7 @@ Users with enough experience might not be surprised, but not everyone has run in
 
 This might be a good segue into what we'll call "truthiness" checking.
 
-# Truthiness narrowing
+## Truthiness narrowing
 
 Truthiness might not be a word you'll find in the dictionary, but it's very much something you'll hear about in JavaScript.
 


### PR DESCRIPTION
## Summary

Fixes the heading level for "Truthiness narrowing" in the Narrowing handbook page, reported in microsoft/TypeScript#63531.

The heading was written as an H1 (`# Truthiness narrowing`) but every other narrowing kind on the same page — `typeof type guards`, `Equality narrowing`, `in operator narrowing`, `instanceof narrowing`, `Assignments`, `Control flow analysis`, `Using type predicates`, `Assertion functions` — is an H2. As a result the on-page Table of Contents nested all of those siblings under "Truthiness narrowing", giving readers the impression they're sub-concepts of truthiness.

## Change

```diff
- # Truthiness narrowing
+ ## Truthiness narrowing
```

`packages/documentation/copy/en/handbook-v2/Narrowing.md`, one character.

## Refs

- Reported: microsoft/TypeScript#63531 (RyanCavanaugh confirmed in the thread; this is the docs source mirror of the same issue.)

## AI disclosure

Used Claude to locate the file in this repo (the issue was filed on `microsoft/TypeScript`, not here) and to draft this description. The change itself is trivial — verified by inspecting the surrounding H2 siblings.
