### PR TITLE
fix: correct heading level for Truthiness narrowing section

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Narrowing.md
+++ b/packages/documentation/copy/en/handbook-v2/Narrowing.md
@@ -106,7 +106,7 @@ Users with enough experience might not be surprised, but not everyone has run in
 
 This might be a good segue into what we'll call "truthiness" checking.
 
-# Truthiness narrowing
+## Truthiness narrowing
 
 Truthiness might not be a word you'll find in the dictionary, but it's very much something you'll hear about in JavaScript.
 


### PR DESCRIPTION
Fixes microsoft/TypeScript#63531

  I found the issue in packages/documentation/copy/en/handbook-v2/Narrowing.md at line 109.
  The "Truthiness narrowing" section uses an H1 heading (#) instead of H2 (##), which breaks
  the Table of Contents structure. All subsequent parallel narrowing concepts like "Equality
  narrowing", "The in operator narrowing", "instanceof narrowing" etc. are incorrectly nested
  under Truthiness narrowing in the TOC.

  Changed `# Truthiness narrowing` to `## Truthiness narrowing` to match the heading level of
  other narrowing concepts in the same page.