### PR TITLE
Update typeRoots.md example for clarity on typeRoots usage

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/typeRoots.md
+++ b/packages/tsconfig-reference/copy/en/options/typeRoots.md
@@ -7,7 +7,7 @@ By default all _visible_ "`@types`" packages are included in your compilation.
 Packages in `node_modules/@types` of any enclosing folder are considered _visible_.
 For example, that means packages within `./node_modules/@types/`, `../node_modules/@types/`, `../../node_modules/@types/`, and so on.
 
-If `typeRoots` is specified, _only_ packages under `typeRoots` will be included. For example:
+If `typeRoots` is specified, _only_ packages under `typeRoots` will be included. For example, the following config file will include _all_ packages under `./typings` and `./vendor/types`, and no packages from `./node_modules/@types`:
 
 ```json tsconfig
 {
@@ -17,5 +17,4 @@ If `typeRoots` is specified, _only_ packages under `typeRoots` will be included.
 }
 ```
 
-This config file will include _all_ packages under `./typings` and `./vendor/types`, and no packages from `./node_modules/@types`.
-All paths are relative to the `tsconfig.json`.
+__Note:__ All paths are relative to the `tsconfig.json`.


### PR DESCRIPTION
The current documentation reads with a little ambiguity, as if `./typings` and `./vendor/types` are by default picked up by the compiler... especially with the large amount of spacing between the sentence, and what it's referring to:

<img width="1464" height="990" alt="image" src="https://github.com/user-attachments/assets/11ca9097-8a41-4517-b9d5-86bfd7dc0403" />

This PR just shifts things around a bit for more clarity to both humans and robots, by making it clear that it's in reference to the example snippet.