### PR TITLE
docs(tsconfig): show the object syntax for the plugins option

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/plugins.md
+++ b/packages/tsconfig-reference/copy/en/options/plugins.md
@@ -14,4 +14,16 @@ For example:
 - [typescript-eslint-language-service](https://github.com/Quramy/typescript-eslint-language-service) &mdash; Provides eslint error messaging and fix-its inside the compiler's output.
 - [ts-graphql-plugin](https://github.com/Quramy/ts-graphql-plugin) &mdash; Provides validation and auto-completion inside GraphQL query template strings.
 
+You enable a plugin by adding it to the `plugins` array in your `tsconfig.json`. Each entry is an object with the plugin's package `name`, plus any options that plugin accepts:
+
+```json tsconfig
+{
+  "compilerOptions": {
+    "plugins": [
+      { "name": "ts-sql-plugin" }
+    ]
+  }
+}
+```
+
 VS Code has the ability for a extension to [automatically include language service plugins](https://code.visualstudio.com/api/references/contribution-points#contributes.typescriptServerPlugins), and so you may have some running in your editor without needing to define them in your `tsconfig.json`.


### PR DESCRIPTION
The `plugins` copy calls it a "list of language service plugins" and gives no example, so it reads like you pass a list of strings. It actually takes an array of objects, each with a `name`. This adds a short `tsconfig.json` example showing the real shape, in the same `json tsconfig` style the other option pages (like `paths`) already use.

Fixes #3039
