### PR TITLE
fix: use semantic button elements for in-page actions (a11y MAS 4.1.2)

### DIFF
--- a/packages/typescriptlang-org/src/components/index/AboveTheFold.tsx
+++ b/packages/typescriptlang-org/src/components/index/AboveTheFold.tsx
@@ -9,8 +9,8 @@ const Row = (props: { children: any, className?: string }) => <div className={[p
 const Col = (props: { children: any, className?: string }) => <div className={[props.className, "col1"].join(" ")}>{props.children}</div>
 const Col2 = (props: { children: any }) => <div className="col2">{props.children}</div>
 
-const FluidButton = (props: { href?: string, onClick?: any, title: string, subtitle?: string, icon: JSX.Element, className?: string }) => (
-  <a className={"fluid-button " + props.className || ""} href={props.href} onClick={props.onClick}>
+const FluidButton = (props: { href?: string, onClick?: any, title: string, subtitle?: string, icon: JSX.Element, className?: string, role?: string }) => (
+  <a className={"fluid-button " + props.className || ""} href={props.href} onClick={props.onClick} role={props.role}>
     <div>
       <div className="fluid-button-title">{props.title}</div>
       <div className="fluid-button-subtitle">{props.subtitle}</div>
@@ -43,6 +43,7 @@ export const AboveTheFold = () => {
             subtitle={i("index_2_cta_install_subtitle")}
             href="/download"
             onClick={onclick}
+            role="button"
             icon={
               <svg width="21" height="5" viewBox="0 0 21 5" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <rect x="0.5" y="0.5" width="4" height="4" stroke="black" />
@@ -122,11 +123,11 @@ export const AboveTheFold = () => {
     const Content = window.innerWidth < 600 ? CTAHeadlineMobile : CTAHeadlines
     return (
       <div className="cta">
-        <a className="transparent-button" onClick={() => setShowCTALinks(false)}  href="#">
+        <button className="transparent-button" onClick={() => setShowCTALinks(false)}>
           <svg width="21" height="14" viewBox="0 0 21 14" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M20.25 7.75L1.75 7.75M1.75 7.75L7.75 1.25M1.75 7.75L7.75 13.25" stroke="white" strokeWidth="2" />
           </svg>
-          Back</a>
+          Back</button>
         <Content />
       </div>
     )

--- a/packages/typescriptlang-org/src/components/index/EditorExamples.tsx
+++ b/packages/typescriptlang-org/src/components/index/EditorExamples.tsx
@@ -70,9 +70,8 @@ export const EditorExamples = () => {
 
       </div>
 
-      <a
+      <button
         className="next-headline-button"
-        href="#"
         onClick={next}
         aria-label="Show code sample"
       >
@@ -85,7 +84,7 @@ export const EditorExamples = () => {
         >
           <path d="M0 14.5V0.5L10.5 7L0 14.5Z" />
         </svg>
-      </a>
+      </button>
     </div>
   );
 };

--- a/packages/typescriptlang-org/src/templates/pages/css/index.scss
+++ b/packages/typescriptlang-org/src/templates/pages/css/index.scss
@@ -50,6 +50,9 @@ $headline-foreground-bg: white;
   padding: 1rem 1rem;
   text-decoration: none;
   cursor: pointer;
+  border: none;
+  font-family: inherit;
+  font-size: inherit;
 
   @media screen and (-ms-high-contrast: active) {
     border: 2px solid grey;
@@ -1281,6 +1284,9 @@ $headline-foreground-bg: white;
   width: 80px;
   padding: 10px;
   cursor: pointer;
+  background: none;
+  font-family: inherit;
+  font-size: inherit;
   svg {
     margin-right: 8px;
   }


### PR DESCRIPTION
## Summary

Interactive controls on the TypeScript homepage that trigger in-page JavaScript actions were implemented as `<a>` elements. These get implicit `role="link"`, misleading screen reader users who expect button behavior.

**AzDO Bug:** [2614223](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2614223) — MAS 4.1.2 (Name, Role, Value)

## Changes

### EditorExamples.tsx
- "Show Sample Code" control: `<a href="#" onClick={next}>` → `<button onClick={next} aria-label="Show code sample">`

### AboveTheFold.tsx
- "Back" control: `<a href="#" onClick={...}>` → `<button onClick={...}>`
- "Try TypeScript Now" FluidButton: added `role="button"` prop (progressive enhancement — onClick calls e.preventDefault())
- FluidButton component: added optional `role` prop to interface and element

### index.scss
- `@mixin flat-button`: added `border: none; font-family: inherit; font-size: inherit;`
- `.transparent-button`: added `background: none; font-family: inherit; font-size: inherit;`