### PR TITLE
Document array values for tsconfig extends

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/extends.md
+++ b/packages/tsconfig-reference/copy/en/options/extends.md
@@ -3,10 +3,10 @@ display: "Extends"
 oneline: "Specify one or more path or node module references to base configuration files from which settings are inherited."
 ---
 
-The value of `extends` is a string which contains a path to another configuration file to inherit from.
-The path may use Node.js style resolution.
+The value of `extends` is a string which contains a path to another configuration file to inherit from, or an array of strings where each entry is a path to another configuration file to inherit from.
+Each path may use Node.js style resolution.
 
-The configuration from the base file are loaded first, then overridden by those in the inheriting config file. All relative paths found in the configuration file will be resolved relative to the configuration file they originated in.
+The configuration from the base file is loaded first, then overridden by those in the inheriting config file. If `extends` is an array, each base configuration is loaded in order, with later entries overriding earlier entries. All relative paths found in the configuration file will be resolved relative to the configuration file they originated in.
 
 It's worth noting that [`files`](#files), [`include`](#include), and [`exclude`](#exclude) from the inheriting config file _overwrite_ those from the
 base config file, and that circularity between configuration files is not allowed.
@@ -32,6 +32,17 @@ Currently, the only top-level property that is excluded from inheritance is [`re
 {
   "extends": "./configs/base",
   "files": ["main.ts", "supplemental.ts"]
+}
+```
+
+`tsconfig.backend.json`:
+
+```json tsconfig
+{
+  "extends": ["./configs/base", "./configs/node"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary

Updates the TSConfig `extends` reference to document that `extends` can be either a single string or an array of strings.

The page already hinted at "one or more" in the one-line summary, but the body only described the single-string form. This adds the array behavior, notes that later entries override earlier entries, and includes a short multi-base example.

Fixes microsoft/TypeScript#62915.

## Validation

- `npx --yes prettier@2.8.8 --check packages/tsconfig-reference/copy/en/options/extends.md`
- `git diff --check`
- Sanity-checked TypeScript config parsing with `typescript-for-docs`; a temp config using `extends: ["./configs/base", "./configs/node"]` resolved later `target`/`module` values from the second config.

I also tried `npx --yes pnpm@10.30.3 run --filter=tsconfig-reference lint`, but it failed before linting this page because the local workspace could not resolve the built `@typescript/twoslash/dist/index.js` entrypoint. Building `@typescript/vfs` succeeded; building `@typescript/twoslash` still failed resolving `@typescript/vfs`. The environment also reports Node `v20.15.0` while the repo requests `>=20.19`.
