### PR TITLE
Fix url for the release candidate

### DIFF
--- a/packages/typescriptlang-org/src/components/VersionBar.tsx
+++ b/packages/typescriptlang-org/src/components/VersionBar.tsx
@@ -12,7 +12,7 @@ import { useIntl } from "react-intl"
 export const VersionBar = () => {
   const i = createInternational<typeof navCopy>(useIntl())
   const beta = <span>{i("nav_version_between")}<a href={releaseInfo.betaPostURL}>{releaseInfo.tags.betaMajMin}</a> {i("nav_version_beta_prefix")}</span>
-  const rc = <span>{i("nav_version_between")}<a href={releaseInfo.betaPostURL}>{releaseInfo.tags.rcMajMin}</a> {i("nav_version_rc_prefix")}</span>
+  const rc = <span>{i("nav_version_between")}<a href={releaseInfo.rcPostURL}>{releaseInfo.tags.rcMajMin}</a> {i("nav_version_rc_prefix")}</span>
   const prefix = releaseInfo.isRC ? rc : releaseInfo.isBeta ? beta : null
 
   return (


### PR DESCRIPTION
Fixes the URL for the release candidate notification on the home page:

<img width="1374" height="842" alt="image" src="https://github.com/user-attachments/assets/ff215023-755a-4eaf-96ef-9c2c527ca081" />
