### PR TITLE
Exhaustiveness checking with runtime error and assertNever

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Narrowing.md
+++ b/packages/documentation/copy/en/handbook-v2/Narrowing.md
@@ -708,9 +708,9 @@ In those cases, TypeScript will use a `never` type to represent a state which sh
 
 # Exhaustiveness checking
 
-The `never` type is assignable to every type; however, no type is assignable to `never` (except `never` itself). This means you can use narrowing and rely on `never` turning up to do exhaustive checking in a `switch` statement.
+The `never` type is assignable to every type; however, no type is assignable to `never` (except `never` itself). It is good practice to create a `assertNever` helper function that would raise a runtime error when called. This means you can use narrowing and rely on `never` turning up to do exhaustive checking in a `switch` statement.
 
-For example, adding a `default` to our `getArea` function which tries to assign the shape to `never` will not raise an error when every possible case has been handled.
+For example, adding a `default` to our `getArea` function which tries to call our `assertNever` function that expects shape to be `never` will not raise an error when every possible case has been handled.
 
 ```ts twoslash
 interface Circle {
@@ -732,9 +732,12 @@ function getArea(shape: Shape) {
     case "square":
       return shape.sideLength ** 2;
     default:
-      const _exhaustiveCheck: never = shape;
-      return _exhaustiveCheck;
+      assertNever(shape);
   }
+}
+
+function assertNever(value: never) {
+  throw new Error(`Missing case for value: ${value}`);
 }
 ```
 
@@ -766,8 +769,11 @@ function getArea(shape: Shape) {
     case "square":
       return shape.sideLength ** 2;
     default:
-      const _exhaustiveCheck: never = shape;
-      return _exhaustiveCheck;
+      assertNever(shape);
   }
+}
+
+function assertNever(value: never) {
+  throw new Error(`Missing case for value: ${value}`);
 }
 ```

--- a/packages/documentation/copy/en/handbook-v2/Narrowing.md
+++ b/packages/documentation/copy/en/handbook-v2/Narrowing.md
@@ -736,7 +736,7 @@ function getArea(shape: Shape) {
   }
 }
 
-function assertNever(value: never) {
+function assertNever(value: never): never {
   throw new Error(`Missing case for value: ${value}`);
 }
 ```
@@ -773,7 +773,7 @@ function getArea(shape: Shape) {
   }
 }
 
-function assertNever(value: never) {
+function assertNever(value: never): never {
   throw new Error(`Missing case for value: ${value}`);
 }
 ```


### PR DESCRIPTION
The example function `getArea` in the documentation on [exhaustiveness checking](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#exhaustiveness-checking) currently creates a conflicting behavior between *compile* time and *run* time:

```ts
interface Circle {
  kind: "circle";
  radius: number;
}

interface Square {
  kind: "square";
  sideLength: number;
}

type Shape = Circle | Square;

function getArea(shape: Shape) {
  switch (shape.kind) {
    case "circle":
      return Math.PI * shape.radius ** 2;
    case "square":
      return shape.sideLength ** 2;
    default:
      const _exhaustiveCheck: never = shape;
      return _exhaustiveCheck;
  }
}
```

The advantage of catching errors during compilation with help of the `never`-type can only occur if the missing type (`Triangle`) is known and has already been implemented to be a variant of type `Shape`. While this is a helpful check during compilation, it can lead to false assumptions on the behavior at runtime.

Where the cases `"circle"` and `"square"` would both return a value of type `number` back to the caller, the `default` case currently would just fall back to returning the input argument of an "unknown" variant of type `Shape`, e.g. `Triangle`. Such a practice could lead to problems in other parts of the code base at runtime, depending on where the `Shape`-objects are originating from. 

In practice, it is likely that objects of type `Shape` are members of response objects from API calls or any other IO results, so our type implementation of `type Shape = Circle | Square` might just be mirroring an expectation of these response-/result-objects. We might not be in charge of their design and are merely a consuming client process. In such cases we might have an outdated implementation running that will *actually* fall back to the current `default` case at runtime, returning a "yet unknown" object of type `Triangle` back to its caller.

This caller has been implemented to expect a value of type `number`, as backed by static type checking, so any further algebraic operation on that return value (`+`, `-`, `*`, `/` etc.) would then throw a runtime error in parts of the code base that shouldn't worry about such a mistake in the first place.

Therefor, it'd be a better practice to throw an explicit runtime error in such a case. *Python* has [assert_never](https://docs.python.org/3/library/typing.html#typing.assert_never) for exactly these occasions.

My proposal is to change the example slightly by throwing a runtime error as fallback in the `default` case with the help of a function called `assertNever`:

```ts
// ...type definitions

function getArea(shape: Shape) {
  switch (shape.kind) {
    // ...implemented cases
    default:
      assertNever(shape);
  }
}

function assertNever(value: never): never {
  throw new Error(`Missing case for value: ${value}`);
}
```