### PR TITLE
docs: fix TypeScript spelling

### DIFF
--- a/packages/documentation/copy/en/project-config/Configuring Watch.md
+++ b/packages/documentation/copy/en/project-config/Configuring Watch.md
@@ -6,7 +6,7 @@ oneline: How to configure the watch mode of TypeScript
 translatable: true
 ---
 
-As of TypeScript 3.8 and onward, the Typescript compiler exposes configuration which controls how it watches files and directories. Prior to this version, configuration required the use of environment variables which are still available.
+As of TypeScript 3.8 and onward, the TypeScript compiler exposes configuration which controls how it watches files and directories. Prior to this version, configuration required the use of environment variables which are still available.
 
 ## Background
 
@@ -50,7 +50,7 @@ The suggested method of configuring watch behavior is through the new `watchOpti
 }
 ```
 
-For further details, see [the release notes for Typescript 3.8](/docs/handbook/release-notes/typescript-3-8.html#better-directory-watching-on-linux-and-watchoptions).
+For further details, see [the release notes for TypeScript 3.8](/docs/handbook/release-notes/typescript-3-8.html#better-directory-watching-on-linux-and-watchoptions).
 
 ## Configuring file watching using environment variable `TSC_WATCHFILE`
 

--- a/packages/documentation/copy/en/reference/Decorators.md
+++ b/packages/documentation/copy/en/reference/Decorators.md
@@ -6,8 +6,8 @@ oneline: TypeScript Decorators overview
 translatable: true
 ---
 
-> NOTE&nbsp; This document refers to an experimental stage 2 decorators implementation. Stage 3 decorator support is available since Typescript 5.0.
-> See: [Decorators in Typescript 5.0](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#decorators)
+> NOTE&nbsp; This document refers to an experimental stage 2 decorators implementation. Stage 3 decorator support is available since TypeScript 5.0.
+> See: [Decorators in TypeScript 5.0](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#decorators)
 
 ## Introduction
 

--- a/packages/documentation/copy/en/release-notes/TypeScript 5.0.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 5.0.md
@@ -461,7 +461,7 @@ If you want all your projects to also use the options from the `@tsconfig/strict
 This works to a point.
 If you have any projects that *don't* want to use `@tsconfig/strictest`, they have to either manually disable the options, or create a separate version of `tsconfig.base.json` that *doesn't* extend from `@tsconfig/strictest`.
 
-To give some more flexibility here, Typescript 5.0 now allows the `extends` field to take multiple entries.
+To give some more flexibility here, TypeScript 5.0 now allows the `extends` field to take multiple entries.
 For example, in this configuration file:
 
 ```jsonc


### PR DESCRIPTION
## Summary

- Fixes several `Typescript` references to use the official `TypeScript` spelling.
- Updates source documentation pages for watch configuration, decorators, and the TypeScript 5.0 release notes.

## Validation

- Ran `rg -n "Typescript"` against the changed files and confirmed no remaining matches.
- Attempted `pnpm exec prettier --check` on the changed files, but Corepack failed before running pnpm with `Cannot find matching keyid` on this machine.
