### PR TITLE
docs: fix JSDoc reference link

### DIFF
--- a/packages/documentation/copy/en/javascript/Creating DTS files From JS.md
+++ b/packages/documentation/copy/en/javascript/Creating DTS files From JS.md
@@ -10,7 +10,7 @@ translatable: true
 TypeScript added support for generating .d.ts files from JavaScript using JSDoc syntax.
 
 This set up means you can own the editor experience of TypeScript-powered editors without porting your project to TypeScript, or having to maintain .d.ts files in your codebase.
-TypeScript supports most JSDoc tags, you can find [the reference here](/docs/handbook/type-checking-javascript-files.html#supported-jsdoc).
+TypeScript supports most JSDoc tags, you can find [the reference here](/docs/handbook/jsdoc-supported-types.html).
 
 ## Setting up your Project to emit .d.ts files
 


### PR DESCRIPTION
## Summary

Updates the "Creating .d.ts Files from .js files" page to link directly to the current JSDoc Reference page instead of the old type-checking JavaScript page anchor.

Closes #3214.

## Testing

- Verified locally with a Node script that `/docs/handbook/jsdoc-supported-types.html` matches the permalink in `packages/documentation/copy/en/javascript/JSDoc Reference.md`.
- `pnpm --version` could not run because Corepack failed with a signature key mismatch before loading pnpm, so I could not run the repo package scripts in this environment.