### PR TITLE
Rename local typescript dep to avoid package manager name bugs

### DIFF
--- a/.changeset/young-rivers-stare.md
+++ b/.changeset/young-rivers-stare.md
@@ -1,0 +1,5 @@
+---
+"@typescript/typescript6": patch
+---
+
+Rename local typescript dep to avoid package manager name bugs

--- a/packages/typescript6/lib/tsc.js
+++ b/packages/typescript6/lib/tsc.js
@@ -1,1 +1,1 @@
-require("typescript/lib/tsc.js");
+require("@typescript/old/lib/tsc.js");

--- a/packages/typescript6/lib/tsserverlibrary.d.ts
+++ b/packages/typescript6/lib/tsserverlibrary.d.ts
@@ -1,2 +1,2 @@
-import ts = require("typescript");
+import ts = require("@typescript/old");
 export = ts;

--- a/packages/typescript6/lib/tsserverlibrary.js
+++ b/packages/typescript6/lib/tsserverlibrary.js
@@ -1,1 +1,1 @@
-module.exports = require("typescript");
+module.exports = require("@typescript/old");

--- a/packages/typescript6/lib/typescript.d.ts
+++ b/packages/typescript6/lib/typescript.d.ts
@@ -1,2 +1,2 @@
-import ts = require("typescript");
+import ts = require("@typescript/old");
 export = ts;

--- a/packages/typescript6/lib/typescript.js
+++ b/packages/typescript6/lib/typescript.js
@@ -1,1 +1,1 @@
-module.exports = require("typescript");
+module.exports = require("@typescript/old");

--- a/packages/typescript6/package.json
+++ b/packages/typescript6/package.json
@@ -31,7 +31,7 @@
         "README.md"
     ],
     "dependencies": {
-        "typescript": "^6"
+        "@typescript/old": "npm:typescript@^6"
     },
     "publishConfig": {
         "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,9 +327,9 @@ importers:
 
   packages/typescript6:
     dependencies:
-      typescript:
-        specifier: 6.0.2
-        version: 6.0.2
+      '@typescript/old':
+        specifier: npm:typescript@^6
+        version: typescript@6.0.2
 
   packages/typescriptlang-org:
     dependencies:


### PR DESCRIPTION
If you do `"typescript": "@typescript/typescript6"`, then some package managers seem to replace `@typescript/typescript6`'s own `typescript` dep with... `@typescript/typescript6`.