### PR TITLE
Update `module` default value in tsconfigRules

### DIFF
--- a/packages/documentation/copy/en/project-config/Compiler Options.md
+++ b/packages/documentation/copy/en/project-config/Compiler Options.md
@@ -846,7 +846,7 @@ tsc app.ts util.ts --target esnext --outfile index.js
   <td><code><a href='/tsconfig/#module'>--module</a></code></td>
   <td><p><code>none</code>, <code>commonjs</code>, <code>amd</code>, <code>umd</code>, <code>system</code>, <code>es6</code>/<code>es2015</code>, <code>es2020</code>, <code>es2022</code>, <code>esnext</code>, <code>node16</code>, <code>node18</code>, <code>node20</code>, <code>nodenext</code>, or <code>preserve</code></p>
 </td>
-  <td><p><code>CommonJS</code> if <a href="#target"><code>target</code></a> is <code>ES5</code>; <code>ES6</code>/<code>ES2015</code> otherwise.</p>
+  <td><p><code>ESNext</code> if <a href="#target"><code>target</code></a> is <code>ESNext</code>; <code>ES2022</code> if <a href="#target"><code>target</code></a> is <code>ES2022</code> or higher; <code>ES2020</code> if <a href="#target"><code>target</code></a> is <code>ES2020</code> or higher; <code>ES2015</code> if <a href="#target"><code>target</code></a> is <code>ES2015</code> or higher; <code>CommonJS</code> otherwise.</p>
 </td>
 </tr>
 <tr class="option-description even"><td colspan="3">

--- a/packages/tsconfig-reference/scripts/tsconfigRules.ts
+++ b/packages/tsconfig-reference/scripts/tsconfigRules.ts
@@ -235,8 +235,11 @@ export const defaultsForOptions = {
   jsxFactory: "React.createElement",
   locale: "Platform specific.",
   module: [
-    "`CommonJS` if [`target`](#target) is `ES5`;",
-    "`ES6`/`ES2015` otherwise.",
+    "`ESNext` if [`target`](#target) is `ESNext`;",
+    "`ES2022` if [`target`](#target) is `ES2022` or higher;",
+    "`ES2020` if [`target`](#target) is `ES2020` or higher;",
+    "`ES2015` if [`target`](#target) is `ES2015` or higher;",
+    "`CommonJS` otherwise.",
   ],
   moduleResolution: [
     "`Node10` if [`module`](#module) is `CommonJS`;",


### PR DESCRIPTION
The documented default value for the `module` compiler option is outdated since TypeScript 6.0.

In TypeScript 5.x, the default was "CommonJS if target is ES5; ES2015 otherwise". In TypeScript 6.0, the `target` default [changed to `es2025`](https://github.com/microsoft/TypeScript/pull/63067) and the `module` computation [was updated](https://github.com/microsoft/TypeScript/pull/62669) to:
- `ESNext` if `target` is `ESNext`
- `ES2022` if `target` is `ES2022` or higher
- `ES2020` if `target` is `ES2020` or higher
- `ES2015` if `target` is `ES2015` or higher
- `CommonJS` otherwise

The relevant computation logic in the compiler:

https://github.com/microsoft/TypeScript/blob/b24015058ae060de249acf5ea09e15dd92a55587/src/compiler/utilities.ts#L9055-L9076

Fixes microsoft/TypeScript#63330
Relates to microsoft/TypeScript#63392