### PR TITLE
Document tsconfig extends arrays

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/extends.md
+++ b/packages/tsconfig-reference/copy/en/options/extends.md
@@ -3,10 +3,10 @@ display: "Extends"
 oneline: "Specify one or more path or node module references to base configuration files from which settings are inherited."
 ---
 
-The value of `extends` is a string which contains a path to another configuration file to inherit from.
-The path may use Node.js style resolution.
+The value of `extends` can be a string which contains a path to another configuration file to inherit from, or an array of paths to multiple base configuration files.
+Each path may use Node.js style resolution.
 
-The configuration from the base file are loaded first, then overridden by those in the inheriting config file. All relative paths found in the configuration file will be resolved relative to the configuration file they originated in.
+The configuration from the base file is loaded first, then overridden by those in the inheriting config file. When `extends` is an array, each configuration is applied in order, with later files overriding settings from earlier files. All relative paths found in the configuration file will be resolved relative to the configuration file they originated in.
 
 It's worth noting that [`files`](#files), [`include`](#include), and [`exclude`](#exclude) from the inheriting config file _overwrite_ those from the
 base config file, and that circularity between configuration files is not allowed.
@@ -42,6 +42,17 @@ Currently, the only top-level property that is excluded from inheritance is [`re
   "extends": "./tsconfig",
   "compilerOptions": {
     "strictNullChecks": false
+  }
+}
+```
+
+`tsconfig.combined.json`:
+
+```json tsconfig
+{
+  "extends": ["./configs/base", "./tsconfig.nostrictnull"],
+  "compilerOptions": {
+    "noImplicitAny": false
   }
 }
 ```


### PR DESCRIPTION
## Summary

- document that `tsconfig.json` `extends` accepts either a string or an array of config paths
- clarify that multiple extended configs are applied in array order, with later configs overriding earlier ones
- add a small array example to the `extends` TSConfig reference page

Fixes microsoft/TypeScript#62915.

## Validation

- `git diff --check`
- `pnpm exec prettier --check packages/tsconfig-reference/copy/en/options/extends.md`
- `pnpm run --filter=tsconfig-reference lint` was attempted after `pnpm install --frozen-lockfile`; it is blocked locally by the existing workspace build for `@typescript/twoslash` failing to resolve `@typescript/vfs` before linting this markdown change. Retried with Node v20.20.0 to satisfy the repo engine requirement and saw the same workspace resolution failure.