### PR TITLE
Clarify truthiness narrowing description

### DIFF
--- a/packages/documentation/copy/en/handbook-v2/Narrowing.md
+++ b/packages/documentation/copy/en/handbook-v2/Narrowing.md
@@ -190,7 +190,7 @@ TypeScript doesn't hurt us here at all, but this behavior is worth noting if you
 TypeScript can often help you catch bugs early on, but if you choose to do _nothing_ with a value, there's only so much that it can do without being overly prescriptive.
 If you want, you can make sure you handle situations like these with a linter.
 
-One last word on narrowing by truthiness is that Boolean negations with `!` filter out from negated branches.
+One last word on narrowing by truthiness is that Boolean negations with `!` filter truthy types out of negated branches.
 
 ```ts twoslash
 function multiplyAll(


### PR DESCRIPTION
Clarifies the truthiness-narrowing sentence by stating which types are filtered from a negated branch.

Fixes #3611.

Tests: not run (documentation-only change).
