### PR TITLE
docs(declaration-files): document implicit export visibility in .d.ts modules

### DIFF
--- a/packages/documentation/copy/en/declaration-files/Deep Dive.md
+++ b/packages/documentation/copy/en/declaration-files/Deep Dive.md
@@ -230,3 +230,50 @@ The second block creates the following name meanings:
 - A type `X`
 
 <!-- TODO: Write more on that. -->
+
+## Export Visibility in Declaration Files
+
+Module declaration files (`.d.ts` files with a top-level `import` or `export`)
+have a behavior that often surprises people: every top-level declaration is
+reachable from outside the module, whether or not it is marked `export`.
+
+Say we have a module file `foo.d.ts`:
+
+```ts
+interface Options {
+  count: number;
+}
+export declare function make(options: Options): void;
+```
+
+Then consumed it:
+
+```ts
+import { make, Options } from "./foo";
+```
+
+In a normal `.ts` module, importing `Options` would be an error
+("Module './foo' declares 'Options' locally, but it is not exported."),
+but in a declaration file the non-exported name is still importable.
+
+This applies to values as well as types: a `declare const` or `declare class`
+without `export` can also be named in an import.
+Be careful with values, though — if the underlying JavaScript module doesn't
+actually export that binding, the import will fail at load time under ES
+modules, or produce `undefined` under CommonJS interop, even though it
+type-checks.
+
+To opt out of this behavior and make a declaration file behave like a normal
+module — where only explicit `export`s are visible from outside — add an empty
+export to the file:
+
+```ts
+interface Options {
+  count: number;
+}
+export declare function make(options: Options): void;
+export {};
+```
+
+With the `export {}` present, importing `Options` elsewhere is now an error,
+even though the file was already a module before adding it.


### PR DESCRIPTION
## Summary

Adds a section to the declaration-files **Deep Dive** page documenting a
long-standing but undocumented behavior: in a module `.d.ts` file, all
top-level declarations (types *and* values) are importable from outside the
module even without the `export` keyword, and appending `export {}` opts back
into normal only-explicit-exports visibility.

This is the behavior discussed in microsoft/TypeScript#32182 (open since 2019,
labeled `Docs`), where it was noted that the handbook doesn't mention it.

## Why

I hit this while adding a type-export test to a library PR: a compile-only
test cannot assert the `export` keyword on a `.d.ts` type, because removing
`export` still type-checks for consumers. The behavior is by design, but
nothing in the handbook says so — the Deep Dive page seemed like the natural
home, since it already covers declaration-file name resolution.

All claims verified against TypeScript 5.9.3:

| Case | Result |
| --- | --- |
| `.ts` module, import non-exported type | error TS2459 |
| `.d.ts` module, import non-exported type | OK (no error) |
| `.d.ts` module, import non-exported `declare const` / `declare class` | OK (no error) |
| same `.d.ts` with `export {}` added | error TS2459 |

The runtime caution was also verified on Node.js: importing a binding that the
underlying JS module doesn't export throws at load time under ESM and yields
`undefined` under CommonJS interop.

## Notes

- Pure addition at the end of the page; no existing content changed.
- Wording follows the page's existing style ("Say we have a module file
  `foo.d.ts`… Then consumed it:").

Refs microsoft/TypeScript#32182
