### PR TITLE
docs: rm error code example and add more practical one and change casts to type assertions

### DIFF
--- a/packages/documentation/copy/en/javascript/JSDoc Reference.md
+++ b/packages/documentation/copy/en/javascript/JSDoc Reference.md
@@ -78,11 +78,6 @@ var win;
 
 /** @type {PromiseLike<string>} */
 var promisedString;
-
-// You can specify an HTML Element with DOM properties
-/** @type {HTMLElement} */
-var myElement = document.querySelector(selector);
-element.dataset.myData = "";
 ```
 
 `@type` can specify a union type &mdash; for example, something can be either a string or a boolean.
@@ -160,10 +155,11 @@ var star;
 var question;
 ```
 
-#### Casts
+#### Type Assertions
 
-TypeScript borrows cast syntax from Google Closure.
-This lets you cast types to other types by adding a `@type` tag before any parenthesized expression.
+TypeScript borrows cast syntax from Google Closure, using it as type assertions in JSDoc.
+
+This lets you "cast" types to other types by adding a `@type` tag before any **parenthesized** expression like `as` keyword in TypeScript.
 
 ```js twoslash
 /**
@@ -173,10 +169,28 @@ var numberOrString = Math.random() < 0.5 ? "hello" : 100;
 var typeAssertedNumber = /** @type {number} */ (numberOrString);
 ```
 
+A more practical and common use case is to assign a specific HTML element type for a element.
+
+Sometimes you will have information about the type of a value that TypeScript can’t know about.
+
+For example, if you’re using `document.getElementById`, TypeScript only knows that this will return *some* kind of `HTMLElement`, but you might know that your page will always have an `HTMLCanvasElement` with a given ID.
+
+In this situation, you can use a *type assertion* to specify a more specific type:
+
+```js twoslash
+const myCanvas = /** @type {HTMLCanvasElement} */ (document.getElementById("main_canvas"));
+```
+
 You can even cast to `const` just like TypeScript:
 
 ```js twoslash
 let one = /** @type {const} */(1);
+```
+
+The type assertions can be nested:
+
+```js twoslash
+const x = /** @type {number} */ (/** @type {unknown} */ ("hello"))
 ```
 
 #### Import types


### PR DESCRIPTION
What's the problem of current docs?

## 1. Type error and Inappropriate example

```js
// You can specify an HTML Element with DOM properties
/** @type {HTMLElement} */
var myElement = document.querySelector(selector)
element.dataset.myData = ""
```

1 `element` should be `myElement`

2 type error and misplaced Example

```
Type 'HTMLElement | null' is not assignable to type 'HTMLElement'.
  Type 'null' is not assignable to type 'HTMLElement'.
```

This example doesn't fit the first use case of `@type` — it's better suited for demonstrating casts. It should be removed from the first part of  `@type` introduction.

> It's a perfect example for `cast`:

```js
// You can specify an HTML Element with DOM properties
const myElement = /** @type {HTMLElement} */ (
  document.querySelector("#selector")
)

myElement.dataset.myData = ""
```

No more errors and the inline usage of `@type` assertion is well explained.

## 2. Rename "Casts" to "Type Assertions"

It's functionally identical to TypeScript's `as` — simply written as inline `@type` in JSDoc!

C-style casts imply a runtime type conversion, whereas TypeScript's `as` syntax and JSDoc's inline `@type` are simply type assertions that do not affect runtime behavior. Thus, "Type Assertions" is a more accurate and less misleading term.

## 3. Add example from https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-assertions

## 4. Add JSDoc equivalent for `as unknown as T`

The original docs don't show how to write nested inline assertions in JSDoc — a pattern many users don't know about.

```ts
const x = "hello" as unknown as number;
```

```js
const x = /** @type {number} */ (/** @type {unknown} */ ("hello"))
```
