### PR TITLE
`Utility Types.md`: clarify `NoInfer` usage

### DIFF
--- a/packages/documentation/copy/en/reference/Utility Types.md
+++ b/packages/documentation/copy/en/reference/Utility Types.md
@@ -464,6 +464,8 @@ Released:
 Blocks inferences to the contained type. Other than blocking inferences, `NoInfer<Type>` is
 identical to `Type`.
 
+For example, the `createStreetLight()` function below is called with a `colors` value of `["red", "yellow", "green"]`, making the `C` type parameter be a union of `"red" | "yellow" | "green"` (so `"blue"` would not be a valid default), but if `NoInfer<C>` was not used, the `defaultColor`'s type of `"blue"` would get added to the type parameter union, so the compiler would consider `"blue"` as a valid default even though it's not in the list of `colors`.
+
 ##### Example
 
 ```ts


### PR DESCRIPTION
add a description of what the example is showing, since I (and [this person on Discord](https://discord.com/channels/508357248330760243/1057653400046674112/threads/1277558743436886016)) were confused about how `NoInfer` is supposed to be used