### PR TITLE
Update "types" default value docs

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/types.md
+++ b/packages/tsconfig-reference/copy/en/options/types.md
@@ -3,7 +3,7 @@ display: "Types"
 oneline: "Specify type package names to be included without being referenced in a source file."
 ---
 
-By default all _visible_ "`@types`" packages are included in your compilation.
+By default ``types`` is set to ``[]``. For versions below TypeScript 6.0, by default all _visible_ "`@types`" packages are included in your compilation.
 Packages in `node_modules/@types` of any enclosing folder are considered _visible_.
 For example, that means packages within `./node_modules/@types/`, `../node_modules/@types/`, `../../node_modules/@types/`, and so on.
 

--- a/packages/tsconfig-reference/copy/en/options/types.md
+++ b/packages/tsconfig-reference/copy/en/options/types.md
@@ -3,7 +3,7 @@ display: "Types"
 oneline: "Specify type package names to be included without being referenced in a source file."
 ---
 
-By default ``types`` is set to ``[]``. For versions below TypeScript 6.0, by default all _visible_ "`@types`" packages are included in your compilation.
+By default `types` is set to `[]`. For versions below TypeScript 6.0, by default all _visible_ "`@types`" packages are included in your compilation.
 Packages in `node_modules/@types` of any enclosing folder are considered _visible_.
 For example, that means packages within `./node_modules/@types/`, `../node_modules/@types/`, `../../node_modules/@types/`, and so on.
 


### PR DESCRIPTION
``types`` defaults to ``[]``, however this is not mentioned in the documentation and confused me, so

Fixes https://github.com/microsoft/TypeScript/issues/63753