### PR TITLE
Fix syntax error in AsyncDisposable example

### DIFF
--- a/packages/documentation/copy/en/reference/Variable Declarations.md
+++ b/packages/documentation/copy/en/reference/Variable Declarations.md
@@ -880,7 +880,7 @@ class DatabaseTransaction implements AsyncDisposable {
 }
 
 async function transfer(db: Database, account1: Account, account2: Account, amount: number) {
-  using tx = await DatabaseTransaction.create(db);
+  await using tx = await DatabaseTransaction.create(db);
   if (await debitAccount(db, account1, amount)) {
     await creditAccount(db, account2, amount);
   }

--- a/packages/documentation/copy/en/reference/Variable Declarations.md
+++ b/packages/documentation/copy/en/reference/Variable Declarations.md
@@ -867,7 +867,7 @@ class DatabaseTransaction implements AsyncDisposable {
 
   async [Symbol.asyncDispose]() {
     if (this.db) {
-      const db = this.db:
+      const db = this.db;
       this.db = undefined;
       if (this.success) {
         await db.execAsync("COMMIT TRANSACTION");


### PR DESCRIPTION
The AsyncDisposable example in the variable declarations reference has a syntax error: `const db = this.db:` uses a colon instead of a semicolon, so the example doesn't compile.

Separately, I noticed the `transfer` function uses `using tx` on an async-disposable resource , should that be `await using tx` so the async disposal is actually awaited? Happy to include that fix too if you'd like !