### PR TITLE
Add as const link for object literal immutability

### DIFF
--- a/packages/documentation/copy/en/reference/Variable Declarations.md
+++ b/packages/documentation/copy/en/reference/Variable Declarations.md
@@ -430,6 +430,7 @@ kitty.numLives--;
 Unless you take specific measures to avoid it, the internal state of a `const` variable is still modifiable.
 Fortunately, TypeScript allows you to specify that members of an object are `readonly`.
 The [chapter on Interfaces](/docs/handbook/interfaces.html) has the details.
+For object literals, you can use a [`const` assertion](/docs/handbook/2/everyday-types.html#literal-inference) to make all properties `readonly` in place.
 
 ## `let` vs. `const`
 


### PR DESCRIPTION
The section on making a `const` object's internals immutable links to the Interfaces chapter, which covers `readonly`. For object literals specifically, `as const` is a more direct in-place option, so I've added a brief mention linking to the Literal Inference section. Also kept the existing Interfaces link as-is