### PR TITLE
docs: remove duplicated words in release notes and README

### DIFF
--- a/packages/documentation/copy/en/release-notes/TypeScript 5.0.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 5.0.md
@@ -1373,7 +1373,7 @@ export class C {
 
 This call will fail because `key` expects a `string | symbol`, but constructor parameters receive a key of `undefined`.
 The correct fix is to change the type of `key` within `inject`.
-A reasonable workaround if you're using a library that can't be upgraded is is to wrap `inject` in a more type-safe decorator function, and use a type-assertion on `key`.
+A reasonable workaround if you're using a library that can't be upgraded is to wrap `inject` in a more type-safe decorator function, and use a type-assertion on `key`.
 
 For more details, [see this issue](https://github.com/microsoft/TypeScript/issues/52435).
 

--- a/packages/documentation/copy/en/release-notes/TypeScript 6.0.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 6.0.md
@@ -599,7 +599,7 @@ import * as someModule from "someModule.js";
 TypeScript will probably resolve this to `src/someModule.js`, even if the developer only intended to add mappings for modules starting with `@app/` and `@lib/`.
 
 In the best case, this also often leads to "worse-looking" paths that bundlers would ignore;
-but it often meant that that many import paths that would never have worked at runtime are considered "just fine" by TypeScript.
+but it often meant that many import paths that would never have worked at runtime are considered "just fine" by TypeScript.
 
 `path` mappings have not required specifying `baseUrl` for a long time, and in practice, most projects that use `baseUrl` only use it as a prefix for their `paths` entries.
 In TypeScript 6.0, `baseUrl` is deprecated and will no longer be considered a look-up root for module resolution.

--- a/packages/typescript-vfs/README.md
+++ b/packages/typescript-vfs/README.md
@@ -106,7 +106,7 @@ interface LanguageService {
 
 It's **very** likely that you will need to set up your lib `*.d.ts` files to use this.
 
-If you are running in an environment where you have access to the `node_modules` folder, then you can can write some code like this:
+If you are running in an environment where you have access to the `node_modules` folder, then you can write some code like this:
 
 ```ts
 const getLib = (name: string) => {
@@ -137,7 +137,7 @@ const createDefaultMap2015 = () => {
 
 This list is the default set of definitions (it's important to note that different options for `target` or `lib` will affect what this list looks like) and you are grabbing the library's content from the local dependency of TypeScript.
 
-Keeping on top of this list is quite a lot of work, so this library ships functions for generating a map with with these pre-filled from a version of TypeScript available on disk.
+Keeping on top of this list is quite a lot of work, so this library ships functions for generating a map with these pre-filled from a version of TypeScript available on disk.
 
 Note: it's possible for this list to get out of sync with TypeScript over time. It was last synced with TypeScript 3.8.0-rc.
 


### PR DESCRIPTION
## Summary

Remove duplicated words across documentation and README files.

| File | Fix |
|------|-----|
| packages/documentation/copy/en/release-notes/TypeScript 5.0.md | "is is" → "is" |
| packages/documentation/copy/en/release-notes/TypeScript 6.0.md | "that that" → "that" |
| packages/typescript-vfs/README.md | "can can" → "can" |
| packages/typescript-vfs/README.md | "with with" → "with" |

## Test plan

- [x] Verified each duplicated word was present before editing
- [x] Residual scan shows no remaining dup-word hits in changed files
- [ ] CI lint checks pass
