### PR TITLE
Fix `lib` source code link

### DIFF
--- a/packages/tsconfig-reference/copy/en/options/lib.md
+++ b/packages/tsconfig-reference/copy/en/options/lib.md
@@ -72,4 +72,4 @@ In TypeScript 4.5, lib files can be overridden by npm modules, find out more [in
 | `ESNext.Intl`             |
 | `ESNext.Symbol`           |
 
-This list may be out of date, you can see the full list in the [TypeScript source code](https://github.com/microsoft/TypeScript/tree/main/src/lib).
+This list may be out of date, you can see the full list in the [TypeScript source code](https://github.com/microsoft/TypeScript/tree/main/tsc/internal/bundled/libs).


### PR DESCRIPTION
The bundled libs moved with the TS7 import.