### PR TITLE
Fix wording in TypeScript 2.6 release notes

### DIFF
--- a/packages/documentation/copy/en/release-notes/TypeScript 2.6.md
+++ b/packages/documentation/copy/en/release-notes/TypeScript 2.6.md
@@ -228,7 +228,7 @@ if (false) {
 A `// @ts-ignore` comment suppresses all errors that originate on the following line.
 It is recommended practice to have the remainder of the comment following `@ts-ignore` explain which error is being suppressed.
 
-Please note that this comment only suppresses the error reporting, and we recommend you use this comments _very sparingly_.
+Please note that this comment only suppresses the error reporting, and we recommend you use these comments _very sparingly_.
 
 ## Faster `tsc --watch`
 


### PR DESCRIPTION
Corrected the wording from 'this comments' to 'these comments' for clarity.