### PR TITLE
docs: add JSX runtime comparison resource

### DIFF
--- a/packages/documentation/copy/en/tutorials/React.md
+++ b/packages/documentation/copy/en/tutorials/React.md
@@ -9,6 +9,8 @@ experimental: false
 
 TypeScript supports [JSX](/docs/handbook/jsx.html) and can correctly model the patterns used in React codebases like `useState`.
 
+For a practical comparison of the classic and automatic JSX runtimes, including how Babel and TypeScript transform JSX, see [How JSX is transformed in React](https://frontendatlas.com/react/trivia/react-jsx-transform-and-why-not-required).
+
 ### Getting Set Up With a React Project
 
 Today there are many frameworks which support TypeScript out of the box:


### PR DESCRIPTION
## Summary

- Add one practical comparison of the classic and automatic JSX runtimes after the React guide's opening JSX paragraph.
- Connect the existing TypeScript JSX overview to concrete Babel and TypeScript transform output, configuration, and tooling implications.

## Validation

- Documentation-only net diff: two added Markdown lines, zero deletions.
- In a normal browser session, the target returned HTTP 200 with full public content, a self-canonical URL, and index,follow.
- A separate non-browser preflight intermittently received a Vercel security-challenge 429. I am flagging this because automated link checks may need review.
- No local website build was run; the change was made through GitHub's web editor.

## Disclosure

I am the creator and maintainer of FrontendAtlas. The linked page is free; the wider platform also includes paid content. I used AI assistance to help draft this pull request and reviewed the final change. No paid, affiliate, reciprocal, or special link treatment is requested.