### PR TITLE
fix(typescript-vfs): resolve lib dir via getDefaultLibFilePath so re-export wrappers (@typescript/typescript6) work

### DIFF
--- a/packages/typescript-vfs/src/index.ts
+++ b/packages/typescript-vfs/src/index.ts
@@ -290,14 +290,18 @@ export const createDefaultMapFromNodeModules = (
   const path = requirePath()
   const fs = requireFS()
 
+  // Resolve the lib dir from the compiler, which follows re-export wrappers (e.g. @typescript/typescript6)
+  // to the real stdlib; require.resolve would point at the wrapper's own lib/, which has no lib.*.d.ts.
+  const ts = _ts ?? (require("typescript") as typeof import("typescript"))
+  const libDir = tsLibDirectory || path.dirname(ts.getDefaultLibFilePath(_compilerOptions))
+
   const getLib = (name: string) => {
-    const lib = tsLibDirectory || path.dirname(require.resolve("typescript"))
-    return fs.readFileSync(path.join(lib, name), "utf8")
+    return fs.readFileSync(path.join(libDir, name), "utf8")
   }
 
   const isDtsFile = (file: string) => /\.d\.([^\.]+\.)?[cm]?ts$/i.test(file)
 
-  const libFiles = fs.readdirSync(tsLibDirectory || path.dirname(require.resolve("typescript")))
+  const libFiles = fs.readdirSync(libDir)
   const knownLibFiles = libFiles.filter(f => f.startsWith("lib.") && isDtsFile(f))
 
   const fsMap = new Map<string, string>()


### PR DESCRIPTION
## Problem

`createDefaultMapFromNodeModules` finds the bundled `lib.*.d.ts` via `path.dirname(require.resolve("typescript"))`. `require.resolve` returns the resolved package's **entry file**, so for a re-export wrapper the directory it points at contains no lib files.

This breaks with the official TypeScript 7.0 side-by-side package [`@typescript/typescript6`](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0) (`npm i -D typescript@npm:@typescript/typescript6`), whose entry is `module.exports = require("@typescript/old")`. The real `lib.*.d.ts` live in the nested `@typescript/old/lib/`, so the default map is built without the stdlib and the VFS later throws:

```
TSVFS: A request was made for .../@typescript/typescript6/lib/lib.es2020.d.ts
but there wasn't a file found in the file map.
```

Any tool that builds a program through `createDefaultMapFromNodeModules` (e.g. `@ark/attest`) fails on a project using the TS 7 side-by-side setup.

## Fix

Derive the lib directory from the compiler's own `getDefaultLibFilePath`, which resolves from the executing file path and so follows the re-export to where the stdlib actually lives, instead of `require.resolve`:

```ts
const ts = _ts ?? (require('typescript') as typeof import('typescript'));
const libDir = tsLibDirectory || path.dirname(ts.getDefaultLibFilePath(_compilerOptions));
```

- Preserves the existing `tsLibDirectory` override.
- No caller change needed — callers like `@ark/attest` invoke `createDefaultMapFromNodeModules(compilerOptions)` with neither `_ts` nor `tsLibDirectory`.
- Works for both plain installs and aliased / wrapped installs.

## Notes

- `createFSBackedSystem` further down has the same `path.dirname(require.resolve("typescript"))` pattern; happy to fix it here too — left out to keep the change focused on the reported path.
- Verified against `@typescript/typescript6@6.0.2`: `getDefaultLibFilePath` returns the `@typescript/old` (`typescript@6.0.3`) lib dir with all 108 `lib.*.d.ts`.
- Same layout concern as the closed docs attempt #3620.
