### PR TITLE
fix(typescript/vfs): don't read localStorage during feature detection in Node

### DIFF
--- a/.changeset/olive-tigers-hammer.md
+++ b/.changeset/olive-tigers-hammer.md
@@ -1,0 +1,5 @@
+---
+"@typescript/vfs": patch
+---
+
+Skip the localStorage feature detect in Node so importing the package no longer emits an ExperimentalWarning on Node 26

--- a/packages/typescript-vfs/src/index.ts
+++ b/packages/typescript-vfs/src/index.ts
@@ -17,13 +17,25 @@ interface LocalStorageLike {
 declare var localStorage: LocalStorageLike | undefined;
 declare var fetch: FetchLike | undefined;
 
-let hasLocalStorage = false
-try {
-  hasLocalStorage = typeof localStorage !== `undefined`
-} catch (error) { }
-
 const hasProcess = typeof process !== `undefined`
-const shouldDebug = (hasLocalStorage && typeof localStorage!.getItem === 'function' && localStorage!.getItem("DEBUG")) || (hasProcess && process.env.DEBUG)
+
+// Node >= 26 exposes `localStorage` as a global accessor which emits an
+// ExperimentalWarning when it is read - including via `typeof` - unless the process
+// was started with `--localstorage-file`. Probing it here would print that warning at
+// module evaluation for every consumer, so skip the probe entirely in a bare Node
+// process, where `process.env.DEBUG` below is the only reachable way to opt in anyway.
+// DOM-bearing hosts that also expose `process` (Electron renderers) still get probed.
+const isBareNodeProcess =
+  hasProcess && typeof process.versions?.node === `string` && !(`window` in globalThis)
+
+let hasLocalStorage = false
+if (!isBareNodeProcess) {
+  try {
+    hasLocalStorage = typeof localStorage !== `undefined` && typeof localStorage.getItem === `function`
+  } catch (error) { }
+}
+
+const shouldDebug = (hasLocalStorage && localStorage!.getItem("DEBUG")) || (hasProcess && process.env.DEBUG)
 const debugLog = shouldDebug ? console.log : (_message?: any, ..._optionalParams: any[]) => ""
 
 export interface VirtualTypeScriptEnvironment {


### PR DESCRIPTION
Fixes #3650.

### Problem

On Node 26, importing `@typescript/vfs` prints a warning at module evaluation, before any API of the package is called:

```text
(node:39835) ExperimentalWarning: localStorage is not available because --localstorage-file was not provided.
```

`globalThis.localStorage` is an accessor on Node 26. Reading it — including via `typeof` — invokes the getter, which emits the warning and then returns `undefined` when `--localstorage-file` was not passed. The existing `try`/`catch` anticipates a global that *throws*; this one warns and returns `undefined`, so the guard is bypassed rather than triggered.

This reaches further than direct dependents: `twoslash` imports the package statically at `dist/core.mjs:1`, so every Twoslash consumer on Node 26 sees it, including `@shikijs/twoslash` and docs pipelines downstream of it.

This is separate from #3450, which fixed the Node 25 *crash* (`localStorage.getItem is not a function`). That fix is still needed and is preserved here.

### Fix

Skip the probe entirely in a bare Node process. The value is only ever used to look up a `DEBUG` key, and in Node `process.env.DEBUG` — already checked on the next line — is the only reachable way to set it.

`'window' in globalThis` tests for the property without invoking any getter, so browsers keep the existing behaviour, and so do DOM-bearing hosts that also expose `process` (Electron renderers).

Two alternatives I tried and backed out of:

- `Object.getOwnPropertyDescriptor(globalThis, "localStorage")` does avoid the getter, but in browsers `localStorage` lives on `Window.prototype` rather than as an own property of `globalThis`, so the descriptor comes back `undefined` and browser detection breaks.
- Gating on `hasProcess` alone would regress Electron renderers.

The `typeof localStorage.getItem === 'function'` guard from #3450 moves up into `hasLocalStorage`, which is where the rest of the availability question is already being answered.

### Verification

Node v26.8.1, `pnpm build` in `packages/typescript-vfs`, then a straight A/B of the built output against published `1.6.4`:

```console
$ node --input-type=module --eval "import * as m from '@typescript/vfs'; console.log('OK:', typeof m.createSystem)"   # this branch
OK: function

$ node --input-type=module --eval "import * as m from '<store>/@typescript/vfs/dist/index.js'; console.log('OK:', typeof m.createSystem)"   # published 1.6.4
OK: function
(node:5345) ExperimentalWarning: localStorage is not available because --localstorage-file was not provided.
```

Also:

- `pnpm test` in `packages/typescript-vfs` — 22 passed. These run under the `jsdom` preset, so they exercise the browser branch (`window` present, real `localStorage`, `hasLocalStorage === true`).
- `DEBUG=1` still turns on debug logging in Node.
- The vendored copy at `packages/sandbox/src/vendor/typescript-vfs.ts` typechecks clean under `--lib esnext,dom`. I used `'window' in globalThis` rather than adding a `declare var window` for exactly this reason — a declaration would have collided with the DOM lib's `Window` in the sandbox build.
- Linked the build into a downstream monorepo that consumes the package both directly and through `twoslash`; its full suite (1641 tests) passes with the warning gone.

I did not add a regression test: CI runs on Node 20, where such a test would pass vacuously.

Changeset included, patch.

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>